### PR TITLE
test+ci: parity corpus and CI enforcement for lint-docs.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,11 @@ jobs:
       - name: Version consistency (VERSION ↔ every SKILL.md)
         run: ./scripts/check-version.sh
 
-      - name: Lint — install.sh syntax, dry-run harnesses, docs invariants
+      - name: Test — lint-docs.sh fixture/parity corpus
+        run: ./tests/lint-docs/run.sh
+
+      - name: Lint — example docs bundle against the Living Docs invariants
+        run: ./skills/living-docs/scripts/lint-docs.sh examples/linkly/docs
+
+      - name: Lint — install.sh syntax, dry-run harnesses, docs invariants (make check)
         run: make check

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ INSTALL := ./install.sh
 .PHONY: help install install-claude install-cursor install-copilot \
         install-opencode install-codex install-pi install-all install-pocock \
         project-claude project-opencode project-codex project-pi \
-        uninstall uninstall-all check lint lint-docs version
+        uninstall uninstall-all check lint lint-docs test-lint-docs version
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
@@ -58,7 +58,7 @@ uninstall: ## Remove the global Claude Code install
 uninstall-all: ## Remove the install for every supported harness
 	$(INSTALL) all --uninstall
 
-check: version lint-docs ## Check version sync, validate install.sh, dry-run harnesses, lint docs
+check: version test-lint-docs lint-docs ## Check version sync, validate install.sh, dry-run harnesses, test+run the docs linter
 	bash -n install.sh
 	bash -n skills/living-docs/scripts/lint-docs.sh
 	bash -n scripts/check-version.sh
@@ -66,6 +66,9 @@ check: version lint-docs ## Check version sync, validate install.sh, dry-run har
 
 lint-docs: ## Validate the example docs bundle against the Living Docs invariants
 	./skills/living-docs/scripts/lint-docs.sh examples/linkly/docs
+
+test-lint-docs: ## Run the lint-docs.sh fixture/parity corpus (clean passes, each violation caught)
+	./tests/lint-docs/run.sh
 
 version: ## Assert the release version is consistent across VERSION and every SKILL.md
 	./scripts/check-version.sh

--- a/tests/lint-docs/README.md
+++ b/tests/lint-docs/README.md
@@ -1,0 +1,53 @@
+# lint-docs.sh fixture corpus
+
+The parity/fixture test that makes `skills/living-docs/scripts/lint-docs.sh`
+trustworthy. The linter is the *instrument* for the mechanical Living Docs
+invariants ("a constraint without an instrument is a vibe"); this corpus proves
+it (a) stays silent on a clean bundle and (b) catches each violation it claims
+to — one violation per dirty fixture, in the spirit of an arch-gate parity test
+(clean partition passes silently; dirty partition each caught 1/1).
+
+## Run
+
+```bash
+make test-lint-docs        # from the repo root
+# or
+tests/lint-docs/run.sh
+```
+
+The runner exits non-zero if any case misbehaves. CI runs it on every push/PR.
+
+## Layout
+
+| Path | Role |
+|---|---|
+| `fixtures/clean/docs/` | a minimal, hand-rolled clean bundle → must exit `0` |
+| `fixtures/dirty-NN-*/docs/` | a minimal bundle with **exactly one** violation → must exit `1` |
+| `expect/dirty-NN-*.grep` | substring that must appear in the linter output for that case |
+| `expect/dirty-NN-*.exit` | (optional) expected exit code; defaults to `1` for dirty cases |
+| `run.sh` | the runner — asserts exit code + message substring, prints PASS/FAIL + summary |
+
+The shipped worked example `examples/linkly/docs` is also asserted clean as a
+second clean-partition case.
+
+## Coverage — one fixture per mechanical check
+
+| Fixture | Check exercised |
+|---|---|
+| `dirty-01-missing-root-index` | bundle-root `index.md` missing |
+| `dirty-02-no-frontmatter` | non-reserved `.md` with no frontmatter |
+| `dirty-03-empty-type` | frontmatter present but `type` empty |
+| `dirty-04-index-has-frontmatter` | non-root `index.md` carrying frontmatter (OKF §6) |
+| `dirty-05-root-index-no-okf` | bundle-root `index.md` frontmatter without `okf_version` (the allowed-exception path) |
+| `dirty-06-orphan` | concept file not listed in its directory `index.md` |
+| `dirty-07-unreachable-index` | directory `index.md` not reachable from the bundle-root index |
+| `dirty-08-broken-link` | broken local markdown link |
+| `dirty-09-superseded-empty` | `status: Superseded` with empty `superseded_by` |
+| `dirty-10-superseded-missing-target` | `superseded_by: NNNN` with no matching record |
+| `dirty-11-no-dir-index` | concept file in a directory with no `index.md` |
+
+The allowed case "bundle-root `index.md` with `okf_version`" is covered by the
+clean fixtures (their root index declares `okf_version` and passes).
+
+Each dirty fixture is verified to trigger **exactly one** violation, so a green
+case can only mean the intended check fired.

