### PR TITLE
feat: diff-aware ratchet for lint-docs + harness-agnostic enforcement triggers

### DIFF
--- a/.github/actions/living-docs-ratchet/action.yml
+++ b/.github/actions/living-docs-ratchet/action.yml
@@ -1,0 +1,88 @@
+name: Living Docs ratchet
+description: >-
+  Fail a pull request only on NEW Living Docs invariant violations (diff-aware
+  ratchet), grandfathering pre-existing debt. A thin wrapper over the single
+  enforcement CLI lint-docs.sh --ratchet — harness-agnostic, the unbypassable
+  CI backstop that complements the local pre-commit hook.
+
+inputs:
+  bundle:
+    description: "Docs bundle to lint (path relative to the repo root)."
+    required: false
+    default: docs
+  base-ref:
+    description: >-
+      Baseline git ref the ratchet compares against (only violations absent here
+      block). Defaults to the PR base sha (github.event.pull_request.base.sha),
+      falling back to origin/<base-branch>. The merge-base with the head is used
+      when available so only the PR's own delta is judged.
+    required: false
+    default: ""
+  lint-docs:
+    description: >-
+      Path to lint-docs.sh. Defaults to the conventional location shipped by the
+      living-docs skill; override if you vendor it elsewhere.
+    required: false
+    default: skills/living-docs/scripts/lint-docs.sh
+
+runs:
+  using: composite
+  steps:
+    - name: Living Docs diff-aware ratchet
+      shell: bash
+      env:
+        IN_BUNDLE: ${{ inputs.bundle }}
+        IN_BASE_REF: ${{ inputs.base-ref }}
+        IN_LINT: ${{ inputs.lint-docs }}
+        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+      run: |
+        set -uo pipefail
+
+        LINT="$IN_LINT"
+        if [[ ! -x "$LINT" ]]; then
+          if [[ -f "$LINT" ]]; then
+            chmod +x "$LINT" || true
+          fi
+        fi
+        if [[ ! -x "$LINT" ]]; then
+          echo "::error::living-docs-ratchet: lint-docs.sh not found/executable at '$LINT'." \
+            "Pass the 'lint-docs' input if you vendor it elsewhere."
+          exit 1
+        fi
+
+        if [[ ! -d "$IN_BUNDLE" ]]; then
+          echo "::notice::living-docs-ratchet: no docs bundle at '$IN_BUNDLE' — nothing to enforce."
+          exit 0
+        fi
+
+        # Resolve the baseline ref: explicit input wins, then the PR base sha,
+        # then origin/<base-branch>.
+        BASE="$IN_BASE_REF"
+        if [[ -z "$BASE" ]]; then
+          if [[ -n "${PR_BASE_SHA:-}" ]]; then
+            BASE="$PR_BASE_SHA"
+          elif [[ -n "${PR_BASE_REF:-}" ]]; then
+            BASE="origin/${PR_BASE_REF}"
+          fi
+        fi
+        if [[ -z "$BASE" ]]; then
+          echo "::warning::living-docs-ratchet: could not determine a baseline ref" \
+            "(not a pull_request event?). Treating baseline as empty (all violations are NEW)."
+          BASE="__living_docs_no_baseline__"
+        fi
+
+        # Ensure the base commit is present (checkout with fetch-depth: 0 provides it).
+        if ! git rev-parse --verify --quiet "${BASE}^{commit}" >/dev/null 2>&1; then
+          echo "::warning::living-docs-ratchet: baseline ref '$BASE' not present in checkout." \
+            "Use 'actions/checkout@v4' with 'fetch-depth: 0'. Proceeding (baseline treated as empty)."
+        fi
+
+        # Prefer the merge-base so we judge only the PR's own delta.
+        if git rev-parse --verify --quiet "${BASE}^{commit}" >/dev/null 2>&1; then
+          MB="$(git merge-base "$BASE" HEAD 2>/dev/null || true)"
+          [[ -n "$MB" ]] && BASE="$MB"
+        fi
+
+        echo "living-docs-ratchet: bundle='$IN_BUNDLE' baseline='$BASE'"
+        "$LINT" --ratchet "$BASE" "$IN_BUNDLE"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Test — lint-docs.sh fixture/parity corpus
         run: ./tests/lint-docs/run.sh
 
+      - name: Test — lint-docs.sh diff-aware ratchet corpus
+        run: ./tests/lint-docs/run-ratchet.sh
+
       - name: Lint — example docs bundle against the Living Docs invariants
         run: ./skills/living-docs/scripts/lint-docs.sh examples/linkly/docs
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ INSTALL := ./install.sh
 .PHONY: help install install-claude install-cursor install-copilot \
         install-opencode install-codex install-pi install-all install-pocock \
         project-claude project-opencode project-codex project-pi \
-        uninstall uninstall-all check lint lint-docs test-lint-docs version
+        uninstall uninstall-all check lint lint-docs test-lint-docs test-ratchet version
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
@@ -58,9 +58,10 @@ uninstall: ## Remove the global Claude Code install
 uninstall-all: ## Remove the install for every supported harness
 	$(INSTALL) all --uninstall
 
-check: version test-lint-docs lint-docs ## Check version sync, validate install.sh, dry-run harnesses, test+run the docs linter
+check: version test-lint-docs test-ratchet lint-docs ## Check version sync, validate install.sh, dry-run harnesses, test+run the docs linter (+ ratchet)
 	bash -n install.sh
 	bash -n skills/living-docs/scripts/lint-docs.sh
+	bash -n enforcement/pre-commit.sh
 	bash -n scripts/check-version.sh
 	$(INSTALL) all --dry-run
 
@@ -69,6 +70,9 @@ lint-docs: ## Validate the example docs bundle against the Living Docs invariant
 
 test-lint-docs: ## Run the lint-docs.sh fixture/parity corpus (clean passes, each violation caught)
 	./tests/lint-docs/run.sh
