### PR TITLE
feat(plugin): scaffold living-docs-enforcer Claude Code plugin

### DIFF
--- a/plugins/living-docs-enforcer/.claude-plugin/marketplace.json
+++ b/plugins/living-docs-enforcer/.claude-plugin/marketplace.json
@@ -1,0 +1,26 @@
+{
+  "name": "living-docs-enforcer",
+  "owner": {
+    "name": "Evaldo Klock"
+  },
+  "metadata": {
+    "description": "Opt-in commit-boundary enforcement of the Living Docs mechanical invariants.",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "living-docs-enforcer",
+      "description": "OPT-IN enforcement of the Living Docs mechanical invariants at the git-commit boundary. Recommended for teams that want the docs floor enforced, not just advised. Bundles the living-docs skill and a PreToolUse hook that runs lint-docs.sh on git commit; enforcement is configurable via LIVING_DOCS_ENFORCE (block|warn).",
+      "source": "./",
+      "version": "0.1.0",
+      "author": {
+        "name": "Evaldo Klock",
+        "url": "https://github.com/ejklock"
+      },
+      "repository": "https://github.com/ejklock/living-docs-skill",
+      "license": "MIT",
+      "keywords": ["documentation", "living-docs", "adr", "lint", "hook", "enforcement", "pre-commit"],
+      "category": "productivity"
+    }
+  ]
+}

--- a/plugins/living-docs-enforcer/.claude-plugin/plugin.json
+++ b/plugins/living-docs-enforcer/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "living-docs-enforcer",
+  "version": "0.1.0",
+  "description": "OPT-IN enforcement of the Living Docs mechanical invariants at the git-commit boundary. Recommended for teams that want the docs floor (well-formed, indexed, linked, supersede-correct docs) enforced, not just advised. Bundles the living-docs skill and a PreToolUse hook that runs lint-docs.sh on git commit. Enforcement is configurable (block|warn) via LIVING_DOCS_ENFORCE; default is an open maintainer decision (currently block for sound checks, warn-only for the absence proxy).",
+  "author": {
+    "name": "Evaldo Klock",
+    "url": "https://github.com/ejklock"
+  },
+  "repository": "https://github.com/ejklock/living-docs-skill",
+  "license": "MIT",
+  "keywords": ["documentation", "living-docs", "adr", "lint", "hook", "enforcement", "pre-commit"],
+  "skills": "./skills/",
+  "hooks": "./hooks/hooks.json"
+}