--- a/tests/lint-docs/expect/dirty-01-missing-root-index.grep
+++ b/tests/lint-docs/expect/dirty-01-missing-root-index.grep
@@ -1,0 +1,1 @@
+missing bundle-root index.md

--- a/tests/lint-docs/expect/dirty-02-no-frontmatter.grep
+++ b/tests/lint-docs/expect/dirty-02-no-frontmatter.grep
@@ -1,0 +1,1 @@
+missing OKF frontmatter

--- a/tests/lint-docs/expect/dirty-03-empty-type.grep
+++ b/tests/lint-docs/expect/dirty-03-empty-type.grep
@@ -1,0 +1,1 @@
+frontmatter has no non-empty 'type'

--- a/tests/lint-docs/expect/dirty-04-index-has-frontmatter.grep
+++ b/tests/lint-docs/expect/dirty-04-index-has-frontmatter.grep
@@ -1,0 +1,1 @@
+must not carry frontmatter

--- a/tests/lint-docs/expect/dirty-05-root-index-no-okf.grep
+++ b/tests/lint-docs/expect/dirty-05-root-index-no-okf.grep
@@ -1,0 +1,1 @@
+lacks okf_version

--- a/tests/lint-docs/expect/dirty-06-orphan.grep
+++ b/tests/lint-docs/expect/dirty-06-orphan.grep
@@ -1,0 +1,1 @@
+orphan (invariant 3)

--- a/tests/lint-docs/expect/dirty-07-unreachable-index.grep
+++ b/tests/lint-docs/expect/dirty-07-unreachable-index.grep
@@ -1,0 +1,1 @@
+not reachable from

--- a/tests/lint-docs/expect/dirty-08-broken-link.grep
+++ b/tests/lint-docs/expect/dirty-08-broken-link.grep
@@ -1,0 +1,1 @@
+broken link

--- a/tests/lint-docs/expect/dirty-09-superseded-empty.grep
+++ b/tests/lint-docs/expect/dirty-09-superseded-empty.grep
@@ -1,0 +1,1 @@
+superseded_by is empty

--- a/tests/lint-docs/expect/dirty-10-superseded-missing-target.grep
+++ b/tests/lint-docs/expect/dirty-10-superseded-missing-target.grep
@@ -1,0 +1,1 @@
+has no matching record

--- a/tests/lint-docs/expect/dirty-11-no-dir-index.grep
+++ b/tests/lint-docs/expect/dirty-11-no-dir-index.grep
@@ -1,0 +1,1 @@
+no index.md in its directory

--- a/tests/lint-docs/fixtures/clean/docs/adr/0001-first-decision.md
+++ b/tests/lint-docs/fixtures/clean/docs/adr/0001-first-decision.md
@@ -1,0 +1,9 @@
+---
+type: ADR
+title: First decision
+status: Accepted
+---
+
+# 0001. First decision
+
+A minimal, well-formed ADR with frontmatter and a non-empty type.

--- a/tests/lint-docs/fixtures/clean/docs/adr/index.md
+++ b/tests/lint-docs/fixtures/clean/docs/adr/index.md
@@ -1,0 +1,7 @@
+# ADRs
+
+Architecture decisions.
+
+## Active
+
+* [0001 — First decision](0001-first-decision.md) - the first recorded decision