+
+test-ratchet: ## Run the diff-aware ratchet corpus (new violation blocks, pre-existing debt grandfathered)
+	./tests/lint-docs/run-ratchet.sh
 
 version: ## Assert the release version is consistent across VERSION and every SKILL.md
 	./scripts/check-version.sh

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ dependencies and the prior-art research that backs its honesty claims:
 | [`references/prior-art-landscape.md`](references/prior-art-landscape.md) | The sourced prior-art analysis. Living Docs is **§2** of this broader study of the system it came from; it is included so every "credit, not invention" claim has a checkable citation. |
 | [`skills/living-docs/scripts/lint-docs.sh`](skills/living-docs/scripts/lint-docs.sh) | The **deterministic checker** for the mechanical invariants — frontmatter/`type`, indexing + reachability, link resolution, supersede integrity. Ships *inside* the skill so an installed agent can run it. *A constraint without an instrument is a vibe*; this is the instrument. Wire it into CI. |
 | [`examples/linkly/`](examples/linkly/) | A worked, **lint-clean** end-to-end corpus (constitution → PRD → ADR + BDR → issue) for a fictional URL shortener — the discipline shown, not just described, and the fixture CI runs `lint-docs` against. |
+| [`enforcement/`](enforcement/) | **Harness-agnostic enforcement** of the linter's **diff-aware ratchet** (`lint-docs.sh --ratchet <ref>` — fails only on *new* violations, grandfathers pre-existing debt): a git **pre-commit hook** (local) and a reusable **GitHub Action** (CI backstop). One CLI at the git/CI boundary covers every harness *and* human commits; a per-harness plugin would be the optional in-loop layer calling the same CLI. |
 
 Each skill is self-describing — open its `SKILL.md` for the full operational
 detail. Living Docs and OKF compose but do not overlap: **Living Docs governs

--- a/enforcement/README.md
+++ b/enforcement/README.md
@@ -1,0 +1,95 @@
+# Living Docs enforcement — harness-agnostic ratchet triggers
+
+The mechanical Living Docs invariants are checked by one instrument:
+`skills/living-docs/scripts/lint-docs.sh`. Its **diff-aware ratchet** mode
+(`--ratchet <baseline-ref>`) fails **only on NEW violations** introduced by a
+change and **grandfathers pre-existing debt** — the same semantics the repo's
+other gates use.
+
+This directory holds two **thin triggers** that call that one CLI. Neither
+reimplements any check:
+
+| Trigger | When it runs | Bypassable? |
+|---|---|---|
+| `pre-commit.sh` | locally, on `git commit` | yes — `git commit --no-verify` |
+| `../.github/actions/living-docs-ratchet/` | in CI, on a pull request | no — the unbypassable backstop |
+
+**Why one CLI instead of a per-harness plugin.** Enforcing at the git boundary
+(pre-commit) and in CI (the Action) is *harness-agnostic*: it covers Claude
+Code, Pi, OpenCode, Cursor, Copilot **and** plain human commits with one
+mechanism. A per-harness plugin would be the optional *in-loop* layer that calls
+this **same** CLI; it is a separate scaffold and is **not** built here.
+
+---
+
+## 1. Pre-commit hook (local, fast feedback)
+
+The hook runs `lint-docs.sh --ratchet HEAD` on your docs bundle and blocks a
+commit that introduces a new violation.
+
+Git hooks **do not travel by clone** — install per checkout. The clean way is
+`core.hooksPath` (one config, no copying into `.git/hooks`):
+
+```bash
+# from your repo root, point git at a tracked hooks directory
+mkdir -p .githooks
+cp path/to/living-docs-skill/enforcement/pre-commit.sh .githooks/pre-commit
+chmod +x .githooks/pre-commit
+git config core.hooksPath .githooks
+```
+
+Now every `git commit` runs the ratchet. To bypass intentionally:
+
+```bash
+git commit --no-verify
+```
+
+Configuration (env vars, optional):
+
+- `DOCS_BUNDLE` — the bundle to lint (default: `docs`).
+- `LINT_DOCS` — explicit path to `lint-docs.sh`. If unset, the hook auto-discovers
+  it under `skills/living-docs/scripts/`, `scripts/`, `.claude/skills/...`, or `PATH`.
+
+Defensive by design: if `lint-docs.sh` or `git` is missing, or there is no docs
+bundle, the hook exits `0` — it never wedges a commit because tooling is absent.
+
+---
+
+## 2. GitHub Action (CI, unbypassable backstop)
+
+A **composite action** at
+[`.github/actions/living-docs-ratchet`](../.github/actions/living-docs-ratchet/action.yml).
+On a pull request it runs `lint-docs.sh --ratchet <base-ref>` with the baseline
+set to the PR's **merge base** (so only violations the PR introduces fail the
+check).
+
+Drop this into a consumer repo at `.github/workflows/living-docs.yml`:
+
+```yaml
+name: Living Docs ratchet
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  living-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # required: the ratchet needs the base ref's history
+
+      - uses: ejklock/living-docs-skill/.github/actions/living-docs-ratchet@main
+        with:
+          bundle: docs                 # optional, default: docs
+          base-ref: ${{ github.event.pull_request.base.sha }}  # optional; auto-detected if omitted
+```
+
+`fetch-depth: 0` is **required** — the ratchet materializes the baseline with
+`git worktree add`, which needs the base commit present in the checkout.
+
+If you vendor `lint-docs.sh` somewhere non-standard, pass `lint-docs:` with its
+path. The action degrades gracefully: a missing baseline ref is treated as empty
+(every current violation counts as new — fail-closed).