--- a/plugins/living-docs-enforcer/README.md
+++ b/plugins/living-docs-enforcer/README.md
@@ -1,0 +1,83 @@
+# living-docs-enforcer
+
+An **opt-in** Claude Code plugin that enforces the [Living Docs](../../skills/living-docs/SKILL.md) *mechanical* invariants at the **git-commit boundary**. It bundles the `living-docs` skill and adds a `PreToolUse` hook that runs the skill's `lint-docs.sh` whenever Claude is about to run `git commit`.
+
+> **Status: SCAFFOLD.** This is a correct, runnable skeleton. The enforcement *default* (block vs. warn) is still an open maintainer decision — see [The block-vs-warn knob](#the-block-vs-warn-knob).
+
+This plugin is **recommended for teams that want the docs floor enforced, not just advised.** Solo / exploratory work can skip it; the skill alone (without this plugin) still provides the templates and the linter to run by hand.
+
+## What it does
+
+On every `git commit` the hook runs `lint-docs.sh` against your docs bundle (`./docs` by default) and decides:
+
+| Situation | lint-docs result | Decision |
+|---|---|---|
+| Docs that **exist** are malformed / orphan / broken-link / supersede-broken | exit 1 | **BLOCK** by default (configurable → warn) |
+| Docs are clean | exit 0 | allow, silent |
+| A structural code change touches **no** `docs/` file (the *absence proxy*) | n/a | **warn only — never blocks** |
+| lint-docs / git missing, no docs bundle, usage error | exit 2 / absent | allow with a warning (never wedges your commit) |
+
+## Install (opt-in)
+
+This plugin lives inside the `living-docs-skill` repo at `plugins/living-docs-enforcer/`. Add the repo as a marketplace and install the plugin:
+
+```bash
+# add this repo as a plugin marketplace (points at plugins/living-docs-enforcer/.claude-plugin/marketplace.json)
+/plugin marketplace add ejklock/living-docs-skill
+
+# install the enforcer
+/plugin install living-docs-enforcer
+```
+
+Installing the plugin installs **both** the bundled `living-docs` skill and the commit-boundary hook. The skill is bundled by reference (a symlink to the repo's single `skills/living-docs/` source) so there is exactly one copy of `lint-docs.sh` — the hook calls that copy via `${CLAUDE_PLUGIN_ROOT}/skills/living-docs/scripts/lint-docs.sh`.
+
+## The block-vs-warn knob
+
+The one knob, read from the environment by the hook:
+
+```bash
+export LIVING_DOCS_ENFORCE=block   # default — sound violations block the commit
+export LIVING_DOCS_ENFORCE=warn    # sound violations print to stderr and ALLOW the commit
+```
+
+(Optional) point the linter at a non-standard bundle root:
+
+```bash
+export LIVING_DOCS_BUNDLE=documentation   # default: docs
+```
+
+> **⚠ OPEN DECISION (pending the maintainer).** Whether the shipped default for the *sound* checks should be `block` or `warn` is **not yet settled.** The scaffold ships `block` (fail-safe: a docs floor that does not block is easy to ignore), but a team adopting this mid-stream may prefer `warn` for a grace period. This is deliberately a configurable knob, not a hard-wired policy — flip it per-repo / per-CI until the maintainer fixes the default.
+
+## What this enforces vs. what it can't
+
+**It forces the verifiable floor** — the half of Living Docs that has a *sound oracle* (the doc is in the tree and demonstrably wrong), exactly what `lint-docs.sh` checks:
+
+- every concept doc has OKF frontmatter with a non-empty `type`
+- `index.md` / `log.md` carry no frontmatter (except the bundle-root `okf_version`)
+- every concept file is listed in its directory's `index.md` (no orphans)
+- every directory index is reachable from the bundle-root index
+- every local markdown link resolves
+- a `status: Superseded` record carries a resolvable `superseded_by`
+
+**It warns on the absence proxy** — a structural code change that touches no `docs/` file gets a non-blocking reminder (invariant 5: "no structural change without its doc"). This **never blocks**: there is no sound oracle for *"an ADR belongs here"*, and a hard block would just be satisfied with an empty placeholder doc (Goodhart). The reminder is a nudge for a human, not a gate.
+
+**It does NOT — and cannot — force a *meaningful* ADR in flow order.** Whether a decision was *worth* recording, whether the ADR's reasoning is sound, whether docs match the code's actual behavior (invariant 1, docs-first) or each fact has exactly one home (invariant 2, semantic half) — none of these have a mechanical oracle. They stay with the **reviewer / human**, exactly as `lint-docs.sh` itself documents ("invariants 1 and 2's semantic half are NOT mechanical — they stay with the reviewing agent"). This plugin is the *floor*, not the ceiling.
+
+## Trust / proof
+
+`lint-docs.sh` is exercised by a fixture corpus (`tests/lint-docs/`) that asserts it stays silent on clean bundles and catches each mechanical violation it claims to — one violation per dirty fixture. That parity corpus is what makes the linter trustworthy enough to gate a commit on. (The corpus lands with the linter-hardening change; the hook wraps the same CLI either way.)
+
+## Files
+
+```
+plugins/living-docs-enforcer/
+├── .claude-plugin/
+│   ├── plugin.json          # manifest: name, components (skills + hooks)
+│   └── marketplace.json     # marketplace entry (source: ./)
+├── hooks/
+│   ├── hooks.json           # PreToolUse / matcher: Bash → block-docs-drift.sh
+│   └── block-docs-drift.sh  # the commit-boundary decision logic
+├── skills/
+│   └── living-docs -> ../../../skills/living-docs   # bundled by symlink (single source)
+└── README.md
+```

--- a/plugins/living-docs-enforcer/hooks/block-docs-drift.sh
+++ b/plugins/living-docs-enforcer/hooks/block-docs-drift.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+#
+# block-docs-drift.sh — PreToolUse hook: enforce the Living Docs mechanical
+# invariants at the git-commit boundary.
+#
+# Claude Code passes the hook input as JSON on stdin:
+#   { "tool_name": "Bash", "tool_input": { "command": "git commit -m ..." } }
+#
+# Decision contract (matches the repo's existing PreToolUse blockers, e.g.
+# block-dangerous-patterns.sh):
+#   exit 0 = allow the command  ·  exit 2 = block it (reason printed to stderr)
+#
+# This hook fires on every Bash call but only ACTS on `git commit`. On a commit
+# it runs the bundled lint-docs.sh against the repo's docs bundle and then:
+#
+#   - SOUND CHECKS — docs that EXIST being malformed / orphan / broken-link /
+#     supersede-broken (lint-docs exit 1). lint-docs has a sound oracle for these
+#     (the doc is in the tree and demonstrably wrong), so the DEFAULT is to BLOCK
+#     the commit. This is the knob: LIVING_DOCS_ENFORCE=block|warn (default block).
+#     With LIVING_DOCS_ENFORCE=warn it prints the violations to stderr and ALLOWS.
+#     ──► THE BLOCK-VS-WARN DEFAULT IS THE OPEN POLICY DECISION (see README).
+#
+#   - THE ABSENCE PROXY — a structural change that touches no docs/ file. There is
+#     NO sound oracle for "an ADR should exist here" (a hard block is gameable with
+#     an empty doc), so this is WARN-ONLY and NEVER blocks, regardless of the knob.
+#     Implemented here as a minimal, clearly-marked structural heuristic.
+#
+# Defensive by construction: if git or lint-docs is missing, if there is no docs
+# bundle, or if anything else goes sideways, the hook EXITS CLEANLY (0) with at
+# most a warning — it must never wedge the user's commit on its own errors.
+
+# Note: intentionally NOT `set -e` — a non-zero from an internal probe must not
+# be reinterpreted as a block. Blocking is only ever an explicit `exit 2`.
+set -uo pipefail
+
+# --- enforcement knob -------------------------------------------------------
+# block (default) | warn. Anything else is treated as block (fail safe).
+ENFORCE="${LIVING_DOCS_ENFORCE:-block}"
+
+# --- bundle root: default ./docs, overridable for non-standard layouts ------
+BUNDLE="${LIVING_DOCS_BUNDLE:-docs}"
+
+# --- read + parse the hook payload ------------------------------------------
+INPUT="$(cat)"
+
+if command -v jq >/dev/null 2>&1; then
+	TOOL_NAME="$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)"
+	COMMAND="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)"
+else
+	TOOL_NAME="$(printf '%s' "$INPUT" \
+		| grep -o '"tool_name"[[:space:]]*:[[:space:]]*"[^"]*"' \
+		| sed 's/.*"tool_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')"
+	COMMAND_RAW="$(printf '%s' "$INPUT" \
+		| sed 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)"}}.*/\1/')"
+	COMMAND="$(printf '%s' "$COMMAND_RAW" \
+		| sed 's/\\"/"/g' \
+		| sed 's/\\n/\n/g' \
+		| sed 's/\\t/\t/g' \
+		| sed 's/\\\\/\\/g')"
+fi
+
+# Only act on Bash, and only on a git commit. Everything else: allow.
+[[ "$TOOL_NAME" != "Bash" ]] && exit 0
+printf '%s' "$COMMAND" | grep -qE 'git([[:space:]]+-[^[:space:]]+)*[[:space:]]+commit([[:space:]]|$)' || exit 0
+
+# --- locate the bundled linter ----------------------------------------------
+# CLAUDE_PLUGIN_ROOT is exported by Claude Code into hook processes. Fall back to
+# the script's own location so the hook is also runnable standalone (e.g. in CI).
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+LINT="$PLUGIN_ROOT/skills/living-docs/scripts/lint-docs.sh"
+
+# --- defensive guards: never wedge the commit on our own missing deps -------
+if ! command -v git >/dev/null 2>&1; then
+	echo "[living-docs-enforcer] git not found — skipping docs lint (commit allowed)." >&2
+	exit 0
+fi
+if [[ ! -f "$LINT" ]]; then
+	echo "[living-docs-enforcer] lint-docs.sh not found at $LINT — skipping docs lint (commit allowed)." >&2
+	exit 0
+fi
+if [[ ! -d "$BUNDLE" ]]; then
+	# No docs bundle at all. This is the absence case at the extreme; warn only.
+	echo "[living-docs-enforcer] no docs bundle at ./$BUNDLE — nothing to lint (commit allowed)." >&2
+	exit 0
+fi
+
+# --- absence proxy (WARN-ONLY, never blocks) --------------------------------
+# Heuristic: if the staged change touches code/structure but NOT a single docs/
+# file, surface a gentle reminder. There is no sound oracle for "an ADR belongs
+# here", so this can never be a block — a hard block would just be satisfied with
+# an empty placeholder doc (Goodhart). Best-effort; silent on any git error.
+STAGED="$(git diff --cached --name-only 2>/dev/null || true)"
+if [[ -n "$STAGED" ]]; then
+	if ! printf '%s\n' "$STAGED" | grep -qE "(^|/)${BUNDLE}/"; then
+		if printf '%s\n' "$STAGED" | grep -qE '\.(ts|tsx|js|jsx|py|go|rb|php|java|kt|rs|c|cc|cpp|h|hpp|cs|swift|sql)$'; then
+			echo "[living-docs-enforcer] reminder: this commit changes code but touches no ./$BUNDLE file." >&2
+			echo "                       if it is a structural change (new module, moved files, schema/flow change)," >&2
+			echo "                       Living Docs invariant 5 wants the doc + diagram updated in the same change." >&2
+			echo "                       (advisory only — not a sound check, never blocks)" >&2
+		fi
+	fi
+fi
+
+# --- sound checks: run the bundled linter -----------------------------------
+LINT_OUT="$(bash "$LINT" "$BUNDLE" 2>&1)"
+LINT_RC=$?
+
+# exit 2 from the linter = usage / bundle-not-found. That is OUR misconfiguration,
+# not the user's docs being wrong — warn and allow, never block.
+if [[ "$LINT_RC" -eq 2 ]]; then
+	echo "[living-docs-enforcer] lint-docs could not run (exit 2 — usage/bundle error) — commit allowed:" >&2
+	printf '%s\n' "$LINT_OUT" | sed 's/^/    /' >&2
+	exit 0
+fi
+
+# exit 0 = clean. Allow silently.
+if [[ "$LINT_RC" -eq 0 ]]; then
+	exit 0
+fi
+
+# exit 1 = real violations on docs that exist (the sound checks). Apply the knob.
+if [[ "$ENFORCE" == "warn" ]]; then
+	echo "[living-docs-enforcer] WARN: Living Docs invariant violations (LIVING_DOCS_ENFORCE=warn — commit allowed):" >&2
+	printf '%s\n' "$LINT_OUT" | sed 's/^/    /' >&2
+	exit 0
+fi
+
+# Default / any non-"warn" value: BLOCK.
+echo "BLOCKED by living-docs-enforcer: Living Docs invariant violations in ./$BUNDLE." >&2
+printf '%s\n' "$LINT_OUT" | sed 's/^/    /' >&2
+echo "" >&2
+echo "Fix the docs above and re-commit. To downgrade to a warning, set LIVING_DOCS_ENFORCE=warn." >&2
+exit 2

--- a/plugins/living-docs-enforcer/hooks/hooks.json
+++ b/plugins/living-docs-enforcer/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/block-docs-drift.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/living-docs-enforcer/skills/living-docs
+++ b/plugins/living-docs-enforcer/skills/living-docs
@@ -1,0 +1,1 @@
+../../../skills/living-docs


### PR DESCRIPTION
## What

Scaffolds an **opt-in** Claude Code plugin, `living-docs-enforcer`, that packages the `living-docs` skill + its deterministic linter + a commit-boundary enforcement hook. This is a **correct, runnable skeleton** — small and reviewable, not the final polished enforcement.

## Layout

```
plugins/living-docs-enforcer/
├── .claude-plugin/
│   ├── plugin.json          # manifest (name, skills + hooks components)
│   └── marketplace.json     # marketplace entry (source: ./)
├── hooks/
│   ├── hooks.json           # PreToolUse / matcher: Bash → block-docs-drift.sh
│   └── block-docs-drift.sh  # commit-boundary decision logic
├── skills/
│   └── living-docs -> ../../../skills/living-docs   # bundled by symlink (single source)
└── README.md
```

Manifest shape mirrors the owner's existing `cache-statusline` plugin (same `.claude-plugin/{plugin.json,marketplace.json}` layout, author/repo/license/keywords style). Hook declaration verified against the official Claude Code plugins reference (`hooks/hooks.json`, `PreToolUse` event, `matcher: "Bash"`, `${CLAUDE_PLUGIN_ROOT}` path substitution, `skills/` at plugin root not inside `.claude-plugin/`).

## Hook decision logic

Fires on every Bash call but only acts on `git commit`. Mirrors the existing `block-dangerous-patterns.sh` PreToolUse blocker — **exit 2 blocks, exit 0 allows**, reason on stderr; same jq-with-grep/sed-fallback stdin parsing.

- **Sound checks** (docs that EXIST being malformed / orphan / broken-link / supersede-broken → `lint-docs.sh` exit 1): **default BLOCK**, flip to warn with the env knob.
- **Absence proxy** (a structural code change touching no `docs/` file): **WARN only, never blocks** — no sound oracle for "an ADR belongs here"; a hard block is gameable with an empty doc (Goodhart).
- **Defensive**: missing git / lint-docs / bundle, or lint usage error (exit 2) → allow with a warning. Never wedges the user's commit on the hook's own errors.

## The block-vs-warn knob (OPEN DECISION)

```bash
LIVING_DOCS_ENFORCE=block   # default — sound violations block the commit
LIVING_DOCS_ENFORCE=warn    # sound violations warn and allow
LIVING_DOCS_BUNDLE=docs     # optional: non-standard bundle root
```

**Whether the shipped default should be `block` or `warn` is deliberately left as an open maintainer decision** (documented in plugin.json, the hook header, and the README). The scaffold ships `block` (fail-safe) but it is a configurable knob, not hard-wired policy.

## Skill bundling

Bundled by **symlink** (git mode `120000`) to the repo's single `skills/living-docs/` — no duplication. The hook calls that one copy at `${CLAUDE_PLUGIN_ROOT}/skills/living-docs/scripts/lint-docs.sh`. **No changes to `lint-docs.sh` logic; no changes to the `tests/lint-docs/` corpus.**

## Honest scope (in the README)

Enforces the **verifiable floor** (existing docs well-formed/indexed/linked/supersede-correct — what lint-docs has a sound oracle for) and **warns** on the absence proxy. It does **not and cannot** force a *meaningful* ADR in flow order, docs-first sync, or one-home-per-fact — those have no mechanical oracle and stay with the reviewer/human.

## Verification

Smoke-tested all decision paths: non-commit Bash → allow; non-Bash → allow; commit + clean bundle → allow (exit 0); commit + dirty bundle → block (exit 2); `LIVING_DOCS_ENFORCE=warn` on dirty → allow (exit 0); missing bundle → defensive allow. All three JSON files validate. Author = Evaldo Klock.

## Out of scope (later steps)

Pi/OpenCode adapters; the final enforcement policy decision; wiring into CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeRKqhb8HLdFQw6npouwTC

---
_Generated by [Claude Code](https://claude.ai/code/session_01TeRKqhb8HLdFQw6npouwTC)_