--- a/tests/lint-docs/fixtures/clean/docs/index.md
+++ b/tests/lint-docs/fixtures/clean/docs/index.md
@@ -1,0 +1,11 @@
+---
+okf_version: "0.1"
+---
+
+# Minimal — Docs
+
+A minimal clean Living Docs bundle for the lint-docs fixture corpus.
+
+## Trail
+
+* [ADRs](adr/) - how it is structured, and why

--- a/tests/lint-docs/fixtures/dirty-01-missing-root-index/docs/adr/0001-first-decision.md
+++ b/tests/lint-docs/fixtures/dirty-01-missing-root-index/docs/adr/0001-first-decision.md
@@ -1,0 +1,9 @@
+---
+type: ADR
+title: First decision
+status: Accepted
+---
+
+# 0001. First decision
+
+A minimal, well-formed ADR with frontmatter and a non-empty type.

--- a/tests/lint-docs/fixtures/dirty-01-missing-root-index/docs/adr/index.md
+++ b/tests/lint-docs/fixtures/dirty-01-missing-root-index/docs/adr/index.md
@@ -1,0 +1,7 @@
+# ADRs
+
+Architecture decisions.
+
+## Active
+
+* [0001 — First decision](0001-first-decision.md) - the first recorded decision

--- a/tests/lint-docs/fixtures/dirty-02-no-frontmatter/docs/adr/0001-first-decision.md
+++ b/tests/lint-docs/fixtures/dirty-02-no-frontmatter/docs/adr/0001-first-decision.md
@@ -1,0 +1,9 @@
+---
+type: ADR
+title: First decision
+status: Accepted
+---
+
+# 0001. First decision
+
+A minimal, well-formed ADR with frontmatter and a non-empty type.

--- a/tests/lint-docs/fixtures/dirty-02-no-frontmatter/docs/adr/0002-no-fm.md
+++ b/tests/lint-docs/fixtures/dirty-02-no-frontmatter/docs/adr/0002-no-fm.md
@@ -1,0 +1,3 @@
+# 0002. No frontmatter
+
+This concept file opens with a heading, not frontmatter.

--- a/tests/lint-docs/fixtures/dirty-02-no-frontmatter/docs/adr/index.md
+++ b/tests/lint-docs/fixtures/dirty-02-no-frontmatter/docs/adr/index.md
@@ -1,0 +1,8 @@
+# ADRs
+
+Architecture decisions.
+
+## Active
+
+* [0001 — First decision](0001-first-decision.md) - the first recorded decision
+* [0002 — No FM](0002-no-fm.md) - missing frontmatter

--- a/tests/lint-docs/fixtures/dirty-02-no-frontmatter/docs/index.md
+++ b/tests/lint-docs/fixtures/dirty-02-no-frontmatter/docs/index.md
@@ -1,0 +1,11 @@
+---
+okf_version: "0.1"
+---
+
+# Minimal — Docs
+
+A minimal clean Living Docs bundle for the lint-docs fixture corpus.
+
+## Trail
+
+* [ADRs](adr/) - how it is structured, and why

--- a/tests/lint-docs/fixtures/dirty-03-empty-type/docs/adr/0001-first-decision.md
+++ b/tests/lint-docs/fixtures/dirty-03-empty-type/docs/adr/0001-first-decision.md
@@ -1,0 +1,9 @@
+---
+type: ADR
+title: First decision
+status: Accepted
+---
+
+# 0001. First decision
+
+A minimal, well-formed ADR with frontmatter and a non-empty type.

--- a/tests/lint-docs/fixtures/dirty-03-empty-type/docs/adr/0002-empty-type.md
+++ b/tests/lint-docs/fixtures/dirty-03-empty-type/docs/adr/0002-empty-type.md
@@ -1,0 +1,9 @@
+---
+type:
+title: Empty type
+status: Accepted
+---
+
+# 0002. Empty type
+
+Frontmatter present but `type` is empty.

--- a/tests/lint-docs/fixtures/dirty-03-empty-type/docs/adr/index.md
+++ b/tests/lint-docs/fixtures/dirty-03-empty-type/docs/adr/index.md
@@ -1,0 +1,8 @@
+# ADRs
+
+Architecture decisions.
+
+## Active
+
+* [0001 — First decision](0001-first-decision.md) - the first recorded decision
+* [0002 — Empty type](0002-empty-type.md) - empty type