--- a/enforcement/pre-commit.sh
+++ b/enforcement/pre-commit.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# pre-commit.sh — git pre-commit hook: block a commit that introduces NEW
+# Living Docs invariant violations, while grandfathering pre-existing debt.
+#
+# It is a THIN trigger: it does not reimplement any check. It calls the single
+# enforcement CLI — `lint-docs.sh --ratchet HEAD` — against the project's docs
+# bundle. That one CLI, enforced here at the git boundary (and in CI via the
+# reusable Action), is HARNESS-AGNOSTIC: it covers Claude Code, Pi, OpenCode,
+# Cursor, Copilot AND plain human commits with one mechanism, instead of a
+# separate per-harness plugin. (The per-harness plugin is the optional in-loop
+# layer that calls this SAME CLI; it is not built here.)
+#
+# Baseline = HEAD: the ratchet compares the bundle you are about to commit
+# against the last commit, so only violations YOU are introducing block.
+#
+# Bypassable: `git commit --no-verify` skips all pre-commit hooks (inherent to
+# git). The unbypassable backstop is the CI Action.
+#
+# Defensive: if lint-docs.sh or git is missing, or this is not a git repo, the
+# hook exits 0 (it never wedges a commit because tooling is absent).
+#
+# --- configuration ---------------------------------------------------------
+# DOCS_BUNDLE  the docs bundle to lint (default: docs). Override via env, e.g.
+#              DOCS_BUNDLE=documentation/docs in your hook wrapper.
+# LINT_DOCS    path to lint-docs.sh. Auto-discovered if unset (see below).
+
+set -uo pipefail
+
+# git exports ambient vars into hooks (GIT_INDEX_FILE / GIT_DIR / GIT_WORK_TREE),
+# often as paths relative to the commit's cwd. They corrupt the `git worktree add`
+# the ratchet uses to materialize the baseline. Clear them so the linter's own git
+# calls operate on the repo cleanly.
+unset GIT_INDEX_FILE GIT_DIR GIT_WORK_TREE GIT_PREFIX
+
+DOCS_BUNDLE="${DOCS_BUNDLE:-docs}"
+
+# Resolve the repo root; bail cleanly if not in a git repo.
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$REPO_ROOT" ]]; then
+	exit 0
+fi
+
+# Locate lint-docs.sh: explicit env wins, then a few conventional locations.
+find_lint() {
+	if [[ -n "${LINT_DOCS:-}" && -x "$LINT_DOCS" ]]; then
+		printf '%s\n' "$LINT_DOCS"
+		return 0
+	fi
+	local c
+	for c in \
+		"$REPO_ROOT/skills/living-docs/scripts/lint-docs.sh" \
+		"$REPO_ROOT/scripts/lint-docs.sh" \
+		"$REPO_ROOT/.claude/skills/living-docs/scripts/lint-docs.sh"; do
+		if [[ -x "$c" ]]; then
+			printf '%s\n' "$c"
+			return 0
+		fi
+	done
+	# fall back to PATH
+	if command -v lint-docs.sh >/dev/null 2>&1; then
+		command -v lint-docs.sh
+		return 0
+	fi
+	return 1
+}
+
+LINT="$(find_lint || true)"
+if [[ -z "$LINT" ]]; then
+	echo "living-docs pre-commit: lint-docs.sh not found — skipping (set LINT_DOCS to enforce)." >&2
+	exit 0
+fi
+
+# No docs bundle in this repo → nothing to enforce.
+if [[ ! -d "$REPO_ROOT/$DOCS_BUNDLE" ]]; then
+	exit 0
+fi
+
+# Run the ratchet against HEAD. Exit 1 only on NEW violations.
+if ! (cd "$REPO_ROOT" && "$LINT" --ratchet HEAD "$DOCS_BUNDLE"); then
+	echo >&2
+	echo "living-docs pre-commit: this commit introduces NEW docs invariant violation(s)." >&2
+	echo "  Fix them, or bypass intentionally with:  git commit --no-verify" >&2
+	exit 1
+fi
+
+exit 0

--- a/skills/living-docs/scripts/lint-docs.sh
+++ b/skills/living-docs/scripts/lint-docs.sh
@@ -150,6 +150,20 @@ is_reserved() { # is_reserved <basename>
 	[[ "$1" == "index.md" || "$1" == "log.md" ]]
 }
 
+# Strip the bundle-root prefix from a path so it is bundle-relative. Used for any
+# path EMBEDDED IN A VIOLATION MESSAGE: report() only normalizes the file column
+# ($1), so an absolute/worktree path baked into the message ($2) would otherwise
+# differ between the current run ('docs/adr') and the ratchet's baseline worktree
+# ('/tmp/wt.../docs/adr'), misclassifying a pre-existing violation as [NEW].
+# Keeping the message itself bundle-relative makes the SAME violation byte-identical
+# across worktrees and also cleans up default-mode output.
+rel_to_bundle() { # rel_to_bundle <path>  → path with the bundle-root prefix dropped
+	local p="$1"
+	p="${p#"$BUNDLE"/}"
+	p="${p#"$BUNDLE"}"
+	printf '%s' "$p"
+}
+
 has_frontmatter() { # has_frontmatter <file>  → 0 if first line is '---'
 	[[ "$(head -n 1 "$1")" == "---" ]]
 }
@@ -283,7 +297,7 @@ for f in "${ALL_MD[@]}"; do
 	dir="$(dirname "$f")"
 	dir_index="$dir/index.md"
 	if [[ ! -f "$dir_index" ]]; then
-		report "$f" "no index.md in its directory ($dir) — orphan (invariant 3)"
+		report "$f" "no index.md in its directory ($(rel_to_bundle "$dir")) — orphan (invariant 3)"
 		continue
 	fi
 	listed=0
@@ -295,7 +309,7 @@ for f in "${ALL_MD[@]}"; do
 			break
 		fi
 	done < <(links_in "$dir_index")
-	((listed == 0)) && report "$f" "not listed in $dir_index — orphan (invariant 3)"
+	((listed == 0)) && report "$f" "not listed in $(rel_to_bundle "$dir_index") — orphan (invariant 3)"
 done
 
 # --- check: every directory index.md is reachable from the bundle root ------

--- a/skills/living-docs/scripts/lint-docs.sh
+++ b/skills/living-docs/scripts/lint-docs.sh
@@ -20,9 +20,27 @@
 # mechanical — they stay with the reviewing agent. This script never claims to check them.
 #
 # Usage:  lint-docs.sh [BUNDLE_ROOT]      (default: docs)
+#         lint-docs.sh --ratchet <baseline-ref> [BUNDLE_ROOT]
 #         lint-docs.sh --help
 #
-# Exit:   0 = clean, 1 = violations found, 2 = usage / bundle-not-found error.
+# Default (whole-bundle) mode:
+#   Exit 0 = clean, 1 = ANY violation, 2 = usage / bundle-not-found error.
+#
+# --ratchet <baseline-ref> mode (diff-aware):
+#   Lint the current bundle AND the bundle as of <baseline-ref> (a git ref), then
+#   exit 1 ONLY for violations present now that were ABSENT at baseline (NEW debt
+#   introduced by the change). Pre-existing violations are printed as informational
+#   "(pre-existing)" lines and do NOT fail the run — legacy debt is not held against
+#   the change. This mirrors the diff-aware ratchet the repo's other gates use:
+#   only NEW violations block; pre-existing debt is grandfathered.
+#
+#   These checks are whole-bundle (index reachability, orphan membership, link
+#   resolution, supersede integrity) — they are NOT file-local, so "lint only the
+#   touched files" cannot work. The ratchet therefore compares violation SETS, not
+#   files. The baseline bundle is materialized with `git worktree add` (robust for
+#   a whole directory) and removed afterward. Baseline ref absent / not a git repo /
+#   bundle missing at baseline → the baseline set is treated as EMPTY, so every
+#   current violation is considered NEW (fail-closed, documented in --help).
 
 set -uo pipefail
 
@@ -38,8 +56,9 @@ usage() {
 $PROG — validate the mechanical Living Docs invariants on a docs bundle.
 
 Usage:
-  $PROG [BUNDLE_ROOT]    Lint the bundle (default: ./docs)
-  $PROG --help           Show this help
+  $PROG [BUNDLE_ROOT]               Lint the bundle (default: ./docs)
+  $PROG --ratchet <ref> [BUNDLE]    Diff-aware: fail only on NEW violations vs <ref>
+  $PROG --help                      Show this help
 
 Checks (mechanical invariants only):
   * frontmatter      every non-reserved .md opens with frontmatter + non-empty type
@@ -50,18 +69,50 @@ Checks (mechanical invariants only):
   * links resolve    every local (/… or relative) markdown link points at a file
   * supersede        a 'status: Superseded' record carries a resolvable superseded_by
 
-Exit: 0 clean · 1 violations · 2 usage error.
+Diff-aware ratchet (--ratchet <baseline-ref>):
+  Lints the current bundle and the bundle as of <baseline-ref> (a git ref), and
+  fails (exit 1) ONLY for violations present now that were absent at the baseline —
+  i.e. NEW debt introduced by the change. Pre-existing violations are printed as
+  "(pre-existing)" and do NOT fail the run; a change that adds no new violation
+  passes even if the bundle carries legacy debt. The baseline is materialized with
+  'git worktree add'. If <baseline-ref> is absent, the tree is not a git repo, or
+  the bundle does not exist at the baseline, the baseline is treated as empty
+  (every current violation counts as NEW — fail-closed).
+
+  These checks are whole-bundle, not file-local, so the ratchet compares violation
+  SETS rather than touched files. One CLI enforced at the git boundary (pre-commit)
+  and in CI (a reusable Action) is harness-agnostic: it covers every AI harness AND
+  human commits with one mechanism, instead of a per-harness plugin.
+
+Exit: 0 clean (or no new violations) · 1 violations (or new violations) · 2 usage error.
 EOF
 }
+
+# --- argument parsing -------------------------------------------------------
+
+RATCHET=0
+BASELINE_REF=""
 
 case "${1:-}" in
 	-h | --help)
 		usage
 		exit 0
 		;;
+	--ratchet)
+		RATCHET=1
+		BASELINE_REF="${2:-}"
+		if [[ -z "$BASELINE_REF" ]]; then
+			echo "$PROG: --ratchet requires a <baseline-ref> argument" >&2
+			echo "       e.g. $PROG --ratchet HEAD docs" >&2
+			exit 2
+		fi
+		BUNDLE="${3:-docs}"
+		;;
+	*)
+		BUNDLE="${1:-docs}"
+		;;
 esac
 
-BUNDLE="${1:-docs}"
 BUNDLE="${BUNDLE%/}"
 
 if [[ ! -d "$BUNDLE" ]]; then
@@ -70,11 +121,27 @@ if [[ ! -d "$BUNDLE" ]]; then
 	exit 2
 fi
 
+# --- violation collection ---------------------------------------------------
+#
+# report() does double duty: it prints the human-readable line (as before) and,
+# when capturing for the ratchet, appends a NORMALIZED line to VIOL_LINES so the
+# same violation matches across two different worktrees. Normalization strips the
+# bundle-root prefix from the file path, so 'docs/adr/x.md' and
+# '/tmp/wt.../docs/adr/x.md' compare equal — the comparison key is
+# "<relpath-within-bundle>\t<message>".
+
 VIOLATIONS=0
+QUIET=""
+declare -a VIOL_LINES=()
 report() {
 	# report <file> <message>
-	printf '  %-44s %s\n' "$1" "$2"
+	[[ "$QUIET" != "quiet" ]] && printf '  %-44s %s\n' "$1" "$2"
 	VIOLATIONS=$((VIOLATIONS + 1))
+	# normalized key: drop the bundle prefix so paths are bundle-relative
+	local rel="$1"
+	rel="${rel#"$BUNDLE"/}"
+	rel="${rel#"$BUNDLE"}"
+	VIOL_LINES+=("$rel	$2")
 }
 
 # --- helpers ----------------------------------------------------------------
@@ -148,14 +215,29 @@ links_in() { # links_in <file>
 	grep -oE '\]\([^)]+\)' "$1" 2>/dev/null | sed -E 's/^\]\(//; s/\)$//'
 }
 
-# --- collect the corpus -----------------------------------------------------
+# --- the lint body, as a function so it can run against two trees ------------
+#
+# lint_run <bundle> [quiet]
+#   Lints <bundle>, appending normalized violations to the (caller-owned)
+#   VIOL_LINES array and bumping VIOLATIONS. When the second arg is "quiet" the
+#   per-violation human lines and the "bundle: …" header are suppressed (used for
+#   the baseline tree in ratchet mode — we only need its violation SET). Resets
+#   VIOLATIONS / VIOL_LINES at entry so it is safe to call twice.
 