--- a/tests/lint-docs/fixtures/dirty-03-empty-type/docs/index.md
+++ b/tests/lint-docs/fixtures/dirty-03-empty-type/docs/index.md
@@ -1,0 +1,11 @@
+---
+okf_version: "0.1"
+---
+
+# Minimal — Docs
+
+A minimal clean Living Docs bundle for the lint-docs fixture corpus.
+
+## Trail
+
+* [ADRs](adr/) - how it is structured, and why

--- a/tests/lint-docs/fixtures/dirty-04-index-has-frontmatter/docs/adr/0001-first-decision.md
+++ b/tests/lint-docs/fixtures/dirty-04-index-has-frontmatter/docs/adr/0001-first-decision.md
@@ -1,0 +1,9 @@
+---
+type: ADR
+title: First decision
+status: Accepted
+---
+
+# 0001. First decision
+
+A minimal, well-formed ADR with frontmatter and a non-empty type.

--- a/tests/lint-docs/fixtures/dirty-04-index-has-frontmatter/docs/adr/index.md
+++ b/tests/lint-docs/fixtures/dirty-04-index-has-frontmatter/docs/adr/index.md
@@ -1,0 +1,11 @@
+---
+type: index
+---
+
+# ADRs
+
+Architecture decisions.
+
+## Active
+
+* [0001 — First decision](0001-first-decision.md) - the first recorded decision

--- a/tests/lint-docs/fixtures/dirty-04-index-has-frontmatter/docs/index.md
+++ b/tests/lint-docs/fixtures/dirty-04-index-has-frontmatter/docs/index.md
@@ -1,0 +1,11 @@
+---
+okf_version: "0.1"
+---
+
+# Minimal — Docs
+
+A minimal clean Living Docs bundle for the lint-docs fixture corpus.
+
+## Trail
+
+* [ADRs](adr/) - how it is structured, and why

--- a/tests/lint-docs/fixtures/dirty-05-root-index-no-okf/docs/adr/0001-first-decision.md
+++ b/tests/lint-docs/fixtures/dirty-05-root-index-no-okf/docs/adr/0001-first-decision.md
@@ -1,0 +1,9 @@
+---
+type: ADR
+title: First decision
+status: Accepted
+---
+
+# 0001. First decision
+
+A minimal, well-formed ADR with frontmatter and a non-empty type.

--- a/tests/lint-docs/fixtures/dirty-05-root-index-no-okf/docs/adr/index.md
+++ b/tests/lint-docs/fixtures/dirty-05-root-index-no-okf/docs/adr/index.md
@@ -1,0 +1,7 @@
+# ADRs
+
+Architecture decisions.
+
+## Active
+
+* [0001 — First decision](0001-first-decision.md) - the first recorded decision

--- a/tests/lint-docs/fixtures/dirty-05-root-index-no-okf/docs/index.md
+++ b/tests/lint-docs/fixtures/dirty-05-root-index-no-okf/docs/index.md
@@ -1,0 +1,11 @@
+---
+title: Minimal
+---
+
+# Minimal — Docs
+
+Root index carries frontmatter but no okf_version (the allowed-exception path fails).
+
+## Trail
+
+* [ADRs](adr/) - how it is structured, and why

--- a/tests/lint-docs/fixtures/dirty-06-orphan/docs/adr/0001-first-decision.md
+++ b/tests/lint-docs/fixtures/dirty-06-orphan/docs/adr/0001-first-decision.md
@@ -1,0 +1,9 @@
+---
+type: ADR
+title: First decision
+status: Accepted
+---
+
+# 0001. First decision
+
+A minimal, well-formed ADR with frontmatter and a non-empty type.

--- a/tests/lint-docs/fixtures/dirty-06-orphan/docs/adr/0002-orphan.md
+++ b/tests/lint-docs/fixtures/dirty-06-orphan/docs/adr/0002-orphan.md
@@ -1,0 +1,9 @@
+---
+type: ADR
+title: Orphan
+status: Accepted
+---
+
+# 0002. Orphan
+
+Well-formed concept file, but NOT listed in adr/index.md.

--- a/tests/lint-docs/fixtures/dirty-06-orphan/docs/adr/index.md
+++ b/tests/lint-docs/fixtures/dirty-06-orphan/docs/adr/index.md
@@ -1,0 +1,7 @@
+# ADRs
+
+Architecture decisions.
+
+## Active
+
+* [0001 — First decision](0001-first-decision.md) - the first recorded decision

--- a/tests/lint-docs/fixtures/dirty-06-orphan/docs/index.md
+++ b/tests/lint-docs/fixtures/dirty-06-orphan/docs/index.md
@@ -1,0 +1,11 @@
+---
+okf_version: "0.1"
+---
+
+# Minimal — Docs
+
+A minimal clean Living Docs bundle for the lint-docs fixture corpus.
+
+## Trail
+
+* [ADRs](adr/) - how it is structured, and why

--- a/tests/lint-docs/fixtures/dirty-07-unreachable-index/docs/adr/0001-first-decision.md
+++ b/tests/lint-docs/fixtures/dirty-07-unreachable-index/docs/adr/0001-first-decision.md
@@ -1,0 +1,9 @@
+---
+type: ADR
+title: First decision
+status: Accepted
+---
+
+# 0001. First decision
+
+A minimal, well-formed ADR with frontmatter and a non-empty type.

--- a/tests/lint-docs/fixtures/dirty-07-unreachable-index/docs/adr/index.md
+++ b/tests/lint-docs/fixtures/dirty-07-unreachable-index/docs/adr/index.md
@@ -1,0 +1,7 @@
+# ADRs
+
+Architecture decisions.
+
+## Active
+
+* [0001 — First decision](0001-first-decision.md) - the first recorded decision

--- a/tests/lint-docs/fixtures/dirty-07-unreachable-index/docs/context/glossary.md
+++ b/tests/lint-docs/fixtures/dirty-07-unreachable-index/docs/context/glossary.md
@@ -1,0 +1,8 @@
+---
+type: Reference
+title: Glossary
+---
+
+# Glossary
+
+A term.

--- a/tests/lint-docs/fixtures/dirty-07-unreachable-index/docs/context/index.md
+++ b/tests/lint-docs/fixtures/dirty-07-unreachable-index/docs/context/index.md
@@ -1,0 +1,5 @@
+# Context
+
+Domain vocabulary.
+
+* [Glossary](glossary.md) - terms

--- a/tests/lint-docs/fixtures/dirty-07-unreachable-index/docs/index.md
+++ b/tests/lint-docs/fixtures/dirty-07-unreachable-index/docs/index.md
@@ -1,0 +1,11 @@
+---
+okf_version: "0.1"
+---
+
+# Minimal — Docs
+
+A minimal clean Living Docs bundle for the lint-docs fixture corpus.
+
+## Trail
+
+* [ADRs](adr/) - how it is structured, and why

--- a/tests/lint-docs/fixtures/dirty-08-broken-link/docs/adr/0001-first-decision.md
+++ b/tests/lint-docs/fixtures/dirty-08-broken-link/docs/adr/0001-first-decision.md
@@ -1,0 +1,11 @@
+---
+type: ADR
+title: First decision
+status: Accepted
+---
+
+# 0001. First decision
+
+A minimal, well-formed ADR with frontmatter and a non-empty type.
+
+See [the missing doc](0099-does-not-exist.md) for more.

--- a/tests/lint-docs/fixtures/dirty-08-broken-link/docs/adr/index.md
+++ b/tests/lint-docs/fixtures/dirty-08-broken-link/docs/adr/index.md
@@ -1,0 +1,7 @@
+# ADRs
+
+Architecture decisions.
+
+## Active
+
+* [0001 — First decision](0001-first-decision.md) - the first recorded decision

--- a/tests/lint-docs/fixtures/dirty-08-broken-link/docs/index.md
+++ b/tests/lint-docs/fixtures/dirty-08-broken-link/docs/index.md
@@ -1,0 +1,11 @@
+---
+okf_version: "0.1"
+---
+
+# Minimal — Docs
+
+A minimal clean Living Docs bundle for the lint-docs fixture corpus.
+
+## Trail
+
+* [ADRs](adr/) - how it is structured, and why