-mapfile -t ALL_MD < <(find "$BUNDLE" -type f -name '*.md' | sort)
+lint_run() { # lint_run <bundle> [quiet]
+	BUNDLE="${1%/}"
+	QUIET="${2:-}"
+	VIOLATIONS=0
+	VIOL_LINES=()
 
-ROOT_INDEX="$BUNDLE/index.md"
+	local ALL_MD ALL_INDEX ROOT_INDEX
+	mapfile -t ALL_MD < <(find "$BUNDLE" -type f -name '*.md' | sort)
+	ROOT_INDEX="$BUNDLE/index.md"
 
-echo "Living Docs lint — bundle: $BUNDLE"
-echo
+	if [[ "$QUIET" != "quiet" ]]; then
+		echo "Living Docs lint — bundle: $BUNDLE"
+		echo
+	fi
 
 # --- check 1: bundle-root index exists --------------------------------------
 
@@ -283,13 +365,120 @@ for f in "${ALL_MD[@]}"; do
 	fi
 done
 
-# --- verdict ----------------------------------------------------------------
+	LAST_MD_COUNT="${#ALL_MD[@]}"
+}
 
-echo
-if ((VIOLATIONS == 0)); then
-	echo "OK — ${#ALL_MD[@]} docs, no invariant violations."
-	exit 0
+# --- driver -----------------------------------------------------------------
+
+if ((RATCHET == 0)); then
+	# Default whole-bundle mode: lint the current tree, fail on ANY violation.
+	lint_run "$BUNDLE"
+	echo
+	if ((VIOLATIONS == 0)); then
+		echo "OK — ${LAST_MD_COUNT} docs, no invariant violations."
+		exit 0
+	else
+		echo "FAIL — $VIOLATIONS violation(s) across ${LAST_MD_COUNT} docs."
+		exit 1
+	fi
+fi
+
+# --- ratchet mode -----------------------------------------------------------
+#
+# Compare the current bundle's violation SET against the baseline tree's set.
+# Only violations that are NEW (present now, absent at baseline) fail the run.
+
+# 1. lint the CURRENT bundle (verbose) and snapshot its normalized set
+lint_run "$BUNDLE"
+CUR_COUNT="$LAST_MD_COUNT"
+declare -a CUR_VIOL=("${VIOL_LINES[@]}")
+
+# 2. materialize the baseline tree and lint it (quiet) for its set
+declare -a BASE_VIOL=()
+BASELINE_NOTE=""
+WORKTREE=""
+
+cleanup_worktree() {
+	if [[ -n "$WORKTREE" && -d "$WORKTREE" ]]; then
+		git -C "$REPO_TOPLEVEL" worktree remove --force "$WORKTREE" >/dev/null 2>&1 ||
+			rm -rf "$WORKTREE" 2>/dev/null
+	fi
+}
+trap cleanup_worktree EXIT
+
+REPO_TOPLEVEL="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+
+if [[ -z "$REPO_TOPLEVEL" ]]; then
+	BASELINE_NOTE="not a git repository — baseline treated as empty (all violations are NEW)"
+elif ! git -C "$REPO_TOPLEVEL" rev-parse --verify --quiet "$BASELINE_REF^{commit}" >/dev/null 2>&1; then
+	BASELINE_NOTE="baseline ref '$BASELINE_REF' not found — baseline treated as empty (all violations are NEW)"
 else