--- a/tests/lint-docs/fixtures/dirty-09-superseded-empty/docs/adr/0001-first-decision.md
+++ b/tests/lint-docs/fixtures/dirty-09-superseded-empty/docs/adr/0001-first-decision.md
@@ -1,0 +1,9 @@
+---
+type: ADR
+title: First decision
+status: Accepted
+---
+
+# 0001. First decision
+
+A minimal, well-formed ADR with frontmatter and a non-empty type.

--- a/tests/lint-docs/fixtures/dirty-09-superseded-empty/docs/adr/0002-superseded.md
+++ b/tests/lint-docs/fixtures/dirty-09-superseded-empty/docs/adr/0002-superseded.md
@@ -1,0 +1,10 @@
+---
+type: ADR
+title: Superseded with no target
+status: Superseded
+superseded_by:
+---
+
+# 0002. Superseded with no target
+
+status is Superseded but superseded_by is empty.

--- a/tests/lint-docs/fixtures/dirty-09-superseded-empty/docs/adr/index.md
+++ b/tests/lint-docs/fixtures/dirty-09-superseded-empty/docs/adr/index.md
@@ -1,0 +1,8 @@
+# ADRs
+
+Architecture decisions.
+
+## Active
+
+* [0001 — First decision](0001-first-decision.md) - the first recorded decision
+* [0002 — Superseded](0002-superseded.md) - no target

--- a/tests/lint-docs/fixtures/dirty-09-superseded-empty/docs/index.md
+++ b/tests/lint-docs/fixtures/dirty-09-superseded-empty/docs/index.md
@@ -1,0 +1,11 @@
+---
+okf_version: "0.1"
+---
+
+# Minimal — Docs
+
+A minimal clean Living Docs bundle for the lint-docs fixture corpus.
+
+## Trail
+
+* [ADRs](adr/) - how it is structured, and why

--- a/tests/lint-docs/fixtures/dirty-10-superseded-missing-target/docs/adr/0001-first-decision.md
+++ b/tests/lint-docs/fixtures/dirty-10-superseded-missing-target/docs/adr/0001-first-decision.md
@@ -1,0 +1,9 @@
+---
+type: ADR
+title: First decision
+status: Accepted
+---
+
+# 0001. First decision
+
+A minimal, well-formed ADR with frontmatter and a non-empty type.

--- a/tests/lint-docs/fixtures/dirty-10-superseded-missing-target/docs/adr/0002-dangling.md
+++ b/tests/lint-docs/fixtures/dirty-10-superseded-missing-target/docs/adr/0002-dangling.md
@@ -1,0 +1,10 @@
+---
+type: ADR
+title: Superseded by a missing record
+status: Superseded
+superseded_by: 0099
+---
+
+# 0002. Superseded by a missing record
+
+superseded_by points at 0099, which does not exist in this directory.

--- a/tests/lint-docs/fixtures/dirty-10-superseded-missing-target/docs/adr/index.md
+++ b/tests/lint-docs/fixtures/dirty-10-superseded-missing-target/docs/adr/index.md
@@ -1,0 +1,8 @@
+# ADRs
+
+Architecture decisions.
+
+## Active
+
+* [0001 — First decision](0001-first-decision.md) - the first recorded decision
+* [0002 — Dangling](0002-dangling.md) - missing target

--- a/tests/lint-docs/fixtures/dirty-10-superseded-missing-target/docs/index.md
+++ b/tests/lint-docs/fixtures/dirty-10-superseded-missing-target/docs/index.md
@@ -1,0 +1,11 @@
+---
+okf_version: "0.1"
+---
+
+# Minimal — Docs
+
+A minimal clean Living Docs bundle for the lint-docs fixture corpus.
+
+## Trail
+
+* [ADRs](adr/) - how it is structured, and why

--- a/tests/lint-docs/fixtures/dirty-11-no-dir-index/docs/adr/0001-first-decision.md
+++ b/tests/lint-docs/fixtures/dirty-11-no-dir-index/docs/adr/0001-first-decision.md
@@ -1,0 +1,9 @@
+---
+type: ADR
+title: First decision
+status: Accepted
+---
+
+# 0001. First decision
+
+A minimal, well-formed ADR with frontmatter and a non-empty type.

--- a/tests/lint-docs/fixtures/dirty-11-no-dir-index/docs/adr/index.md
+++ b/tests/lint-docs/fixtures/dirty-11-no-dir-index/docs/adr/index.md
@@ -1,0 +1,7 @@
+# ADRs
+
+Architecture decisions.
+
+## Active
+
+* [0001 — First decision](0001-first-decision.md) - the first recorded decision

--- a/tests/lint-docs/fixtures/dirty-11-no-dir-index/docs/context/glossary.md
+++ b/tests/lint-docs/fixtures/dirty-11-no-dir-index/docs/context/glossary.md
@@ -1,0 +1,8 @@
+---
+type: Reference
+title: Glossary
+---
+
+# Glossary
+
+A concept file sitting in a directory that has no index.md.

--- a/tests/lint-docs/fixtures/dirty-11-no-dir-index/docs/index.md
+++ b/tests/lint-docs/fixtures/dirty-11-no-dir-index/docs/index.md
@@ -1,0 +1,11 @@
+---
+okf_version: "0.1"
+---
+
+# Minimal — Docs
+
+A minimal clean Living Docs bundle for the lint-docs fixture corpus.
+
+## Trail
+
+* [ADRs](adr/) - how it is structured, and why