-	echo "FAIL — $VIOLATIONS violation(s) across ${#ALL_MD[@]} docs."
+	# Where does BUNDLE live relative to the repo root? (so we can find it in the worktree)
+	BUNDLE_ABS="$(cd "$BUNDLE" && pwd)"
+	BUNDLE_REL="${BUNDLE_ABS#"$REPO_TOPLEVEL"/}"
+	if [[ "$BUNDLE_REL" == "$BUNDLE_ABS" ]]; then
+		# bundle is outside the repo — cannot map into the worktree
+		BASELINE_NOTE="bundle is outside the git repo — baseline treated as empty (all violations are NEW)"
+	else
+		WORKTREE="$(mktemp -d "${TMPDIR:-/tmp}/lint-docs-baseline.XXXXXX")"
+		if git -C "$REPO_TOPLEVEL" worktree add --quiet --detach "$WORKTREE" "$BASELINE_REF" >/dev/null 2>&1; then
+			BASE_BUNDLE="$WORKTREE/$BUNDLE_REL"
+			if [[ -d "$BASE_BUNDLE" ]]; then
+				lint_run "$BASE_BUNDLE" quiet
+				BASE_VIOL=("${VIOL_LINES[@]}")
+			else
+				BASELINE_NOTE="bundle '$BUNDLE_REL' did not exist at '$BASELINE_REF' — baseline treated as empty (all violations are NEW)"
+			fi
+		else
+			BASELINE_NOTE="could not check out '$BASELINE_REF' — baseline treated as empty (all violations are NEW)"
+		fi
+	fi
+fi
+
+# 3. set difference: NEW = CUR \ BASE ; pre-existing = CUR ∩ BASE
+declare -A BASE_SET=()
+for v in "${BASE_VIOL[@]:-}"; do
+	[[ -n "$v" ]] && BASE_SET["$v"]=1
+done
+
+declare -a NEW_VIOL=()
+declare -a OLD_VIOL=()
+for v in "${CUR_VIOL[@]:-}"; do
+	[[ -z "$v" ]] && continue
+	if [[ -n "${BASE_SET[$v]:-}" ]]; then
+		OLD_VIOL+=("$v")
+	else
+		NEW_VIOL+=("$v")
+	fi
+done
+
+# 4. report
+echo
+echo "Ratchet — baseline: $BASELINE_REF"
+[[ -n "$BASELINE_NOTE" ]] && echo "  note: $BASELINE_NOTE"
+echo
+
+fmt_viol() { # fmt_viol <normalized-line> <tag>
+	# normalized line is "<relpath>\t<message>"; print it human-readably with a tag
+	local line="$1" tag="$2" rel msg
+	rel="${line%%$'\t'*}"
+	msg="${line#*$'\t'}"
+	printf '  %-7s %-40s %s\n' "$tag" "$rel" "$msg"
+}
+
+if ((${#OLD_VIOL[@]} > 0)); then
+	echo "Pre-existing violations (grandfathered — do NOT block this change):"
+	for v in "${OLD_VIOL[@]}"; do fmt_viol "$v" "[old]"; done
+	echo
+fi
+
+if ((${#NEW_VIOL[@]} > 0)); then
+	echo "NEW violations introduced by this change (these block):"
+	for v in "${NEW_VIOL[@]}"; do fmt_viol "$v" "[NEW]"; done
+	echo
+	echo "FAIL — ${#NEW_VIOL[@]} new violation(s) vs baseline $BASELINE_REF (${#OLD_VIOL[@]} pre-existing, not counted)."
 	exit 1
+else
+	echo "OK — no new violations vs baseline $BASELINE_REF (${#OLD_VIOL[@]} pre-existing, grandfathered)."
+	exit 0
 fi

--- a/tests/lint-docs/README.md
+++ b/tests/lint-docs/README.md
@@ -10,12 +10,28 @@ to — one violation per dirty fixture, in the spirit of an arch-gate parity tes
 ## Run
 
 ```bash
-make test-lint-docs        # from the repo root
-# or
+make test-lint-docs        # default-mode fixture/parity corpus
+make test-ratchet          # diff-aware ratchet corpus
+# or directly
 tests/lint-docs/run.sh
+tests/lint-docs/run-ratchet.sh
 ```
 
-The runner exits non-zero if any case misbehaves. CI runs it on every push/PR.
+The runners exit non-zero if any case misbehaves. CI runs both on every push/PR.
+
+## Two corpora
+
+- **`run.sh`** — default whole-bundle mode: clean passes silently, each
+  mechanical violation is caught (one per dirty fixture, table below).
+- **`run-ratchet.sh`** — the **diff-aware ratchet** (`lint-docs.sh --ratchet
+  <ref>`): proves only NEW violations block while pre-existing debt is
+  grandfathered. Each case spins up a throwaway git repo (init → commit a
+  baseline → mutate the working tree), exercising the real `git worktree add`
+  baseline materialization. Cases: `new-blocks` (introduce one violation →
+  exit 1, named), `preexisting-ok` (committed debt + unrelated clean change →
+  exit 0), `fix-passes` (remove a pre-existing violation → exit 0),
+  `baseline-absent` (ratchet against a missing ref → baseline empty, violation
+  counts as new → exit 1, fail-closed).
 
 ## Layout
 

--- a/tests/lint-docs/run-ratchet.sh
+++ b/tests/lint-docs/run-ratchet.sh
@@ -17,6 +17,12 @@
 #   preexisting-ok    bundle with a committed violation, make an unrelated clean change
 #                     → exit 0 (legacy debt is not held against the change)
 #   fix-passes        remove a pre-existing violation → exit 0
+#   orphan-preexisting-ok  pre-existing ORPHAN (a violation whose message embeds a
+#                     dir-index path) + unrelated clean change → exit 0. This is the
+#                     regression for the worktree-absolute-vs-bundle-relative path bug:
+#                     the orphan message must be bundle-relative so the same violation
+#                     keys identically across the baseline worktree and the current run.
+#   orphan-new-blocks a newly-introduced orphan → exit 1 (the fix must not blunt the ratchet)
 #   baseline-absent   --ratchet against a non-existent ref → baseline empty, current
 #                     violation counts as NEW → exit 1 (fail-closed)
 #
@@ -163,6 +169,56 @@ EOF
 	assert "fix-passes" 0 "$out" "$exit_out" "no new violations"
 }
 
+run_orphan_preexisting_ok() {
+	# An ORPHAN violation embeds a directory-index path in its MESSAGE. That path is
+	# absolute inside the `git worktree add` baseline tree but bundle-relative in the
+	# current run; if the message is not normalized to bundle-relative the SAME orphan
+	# yields different keys across the two trees, so a pre-existing orphan is wrongly
+	# classified [NEW] and the ratchet blocks legacy debt it should grandfather.
+	# This is the case that catches that bug (broken-link/frontmatter messages, used
+	# by the other cases, carry only bundle-relative strings and hid it).
+	local repo out exit_out
+	repo="$(new_repo)"
+	seed_clean_bundle "$repo"
+	# commit a bundle that ALREADY carries an orphan (a concept file not listed in
+	# its directory's index.md) — pre-existing orphan debt
+	cat >"$repo/docs/adr/0002-orphan.md" <<'EOF'
+---
+type: adr
+---
+# Orphaned decision (not listed in adr/index.md)
+EOF
+	git -C "$repo" add -A
+	git -C "$repo" commit -qm "baseline with pre-existing orphan"
+	# make an UNRELATED, clean change in the working tree
+	echo '<!-- unrelated clean edit -->' >>"$repo/docs/index.md"
+	out="$(cd "$repo" && "$LINT" --ratchet HEAD docs 2>&1)"
+	exit_out=$?
+	assert "orphan-preexisting-ok" 0 "$out" "$exit_out" "no new violations"
+	assert "orphan-grandfathered" 0 "$out" "$exit_out" "grandfathered"
+}
+
+run_orphan_new_blocks() {
+	# A NEWLY-introduced orphan must still block (exit 1) — the fix must not blunt
+	# the ratchet, only stop it misclassifying PRE-EXISTING orphans.
+	local repo out exit_out
+	repo="$(new_repo)"
+	seed_clean_bundle "$repo"
+	git -C "$repo" add -A
+	git -C "$repo" commit -qm "clean baseline"
+	# introduce an orphan in the working tree
+	cat >"$repo/docs/adr/0002-orphan.md" <<'EOF'
+---
+type: adr
+---
+# Newly orphaned decision (not listed in adr/index.md)
+EOF
+	out="$(cd "$repo" && "$LINT" --ratchet HEAD docs 2>&1)"
+	exit_out=$?
+	assert "orphan-new-blocks" 1 "$out" "$exit_out" "0002-orphan.md"
+	assert "orphan-new-marked" 1 "$out" "$exit_out" "NEW violations introduced"
+}
+
 run_baseline_absent() {
 	local repo out exit_out
 	repo="$(new_repo)"
@@ -180,6 +236,8 @@ run_baseline_absent() {
 run_new_blocks
 run_preexisting_ok
 run_fix_passes
+run_orphan_preexisting_ok
+run_orphan_new_blocks
 run_baseline_absent
 
 echo

--- a/tests/lint-docs/run-ratchet.sh
+++ b/tests/lint-docs/run-ratchet.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+#
+# run-ratchet.sh — corpus for the DIFF-AWARE RATCHET mode of lint-docs.sh.
+#
+# The default-mode corpus (run.sh) proves the linter catches each whole-bundle
+# violation. This corpus proves the *ratchet* layer on top of it: that only NEW
+# violations (present now, absent at the baseline ref) block, while pre-existing
+# debt is grandfathered — the same diff-aware semantics the repo's other gates use.
+#
+# Each case spins up a THROWAWAY git repo (init → commit a baseline → mutate the
+# working tree), so the cases exercise the real `git worktree add` baseline
+# materialization end-to-end. A local git identity is set inside each temp repo so
+# commits work in CI.
+#
+# Cases:
+#   new-blocks        clean committed bundle, introduce ONE violation → exit 1, names it
+#   preexisting-ok    bundle with a committed violation, make an unrelated clean change
+#                     → exit 0 (legacy debt is not held against the change)
+#   fix-passes        remove a pre-existing violation → exit 0
+#   baseline-absent   --ratchet against a non-existent ref → baseline empty, current
+#                     violation counts as NEW → exit 1 (fail-closed)
+#
+# Exit: 0 = every case behaved as asserted · 1 = at least one case failed.
+
+set -uo pipefail
+
+if [[ -z "${BASH_VERSINFO:-}" || "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+	echo "run-ratchet.sh requires bash 4+ (you have ${BASH_VERSION:-unknown})." >&2
+	exit 2
+fi
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+LINT="$REPO_ROOT/skills/living-docs/scripts/lint-docs.sh"
+
+if [[ ! -x "$LINT" ]]; then
+	echo "run-ratchet.sh: linter not found or not executable: $LINT" >&2
+	exit 2
+fi
+
+PASS=0
+FAIL=0
+WORKDIRS=()
+
+cleanup() {
+	local d
+	for d in "${WORKDIRS[@]:-}"; do
+		[[ -n "$d" && -d "$d" ]] && rm -rf "$d"
+	done
+}
+trap cleanup EXIT
+
+# new_repo → prints the path to a fresh git repo with identity configured
+new_repo() {
+	local d
+	d="$(mktemp -d "${TMPDIR:-/tmp}/ldr.XXXXXX")"
+	WORKDIRS+=("$d")
+	git -C "$d" init -q
+	git -C "$d" config user.email "ratchet-test@example.com"
+	git -C "$d" config user.name "Ratchet Test"
+	# discourage a stray global hooksPath from interfering with these temp commits
+	git -C "$d" config core.hooksPath /dev/null 2>/dev/null || true
+	printf '%s\n' "$d"
+}
+
+# write a minimal CLEAN bundle under <repo>/docs
+seed_clean_bundle() {
+	local repo="$1"
+	mkdir -p "$repo/docs/adr"
+	cat >"$repo/docs/index.md" <<'EOF'
+---
+okf_version: 0.1
+---
+# Docs
+- [ADR](/adr/)
+EOF
+	cat >"$repo/docs/adr/index.md" <<'EOF'
+# ADR
+- [0001](0001-first.md)
+EOF
+	cat >"$repo/docs/adr/0001-first.md" <<'EOF'
+---
+type: adr
+---
+# First decision
+EOF
+}
+
+# assert <name> <expected-exit> <output> <actual-exit> [substring]
+assert() {
+	local name="$1" want_exit="$2" out="$3" got_exit="$4" want_grep="${5:-}"
+	local ok=1 reason=""
+	if [[ "$got_exit" -ne "$want_exit" ]]; then
+		ok=0
+		reason="exit $got_exit (wanted $want_exit)"
+	fi
+	if [[ -n "$want_grep" ]] && ! grep -qF -- "$want_grep" <<<"$out"; then
+		ok=0
+		reason="${reason:+$reason; }missing substring: '$want_grep'"
+	fi
+	if [[ "$ok" -eq 1 ]]; then
+		printf 'PASS  %-24s exit=%s\n' "$name" "$got_exit"
+		PASS=$((PASS + 1))
+	else
+		printf 'FAIL  %-24s %s\n' "$name" "$reason"
+		printf '%s\n' "$out" | sed 's/^/        | /'
+		FAIL=$((FAIL + 1))
+	fi
+}
+
+echo "=== lint-docs.sh ratchet corpus ==="
+echo
+
+# Cases are functions run in the current shell (not subshells) so the PASS/FAIL
+# counters aggregate into the final summary.
+
+run_new_blocks() {
+	local repo out exit_out
+	repo="$(new_repo)"
+	seed_clean_bundle "$repo"
+	git -C "$repo" add -A
+	git -C "$repo" commit -qm "clean baseline"
+	echo '- [dead](this-file-does-not-exist.md)' >>"$repo/docs/adr/0001-first.md"
+	out="$(cd "$repo" && "$LINT" --ratchet HEAD docs 2>&1)"
+	exit_out=$?
+	assert "new-blocks" 1 "$out" "$exit_out" "this-file-does-not-exist.md"
+	# the NEW marker must be present and the fail summary must mention 1 new violation
+	assert "new-blocks-marked" 1 "$out" "$exit_out" "NEW violations introduced"
+}
+
+run_preexisting_ok() {
+	local repo out exit_out
+	repo="$(new_repo)"
+	seed_clean_bundle "$repo"
+	# commit a bundle that ALREADY carries a broken link (pre-existing debt)
+	echo '- [legacy-dead](legacy-missing.md)' >>"$repo/docs/adr/0001-first.md"
+	git -C "$repo" add -A
+	git -C "$repo" commit -qm "baseline with pre-existing debt"
+	# make an UNRELATED, clean change in the working tree
+	echo '<!-- unrelated clean edit -->' >>"$repo/docs/adr/index.md"
+	out="$(cd "$repo" && "$LINT" --ratchet HEAD docs 2>&1)"
+	exit_out=$?
+	assert "preexisting-ok" 0 "$out" "$exit_out" "no new violations"
+	assert "preexisting-grandfathered" 0 "$out" "$exit_out" "grandfathered"
+}
+
+run_fix_passes() {
+	local repo out exit_out
+	repo="$(new_repo)"
+	seed_clean_bundle "$repo"
+	echo '- [legacy-dead](legacy-missing.md)' >>"$repo/docs/adr/0001-first.md"
+	git -C "$repo" add -A
+	git -C "$repo" commit -qm "baseline with pre-existing debt"
+	# FIX the pre-existing violation in the working tree
+	cat >"$repo/docs/adr/0001-first.md" <<'EOF'
+---
+type: adr
+---
+# First decision
+EOF
+	out="$(cd "$repo" && "$LINT" --ratchet HEAD docs 2>&1)"
+	exit_out=$?
+	assert "fix-passes" 0 "$out" "$exit_out" "no new violations"
+}
+
+run_baseline_absent() {
+	local repo out exit_out
+	repo="$(new_repo)"
+	seed_clean_bundle "$repo"
+	git -C "$repo" add -A
+	git -C "$repo" commit -qm "clean baseline"
+	# introduce a violation, but ratchet against a ref that does not exist:
+	# baseline is treated as empty → the violation is NEW → exit 1 (fail-closed)
+	echo '- [dead](nope.md)' >>"$repo/docs/adr/0001-first.md"
+	out="$(cd "$repo" && "$LINT" --ratchet refs/heads/does-not-exist docs 2>&1)"
+	exit_out=$?
+	assert "baseline-absent" 1 "$out" "$exit_out" "treated as empty"
+}
+
+run_new_blocks
+run_preexisting_ok
+run_fix_passes
+run_baseline_absent
+
+echo
+echo "=== summary: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Stacks on #2 (base = `claude/living-docs-hardening-mcp-h8bb6n`) so the diff shows only this delta.

## What this adds

The **harness-agnostic enforcement foundation** for the Living Docs linter: a diff-aware ratchet mode on `lint-docs.sh` plus two thin triggers that call it.

### Goal 1 — diff-aware ratchet mode in `lint-docs.sh`

New opt-in flag: **`lint-docs.sh --ratchet <baseline-ref> [BUNDLE]`**.

- **Semantics:** lint the current bundle and the bundle as of `<baseline-ref>`; exit **1 only for violations present now that were absent at baseline** (NEW debt). Pre-existing violations print as `[old]` (pre-existing) lines and do **not** fail the run. Mirrors the diff-aware ratchet the repo's other gates use.
- **Default mode unchanged** — no flag = whole-bundle, exit 1 on ANY violation. The existing corpus stays green.
- The checks are **whole-bundle, not file-local** (index reachability, orphan membership, link resolution, supersede integrity), so the ratchet compares violation **SETS**, not touched files.
- **Baseline materialization:** `git worktree add --detach` a temp checkout of `<baseline-ref>`, lint it quietly, capture its set, remove the worktree. Violation lines are **normalized to bundle-relative paths** (`<relpath>\t<message>`) so the same violation matches across the two trees.
- **Graceful degradation:** baseline ref absent / not a git repo / bundle missing at baseline → baseline treated as **empty** (every current violation counts as NEW — fail-closed), documented in `--help`.

### Goal 2 — ratchet corpus (`tests/lint-docs/run-ratchet.sh`)

Each case spins up a **throwaway git repo** (init → commit baseline → mutate working tree), exercising the real `git worktree add` path. Cases:
- `new-blocks` — introduce one violation → exit 1, names it.
- `preexisting-ok` — committed debt + unrelated clean change → exit 0 (debt grandfathered).
- `fix-passes` — remove a pre-existing violation → exit 0.
- `baseline-absent` — ratchet against a missing ref → baseline empty, violation counts as new → exit 1.

### Goal 3 — two thin triggers (call the same CLI, reimplement nothing)

- **`enforcement/pre-commit.sh`** — local git hook running `--ratchet HEAD`, blocks NEW violations, bypassable with `--no-verify`. Clears git's ambient `GIT_INDEX_FILE`/`GIT_DIR`/`GIT_WORK_TREE` (they break `worktree add` inside a hook). Defensive when lint-docs/git/bundle absent.
- **`.github/actions/living-docs-ratchet/action.yml`** — reusable composite Action, baseline = the PR's merge base, the unbypassable CI backstop. Copy-paste consumer snippet in `enforcement/README.md`.

One CLI enforced at the git boundary (pre-commit) + CI (Action) is **harness-agnostic** — it covers Claude Code, Pi, OpenCode, Cursor, Copilot **and** human commits with one mechanism. The per-harness plugin is the optional *in-loop* layer that would call this **same** CLI; not built here.

## Verification (local, bash 5.2)

- Existing fixture corpus: **13 passed, 0 failed**.
- New ratchet corpus: **6 passed, 0 failed**.
- Pre-commit hook: blocks a new violation, grandfathers pre-existing debt, `--no-verify` bypasses — all confirmed in scratch repos.
- `action.yml` + `ci.yml` validate as YAML.
- `make check` exits 0.

Makefile (`test-ratchet` target) and `ci.yml` (ratchet corpus step) edits are additive and minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeRKqhb8HLdFQw6npouwTC

---
_Generated by [Claude Code](https://claude.ai/code/session_01TeRKqhb8HLdFQw6npouwTC)_