--- a/tests/lint-docs/run.sh
+++ b/tests/lint-docs/run.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# run.sh — parity/fixture corpus runner for lint-docs.sh.
+#
+# This is the parity test that makes the linter trustworthy (the "harden" floor):
+# it exercises the tool against a curated corpus so we know it (a) stays silent on a
+# clean bundle and (b) catches each mechanical violation it claims to catch — one
+# violation per dirty fixture, in the spirit of an arch-gate parity test (clean
+# partition passes silently; dirty partition each caught 1/1).
+#
+# Layout:
+#   fixtures/clean/...        a clean bundle → asserts exit 0   (also runs the shipped
+#                             examples/linkly/docs as a second clean assertion)
+#   fixtures/<name>/...       a dirty bundle, one violation     → asserts exit 1 + msg
+#   expect/<name>.exit        expected exit code
+#   expect/<name>.grep        substring that must appear in the linter output
+#
+# Exit: 0 = every case behaved as asserted · 1 = at least one case failed.
+
+set -uo pipefail
+
+if [[ -z "${BASH_VERSINFO:-}" || "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+	echo "run.sh requires bash 4+ (you have ${BASH_VERSION:-unknown})." >&2
+	exit 2
+fi
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+LINT="$REPO_ROOT/skills/living-docs/scripts/lint-docs.sh"
+FIXTURES="$HERE/fixtures"
+EXPECT="$HERE/expect"
+
+if [[ ! -x "$LINT" ]]; then
+	echo "run.sh: linter not found or not executable: $LINT" >&2
+	exit 2
+fi
+
+PASS=0
+FAIL=0
+
+# run_case <case-name> <bundle-dir> <expected-exit> [expected-substring]
+run_case() {
+	local name="$1" bundle="$2" want_exit="$3" want_grep="${4:-}"
+	local out got_exit ok=1 reason=""
+
+	out="$("$LINT" "$bundle" 2>&1)"
+	got_exit=$?
+
+	if [[ "$got_exit" -ne "$want_exit" ]]; then
+		ok=0
+		reason="exit $got_exit (wanted $want_exit)"
+	fi
+	if [[ -n "$want_grep" ]] && ! grep -qF -- "$want_grep" <<<"$out"; then
+		ok=0
+		reason="${reason:+$reason; }missing substring: '$want_grep'"
+	fi
+
+	if [[ "$ok" -eq 1 ]]; then
+		printf 'PASS  %-32s exit=%s\n' "$name" "$got_exit"
+		PASS=$((PASS + 1))
+	else
+		printf 'FAIL  %-32s %s\n' "$name" "$reason"
+		printf '%s\n' "$out" | sed 's/^/        | /'
+		FAIL=$((FAIL + 1))
+	fi
+}
+
+echo "=== lint-docs.sh fixture corpus ==="
+echo
+
+# --- clean partition: must exit 0, silent on violations ---------------------
+
+# The shipped worked example is the canonical clean bundle.
+run_case "examples/linkly (shipped)" "$REPO_ROOT/examples/linkly/docs" 0
+# A second, minimal clean bundle proves a hand-rolled clean corpus also passes.
+run_case "clean (minimal)" "$FIXTURES/clean/docs" 0
+
+echo
+
+# --- dirty partition: one violation per fixture, must exit 1 + emit message --
+
+for dir in "$FIXTURES"/dirty-*/; do
+	[[ -d "$dir" ]] || continue
+	name="$(basename "$dir")"
+	bundle="$dir/docs"
+	exit_file="$EXPECT/$name.exit"
+	grep_file="$EXPECT/$name.grep"
+	want_exit=1
+	[[ -f "$exit_file" ]] && want_exit="$(cat "$exit_file")"
+	want_grep=""
+	[[ -f "$grep_file" ]] && want_grep="$(cat "$grep_file")"
+	run_case "$name" "$bundle" "$want_exit" "$want_grep"
+done
+
+echo
+echo "=== summary: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## What

Completes the "harden" thesis for the Living Docs mechanical linter (`skills/living-docs/scripts/lint-docs.sh`). The instrument existed and SKILL.md says to wire it into CI — but **nothing executed it and it had no test of its own**. This makes it (1) trustworthy via a parity/fixture corpus and (2) enforced via CI. No new checks, no linter-logic changes, semantic invariants left as judgment.

## Goal 1 — parity/fixture corpus (`tests/lint-docs/`)

- **Clean partition** (must exit `0`): the shipped `examples/linkly/docs` plus a minimal hand-rolled clean bundle.
- **Dirty partition** (each must exit `1` + emit the expected message substring): eleven minimal bundles, **one violation per fixture**, covering every mechanical check:

| Fixture | Check |
|---|---|
| `dirty-01-missing-root-index` | bundle-root `index.md` missing |
| `dirty-02-no-frontmatter` | non-reserved `.md` with no frontmatter |
| `dirty-03-empty-type` | frontmatter present but `type` empty |
| `dirty-04-index-has-frontmatter` | non-root `index.md` carrying frontmatter |
| `dirty-05-root-index-no-okf` | root `index.md` frontmatter without `okf_version` |
| `dirty-06-orphan` | concept file not listed in its directory index |
| `dirty-07-unreachable-index` | directory index not reachable from root |
| `dirty-08-broken-link` | broken local markdown link |
| `dirty-09-superseded-empty` | `status: Superseded` + empty `superseded_by` |
| `dirty-10-superseded-missing-target` | `superseded_by: NNNN` with no matching record |
| `dirty-11-no-dir-index` | concept file in a directory with no `index.md` |

The allowed exception (root `index.md` **with** `okf_version`) is covered by the clean fixtures. Each dirty fixture is verified to trigger **exactly one** violation, so a green case can only mean the intended check fired.

`tests/lint-docs/run.sh` asserts exit code + substring per case, prints a per-case PASS/FAIL line and a summary, and exits non-zero if any case fails. Requires bash 4+; runs clean here (bash 5.2). A negative test confirms the runner fails when an assertion is wrong.

## Goal 2 — enforced gate

- **Makefile**: new `test-lint-docs` target; folded into `check` alongside the existing `lint-docs` (example-bundle lint). `make check` is already run by CI.
- **`.github/workflows/ci.yml`**: explicit steps to run the corpus and lint the example bundle on every push/PR; a failing fixture or lint fails CI.

## Notes

- No linter bug found — the script behaved exactly as documented against every fixture.
- Stayed strictly on the verification floor: no MCP, no new checks, no touching the semantic (no-sound-oracle) invariants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeRKqhb8HLdFQw6npouwTC

---
_Generated by [Claude Code](https://claude.ai/code/session_01TeRKqhb8HLdFQw6npouwTC)_