### PR TITLE
Finalize living-docs-enforcer plugin: self-contained, diff-aware, block default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,8 @@ jobs:
       - name: Lint — example docs bundle against the Living Docs invariants
         run: ./skills/living-docs/scripts/lint-docs.sh examples/linkly/docs
 
+      - name: Check — plugin's vendored living-docs skill is in sync with the source
+        run: make check-plugin-skill-sync
+
       - name: Lint — install.sh syntax, dry-run harnesses, docs invariants (make check)
         run: make check

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ INSTALL := ./install.sh
 .PHONY: help install install-claude install-cursor install-copilot \
         install-opencode install-codex install-pi install-all install-pocock \
         project-claude project-opencode project-codex project-pi \
-        uninstall uninstall-all check lint lint-docs test-lint-docs test-ratchet version
+        uninstall uninstall-all check lint lint-docs test-lint-docs test-ratchet version \
+        sync-plugin-skill check-plugin-skill-sync
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
@@ -58,10 +59,11 @@ uninstall: ## Remove the global Claude Code install
 uninstall-all: ## Remove the install for every supported harness
 	$(INSTALL) all --uninstall
 
-check: version test-lint-docs test-ratchet lint-docs ## Check version sync, validate install.sh, dry-run harnesses, test+run the docs linter (+ ratchet)
+check: version test-lint-docs test-ratchet lint-docs check-plugin-skill-sync ## Check version sync, validate install.sh, dry-run harnesses, test+run the docs linter (+ ratchet), assert the plugin's vendored skill is in sync
 	bash -n install.sh
 	bash -n skills/living-docs/scripts/lint-docs.sh
 	bash -n enforcement/pre-commit.sh
+	bash -n plugins/living-docs-enforcer/hooks/block-docs-drift.sh
 	bash -n scripts/check-version.sh
 	$(INSTALL) all --dry-run
 
@@ -76,5 +78,21 @@ test-ratchet: ## Run the diff-aware ratchet corpus (new violation blocks, pre-ex
 
 version: ## Assert the release version is consistent across VERSION and every SKILL.md
 	./scripts/check-version.sh
+
+sync-plugin-skill: ## Regenerate the plugin's vendored living-docs skill from the canonical source
+	rm -rf plugins/living-docs-enforcer/skills/living-docs
+	mkdir -p plugins/living-docs-enforcer/skills
+	cp -R skills/living-docs plugins/living-docs-enforcer/skills/living-docs
+	@echo "synced: skills/living-docs -> plugins/living-docs-enforcer/skills/living-docs"
+
+check-plugin-skill-sync: ## Fail if the plugin's vendored living-docs skill drifted from the source
+	@if diff -r skills/living-docs plugins/living-docs-enforcer/skills/living-docs >/dev/null 2>&1; then \
+		echo "plugin vendored skill is in sync with skills/living-docs"; \
+	else \
+		echo "ERROR: plugins/living-docs-enforcer/skills/living-docs has DRIFTED from skills/living-docs." >&2; \
+		echo "       Edit the source (skills/living-docs/), then run: make sync-plugin-skill" >&2; \
+		diff -r skills/living-docs plugins/living-docs-enforcer/skills/living-docs >&2 || true; \
+		exit 1; \
+	fi
 
 lint: check ## Alias for check

--- a/plugins/living-docs-enforcer/.claude-plugin/marketplace.json
+++ b/plugins/living-docs-enforcer/.claude-plugin/marketplace.json
@@ -1,0 +1,26 @@
+{
+  "name": "living-docs-enforcer",
+  "owner": {
+    "name": "Evaldo Klock"
+  },
+  "metadata": {
+    "description": "Opt-in, diff-aware commit-boundary enforcement of the Living Docs mechanical invariants.",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "living-docs-enforcer",
+      "description": "OPT-IN enforcement of the Living Docs mechanical invariants at the git-commit boundary. Recommended for teams that want the docs floor enforced, not just advised. Bundles a self-contained copy of the living-docs skill and a PreToolUse hook that runs lint-docs.sh in diff-aware --ratchet mode on git commit (blocks NEW violations, grandfathers legacy debt). Default is block; downgrade with LIVING_DOCS_ENFORCE=warn.",
+      "source": "./",
+      "version": "0.1.0",
+      "author": {
+        "name": "Evaldo Klock",
+        "url": "https://github.com/ejklock"
+      },
+      "repository": "https://github.com/ejklock/living-docs-skill",
+      "license": "MIT",
+      "keywords": ["documentation", "living-docs", "adr", "lint", "hook", "enforcement", "pre-commit"],
+      "category": "productivity"
+    }
+  ]
+}

--- a/plugins/living-docs-enforcer/.claude-plugin/plugin.json
+++ b/plugins/living-docs-enforcer/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "living-docs-enforcer",
+  "version": "0.1.0",
+  "description": "OPT-IN enforcement of the Living Docs mechanical invariants at the git-commit boundary, for teams that want the docs floor (well-formed, indexed, linked, supersede-correct docs) enforced, not just advised. Bundles a self-contained copy of the living-docs skill and a PreToolUse hook that runs lint-docs.sh in diff-aware --ratchet mode on git commit: it blocks ONLY new violations and grandfathers pre-existing legacy debt. The default is block; downgrade per-repo with LIVING_DOCS_ENFORCE=warn. The absence proxy (a structural change touching no docs) is warn-only and never blocks.",
+  "author": {
+    "name": "Evaldo Klock",
+    "url": "https://github.com/ejklock"
+  },
+  "repository": "https://github.com/ejklock/living-docs-skill",
+  "license": "MIT",
+  "keywords": ["documentation", "living-docs", "adr", "lint", "hook", "enforcement", "pre-commit"],
+  "skills": "./skills/",
+  "hooks": "./hooks/hooks.json"
+}

--- a/plugins/living-docs-enforcer/README.md
+++ b/plugins/living-docs-enforcer/README.md
@@ -1,0 +1,107 @@
+# living-docs-enforcer
+
+An **opt-in** Claude Code plugin that enforces the [Living Docs](skills/living-docs/SKILL.md) *mechanical* invariants at the **git-commit boundary**, **diff-aware**. It bundles a self-contained copy of the `living-docs` skill and adds a `PreToolUse` hook that runs the skill's `lint-docs.sh` in `--ratchet` mode whenever Claude is about to run `git commit` — so it blocks **only the violations a commit introduces** and grandfathers any pre-existing legacy debt.
+
+This plugin is **recommended for teams that want the docs floor enforced, not just advised.** Solo / exploratory work can skip it; the skill alone (without this plugin) still provides the templates and the linter to run by hand.
+
+## What it does
+
+On every `git commit` the hook runs `lint-docs.sh --ratchet HEAD` against your docs bundle (`./docs` by default) and decides:
+
+| Situation | ratchet result | Decision |
+|---|---|---|
+| The commit **introduces NEW** malformed / orphan / broken-link / supersede-broken docs | exit 1 | **BLOCK** (default; downgrade → warn) |
+| Docs are clean, or only **pre-existing** debt is present | exit 0 | allow, silent (legacy debt grandfathered) |
+| A structural code change touches **no** `docs/` file (the *absence proxy*) | n/a | **warn only — never blocks** |
+| lint-docs / git missing, no docs bundle, usage / baseline error | exit 2 / absent | allow with a warning (never wedges your commit) |
+
+Because the ratchet never punishes you for debt you didn't touch, blocking by default is **adoption-safe**: you can drop the plugin into a repo with pre-existing docs debt and only *new* drift will block.
+
+## Install (opt-in)
+
+This plugin lives inside the `living-docs-skill` repo at `plugins/living-docs-enforcer/`. Add the repo as a marketplace and install the plugin:
+
+```bash
+# add this repo as a plugin marketplace (points at plugins/living-docs-enforcer/.claude-plugin/marketplace.json)
+/plugin marketplace add ejklock/living-docs-skill
+
+# install the enforcer
+/plugin install living-docs-enforcer
+```
+
+Installing the plugin installs **both** the bundled `living-docs` skill and the commit-boundary hook.
+
+The skill is **vendored as a real, self-contained copy** inside the plugin (`skills/living-docs/`, not a symlink), so the plugin installs correctly from **any** source — a full-repo clone, a zip download, or a copy of just the `plugins/living-docs-enforcer/` directory. The hook calls that vendored copy via `${CLAUDE_PLUGIN_ROOT}/skills/living-docs/scripts/lint-docs.sh`.
+
+### Keeping the vendored copy in sync (for repo maintainers)
+
+The canonical source of the skill is the repo's single `skills/living-docs/` tree. The vendored copy under the plugin is a real directory, so it could drift — neutralized by an instrument (a constraint without an instrument is a vibe):
+
+```bash
+# edit the skill at the canonical source, then regenerate the vendored copy:
+make sync-plugin-skill
+
+# assert they are identical (this runs in CI and as part of `make check`):
+make check-plugin-skill-sync
+```
+
+**Always edit the skill at the source (`skills/living-docs/`), then run `make sync-plugin-skill`.** Never hand-edit the vendored copy under `plugins/`. `make check-plugin-skill-sync` exits non-zero if the two trees differ, and it is wired into `.github/workflows/ci.yml` and `make check`, so a drifted copy fails the build.
+
+## The enforcement knob
+
+The default is **`block`** — this is the **settled, decided policy**: a docs floor that does not block is easy to ignore, and the diff-aware ratchet makes block-by-default safe (only *new* drift blocks). The one documented opt-out, read from the environment by the hook:
+
+```bash
+export LIVING_DOCS_ENFORCE=block   # default (decided) — NEW sound violations block the commit
+export LIVING_DOCS_ENFORCE=warn    # NEW sound violations print to stderr and ALLOW the commit
+```
+
+(Optional) point the linter at a non-standard bundle root:
+
+```bash
+export LIVING_DOCS_BUNDLE=documentation   # default: docs
+```
+
+## What this enforces vs. what it can't
+
+**It forces the verifiable floor** — the half of Living Docs that has a *sound oracle* (the doc is in the tree and demonstrably wrong), exactly what `lint-docs.sh` checks, scoped diff-aware to what the commit introduces:
+
+- every concept doc has OKF frontmatter with a non-empty `type`
+- `index.md` / `log.md` carry no frontmatter (except the bundle-root `okf_version`)
+- every concept file is listed in its directory's `index.md` (no orphans)
+- every directory index is reachable from the bundle-root index
+- every local markdown link resolves
+- a `status: Superseded` record carries a resolvable `superseded_by`
+
+**It warns on the absence proxy** — a structural code change that touches no `docs/` file gets a non-blocking reminder (invariant 5: "no structural change without its doc"). This **never blocks**: there is no sound oracle for *"an ADR belongs here"*, and a hard block would just be satisfied with an empty placeholder doc (Goodhart). The reminder is a nudge for a human, not a gate.
+
+**It does NOT — and cannot — force a *meaningful* ADR in flow order.** Whether a decision was *worth* recording, whether the ADR's reasoning is sound, whether docs match the code's actual behavior (invariant 1, docs-first) or each fact has exactly one home (invariant 2, semantic half) — none of these have a mechanical oracle. They stay with the **reviewer / human**, exactly as `lint-docs.sh` itself documents ("invariants 1 and 2's semantic half are NOT mechanical — they stay with the reviewing agent"). This plugin is the *floor*, not the ceiling.
+
+## Relationship to the harness-agnostic enforcement (`enforcement/`)
+
+This plugin is the **Claude-Code in-loop layer** plus the skill bundle. It is **not** the only place the floor is enforced — it calls the **same** `lint-docs.sh --ratchet` CLI as its harness-agnostic siblings in the repo's [`enforcement/`](../../enforcement/README.md) directory:
+
+- `enforcement/pre-commit.sh` — a plain **git pre-commit hook** that enforces the same ratchet for *any* committer (human, Pi, OpenCode, Cursor, Copilot). Bypassable with `git commit --no-verify`.
+- the CI **Action** — the unbypassable backstop that runs the same ratchet on every PR.
+
+All three call **one CLI** at the same boundary. This plugin adds the Claude-Code in-loop ergonomics (the hook fires inside the agent's `git commit`, with the `block|warn` knob) and ships the skill so the templates + linter install together.
+
+## Trust / proof
+
+`lint-docs.sh` is exercised by a fixture corpus (`tests/lint-docs/`) that asserts it stays silent on clean bundles and catches each mechanical violation it claims to (one violation per dirty fixture), plus a diff-aware ratchet corpus (`tests/lint-docs/run-ratchet.sh`) that asserts a NEW violation blocks while pre-existing debt is grandfathered. That parity corpus is what makes the linter trustworthy enough to gate a commit on.
+
+## Files
+
+```
+plugins/living-docs-enforcer/
+├── .claude-plugin/
+│   ├── plugin.json          # manifest: name, components (skills + hooks)
+│   └── marketplace.json     # marketplace entry (source: ./)
+├── hooks/
+│   ├── hooks.json           # PreToolUse / matcher: Bash → block-docs-drift.sh
+│   └── block-docs-drift.sh  # the commit-boundary decision logic (diff-aware ratchet)
+├── skills/
+│   └── living-docs/         # SELF-CONTAINED vendored copy (real dir, not a symlink)
+│                            # regenerate from the canonical source with `make sync-plugin-skill`
+└── README.md
+```

--- a/plugins/living-docs-enforcer/hooks/block-docs-drift.sh
+++ b/plugins/living-docs-enforcer/hooks/block-docs-drift.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# block-docs-drift.sh — PreToolUse hook: enforce the Living Docs mechanical
+# invariants at the git-commit boundary, DIFF-AWARE.
+#
+# Claude Code passes the hook input as JSON on stdin:
+#   { "tool_name": "Bash", "tool_input": { "command": "git commit -m ..." } }
+#
+# Decision contract (matches the repo's existing PreToolUse blockers, e.g.
+# block-dangerous-patterns.sh):
+#   exit 0 = allow the command  ·  exit 2 = block it (reason printed to stderr)
+#
+# This hook fires on every Bash call but only ACTS on `git commit`. On a commit
+# it runs the bundled linter in DIFF-AWARE RATCHET mode against HEAD and then:
+#
+#   - SOUND CHECKS — docs that EXIST being malformed / orphan / broken-link /
+#     supersede-broken. The hook runs `lint-docs.sh --ratchet HEAD <bundle>`, so
+#     it blocks ONLY violations this commit INTRODUCES and grandfathers any
+#     pre-existing legacy debt (ratchet exit 1 = NEW violations). lint-docs has a
+#     sound oracle for these (the doc is in the tree and demonstrably wrong), and
+#     because the ratchet never punishes you for legacy debt you did not touch,
+#     block-by-default is adoption-safe — so the SETTLED default is to BLOCK.
+#     The one knob: LIVING_DOCS_ENFORCE=block|warn (default block).
+#     With LIVING_DOCS_ENFORCE=warn it prints the NEW violations and ALLOWS.
+#
+#   - THE ABSENCE PROXY — a structural change that touches no docs/ file. There is
+#     NO sound oracle for "an ADR should exist here" (a hard block is gameable with
+#     an empty doc), so this is WARN-ONLY and NEVER blocks, regardless of the knob.
+#     Implemented here as a minimal, clearly-marked structural heuristic.
+#
+# Defensive by construction: if git or lint-docs is missing, if there is no docs
+# bundle, or if anything else goes sideways, the hook EXITS CLEANLY (0) with at
+# most a warning — it must never wedge the user's commit on its own errors.
+#
+# This is the Claude-Code IN-LOOP layer. The harness-agnostic siblings —
+# enforcement/pre-commit.sh (git hook) and the CI Action — call the SAME
+# `lint-docs.sh --ratchet` CLI at the same boundary for non-Claude commits.
+
+# Note: intentionally NOT `set -e` — a non-zero from an internal probe must not
+# be reinterpreted as a block. Blocking is only ever an explicit `exit 2`.
+set -uo pipefail
+
+# git exports ambient vars into hooks (GIT_INDEX_FILE / GIT_DIR / GIT_WORK_TREE),
+# often as paths relative to the commit's cwd. A PreToolUse hook firing DURING a
+# `git commit` inherits the same ambient env, and those vars corrupt the
+# `git worktree add` the --ratchet mode uses to materialize the HEAD baseline.
+# Clear them so the linter's own git calls operate on the repo cleanly (same fix
+# as enforcement/pre-commit.sh).
+unset GIT_INDEX_FILE GIT_DIR GIT_WORK_TREE GIT_PREFIX
+
+# --- enforcement knob -------------------------------------------------------
+# block (default, the settled policy) | warn. Anything else is treated as block
+# (fail safe).
+ENFORCE="${LIVING_DOCS_ENFORCE:-block}"
+
+# --- bundle root: default ./docs, overridable for non-standard layouts ------
+BUNDLE="${LIVING_DOCS_BUNDLE:-docs}"
+
+# --- the diff-aware baseline ------------------------------------------------
+# Compare the bundle you are about to commit against the last commit, so only
+# violations YOU are introducing can ever block. Pre-existing debt is grandfathered.
+BASELINE_REF="HEAD"
+
+# --- read + parse the hook payload ------------------------------------------
+INPUT="$(cat)"
+
+if command -v jq >/dev/null 2>&1; then
+	TOOL_NAME="$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)"
+	COMMAND="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)"
+else
+	TOOL_NAME="$(printf '%s' "$INPUT" \
+		| grep -o '"tool_name"[[:space:]]*:[[:space:]]*"[^"]*"' \
+		| sed 's/.*"tool_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')"
+	COMMAND_RAW="$(printf '%s' "$INPUT" \
+		| sed 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)"}}.*/\1/')"
+	COMMAND="$(printf '%s' "$COMMAND_RAW" \
+		| sed 's/\\"/"/g' \
+		| sed 's/\\n/\n/g' \
+		| sed 's/\\t/\t/g' \
+		| sed 's/\\\\/\\/g')"
+fi
+
+# Only act on Bash, and only on a git commit. Everything else: allow.
+[[ "$TOOL_NAME" != "Bash" ]] && exit 0
+printf '%s' "$COMMAND" | grep -qE 'git([[:space:]]+-[^[:space:]]+)*[[:space:]]+commit([[:space:]]|$)' || exit 0
+
+# --- locate the bundled linter ----------------------------------------------
+# CLAUDE_PLUGIN_ROOT is exported by Claude Code into hook processes. Fall back to
+# the script's own location so the hook is also runnable standalone (e.g. in CI).
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+LINT="$PLUGIN_ROOT/skills/living-docs/scripts/lint-docs.sh"
+
+# --- defensive guards: never wedge the commit on our own missing deps -------
+if ! command -v git >/dev/null 2>&1; then
+	echo "[living-docs-enforcer] git not found — skipping docs lint (commit allowed)." >&2
+	exit 0
+fi
+if [[ ! -f "$LINT" ]]; then
+	echo "[living-docs-enforcer] lint-docs.sh not found at $LINT — skipping docs lint (commit allowed)." >&2
+	exit 0
+fi
+if [[ ! -d "$BUNDLE" ]]; then
+	# No docs bundle at all. This is the absence case at the extreme; warn only.
+	echo "[living-docs-enforcer] no docs bundle at ./$BUNDLE — nothing to lint (commit allowed)." >&2
+	exit 0
+fi
+
+# --- absence proxy (WARN-ONLY, never blocks) --------------------------------
+# Heuristic: if the staged change touches code/structure but NOT a single docs/
+# file, surface a gentle reminder. There is no sound oracle for "an ADR belongs
+# here", so this can never be a block — a hard block would just be satisfied with
+# an empty placeholder doc (Goodhart). Best-effort; silent on any git error.
+STAGED="$(git diff --cached --name-only 2>/dev/null || true)"
+if [[ -n "$STAGED" ]]; then
+	if ! printf '%s\n' "$STAGED" | grep -qE "(^|/)${BUNDLE}/"; then
+		if printf '%s\n' "$STAGED" | grep -qE '\.(ts|tsx|js|jsx|py|go|rb|php|java|kt|rs|c|cc|cpp|h|hpp|cs|swift|sql)$'; then
+			echo "[living-docs-enforcer] reminder: this commit changes code but touches no ./$BUNDLE file." >&2
+			echo "                       if it is a structural change (new module, moved files, schema/flow change)," >&2
+			echo "                       Living Docs invariant 5 wants the doc + diagram updated in the same change." >&2
+			echo "                       (advisory only — not a sound check, never blocks)" >&2
+		fi
+	fi
+fi
+
+# --- sound checks: run the bundled linter in DIFF-AWARE RATCHET mode ---------
+# `--ratchet HEAD` => exit 0 on clean OR pre-existing-only debt, exit 1 on NEW
+# violations this commit introduces, exit 2 on usage / bundle error.
+LINT_OUT="$(bash "$LINT" --ratchet "$BASELINE_REF" "$BUNDLE" 2>&1)"
+LINT_RC=$?
+
+# exit 2 from the linter = usage / bundle-not-found / no-git-baseline. That is OUR
+# misconfiguration, not the user's docs being wrong — warn and allow, never block.
+if [[ "$LINT_RC" -eq 2 ]]; then
+	echo "[living-docs-enforcer] lint-docs --ratchet could not run (exit 2 — usage/bundle/baseline error) — commit allowed:" >&2
+	printf '%s\n' "$LINT_OUT" | sed 's/^/    /' >&2
+	exit 0
+fi
+
+# exit 0 = clean, or only pre-existing debt (grandfathered). Allow silently.
+if [[ "$LINT_RC" -eq 0 ]]; then
+	exit 0
+fi
+
+# exit 1 = NEW violations this commit introduces (the sound checks). Apply the knob.
+if [[ "$ENFORCE" == "warn" ]]; then
+	echo "[living-docs-enforcer] WARN: this commit introduces NEW Living Docs invariant violation(s) (LIVING_DOCS_ENFORCE=warn — commit allowed):" >&2
+	printf '%s\n' "$LINT_OUT" | sed 's/^/    /' >&2
+	exit 0
+fi
+
+# Default / any non-"warn" value: BLOCK.
+echo "BLOCKED by living-docs-enforcer: this commit introduces NEW Living Docs invariant violation(s) in ./$BUNDLE." >&2
+echo "(Pre-existing legacy debt is grandfathered by the diff-aware ratchet — only NEW violations block.)" >&2
+printf '%s\n' "$LINT_OUT" | sed 's/^/    /' >&2
+echo "" >&2
+echo "Fix the docs above and re-commit. To downgrade to a warning, set LIVING_DOCS_ENFORCE=warn." >&2
+exit 2

--- a/plugins/living-docs-enforcer/hooks/hooks.json
+++ b/plugins/living-docs-enforcer/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/block-docs-drift.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/living-docs-enforcer/skills/SKILL.md
+++ b/plugins/living-docs-enforcer/skills/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: living-docs
+description: Run a project's documentation as a living system — docs-first issues/PRDs, MADR-lite ADRs (supersede, never delete), Behavior Decision Records (BDRs), a project constitution, research artifacts, living Mermaid architecture diagrams, and semantic-index organization where every doc lands in exactly one place and indexes never drift. Use when setting up or maintaining project docs, writing an ADR/PRD/BDR/constitution/issue/research note, defining a term or acronym in the glossary, drawing or updating an architecture/flow/sequence diagram, splitting an oversized doc into an index, or enforcing the no-drift maintenance rule.
+version: "0.1.0"
+metadata:
+  type: skill
+  layer: procedural
+  tags: [documentation, adr, prd, bdr, constitution, issues, research, architecture, semantic-index]
+---
+
+# Living Docs
+
+Treat documentation as a living system that stays in sync with the code, not a write-once artifact that rots. The discipline has one spine — **every piece of knowledge has exactly one home, that home is indexed, and nothing structural ships without its doc** — and several document types that hang off it: a constitution, ADRs, BDRs, PRDs, issues, research, architecture diagrams, and a semantic context index.
+
+This skill is stack-agnostic. It governs *how* docs are organized and maintained, never *what* technology a project uses.
+
+---
+
+## Core invariants (the spine)
+
+These hold across every document type. Everything else is detail.
+
+1. **Docs-first.** Author the body in the repo (`docs/…`) *before* publishing anywhere external (tracker, wiki). The repo file is the source of truth; the external copy is a mirror.
+2. **One home per fact.** Each concept, decision, or requirement lives in exactly one file. No duplication — cross-reference instead of copying. Duplicated prose is drift waiting to happen.
+3. **Indexed or it doesn't exist.** Every doc is reachable from an index (an `index.md` listing in its directory, and the bundle-root `docs/index.md` that the project guide links). No orphan files.
+4. **Supersede, never rewrite history.** Decisions and requirements are append-only records. When something changes, mark the old record superseded and write a new one — never silently edit the past.
+5. **No structural change without its doc.** New module, moved files, schema change, new data flow → update the relevant doc *and its diagram* in the same change. No "I'll document it later."
+
+When in doubt, re-derive the right action from these five. The rules files below are just these invariants applied to each document type.
+
+---
+
+## Format: OKF-conformant
+
+The five invariants govern *organization and lifecycle*; the **Open Knowledge Format** governs the *file format* so the corpus stays portable and agent-parseable. Every doc in the system is also an OKF concept. Load the `okf-knowledge-format` skill (it vendors the spec) when authoring or checking format.
+
+> **OKF is a thin, swappable dependency — not a foundation (version risk).** OKF is **v0.1
+> from a single vendor**; a backward-incompatible v0.2 is a real possibility. The invariants
+> above do **not** depend on OKF — they depend only on a small set of frontmatter fields, so an
+> OKF break cannot take the governance layer down with it. Keep the boundary explicit:
+> - **Required by Living Docs** (the fact contract `scripts/lint-docs.sh` enforces): a non-empty
+>   `type`, and `status` + `superseded_by` on superseded records. These are *ours*; they survive
+>   regardless of OKF.
+> - **Inherited from OKF** (format conventions): reserved `index.md`/`log.md`, the bundle-root
+>   `okf_version`, bundle-relative links, the `# References` heading (§8). If OKF changes, only
+>   this row moves — re-pin the version in the `okf-knowledge-format` skill and adjust.
+
+Two rules apply to every concept file:
+
+1. **Frontmatter with a required `type`.** Every non-reserved `.md` doc opens with a YAML frontmatter block whose `type` names the doc kind (`Constitution`, `PRD`, `ADR`, `BDR`, `Issue`, `Context`, `Architecture View`, `Research`, `Reference`). Recommended: `title`, `description`, `tags`, `timestamp`. Living-docs adds producer keys: `status`, `supersedes`, `superseded_by`. **Status moves into frontmatter — no `**Status:**` body line.**
+2. **Reserved files + bundle-relative links.** The bundle root is `docs/`. Directory listings are `index.md` (OKF §6, no frontmatter — except the bundle-root `docs/index.md`, which carries `okf_version: "0.1"`). Optional `log.md` records directory history (§7). Cross-link with `/`-prefixed bundle-relative paths (`/adr/0007-slug.md`); list sources under a `# References` heading (§8), each entry formatted per `rules/citation-conventions.md` — **ABNT NBR 6023 structure, always carrying the link**, with connective labels in the project doc language (default English: `Available at: <URL>. Accessed on: <date>`) per `rules/doc-language.md`.
+
+---
+
+## Doc trail
+
+Every change follows this chain, from foundational source of truth down to code:
+
+```mermaid
+flowchart LR
+  C[constitution] --> P[PRD]
+  P --> A[ADR]
+  P --> B[BDR]
+  A --> I[issues]
+  B --> I
+  I --> K[code]
+```
+
+| Artifact | Role |
+|---|---|
+| **constitution** | Foundational source of truth: what the product is, core data model, non-negotiables. All other docs sit under it. |
+| **PRD** | What the system must do and why — feature/product requirement spec. |
+| **ADR** | How the system is structured — architectural/implementation decision and rationale. |
+| **BDR** | What the system must observably do — inputs, outputs, side effects, Given/When/Then scenarios. |
+| **issues** | Execution slices — discrete units of work that trace back to ADRs/BDRs. |
+| **code** | Implementation — every behavior, structure, and interface specified above, realized. |
+
+---
+
+## When to invoke
+
+- Standing up documentation for a project (creating `docs/` structure, the docs index, ADR/issue/BDR/constitution directories).
+- Writing or editing an **ADR** (an architectural/implementation decision) → load `rules/adr-conventions.md` + `templates/adr.md`.
+- Writing or editing a **PRD** (a product/feature requirement spec) → load `rules/prd-conventions.md` + `templates/prd.md`.
+- Writing or editing a **BDR** (observable behavior — inputs, outputs, Given/When/Then scenarios) → load `rules/bdr-conventions.md` + `templates/bdr.md`.
+- Establishing or amending the **constitution** (foundational scope, data model, non-negotiables) → load `rules/constitution-conventions.md` + `templates/constitution.md`.
+- Creating or editing an **issue/ticket** → load `rules/issue-workflow.md` + `templates/issue.md`.
+- Recording **research** (technology evaluation, external trade-offs) → load the **`research-artifacts`** skill. It owns the OKF research-note format (single file per note, no per-research subfolder), the source discipline, and the research → decision → issue traceable chain, and links back here for the ADR/BDR/issue artifacts. Pairs with the `deep-research` skill.
+- Drawing or updating an **architecture, data-flow, or tool-calling diagram** → load `rules/architecture-diagrams.md` + `templates/architecture-index.md`.
+- Defining a **term or acronym** the docs use → add it to the **glossary** (`docs/context/glossary.md`), one home per term → load `rules/glossary-conventions.md` + `templates/glossary.md`.
+- A doc has grown too large or mixes concerns → **split into a semantic index** → load `rules/semantic-index.md` + `templates/context-index.md`.
+- Enforcing the **no-drift maintenance rule** after any structural change → load `rules/maintenance-invariant.md`.
+- Authoring or checking the **OKF format** of any doc (frontmatter `type`, reserved `index.md`/`log.md`, bundle-relative links, `# References`) → load the **`okf-knowledge-format`** skill.
+- Deciding **which language** the docs are written in (default English; user may override at session start and pin it) → load `rules/doc-language.md`.
+
+---
+
+## Document map
+
+| Type | Lives in | Purpose | Mutability |
+|---|---|---|---|
+| Project guide | `CLAUDE.md` / `README.md` (root) | Entry point: scope, stack, docs index, mandatory workflows | Live — edit freely |
+| Constitution | `docs/constitution.md` | Foundational source of truth: product scope, data model, non-negotiables | Append-only once ratified (amendment log) |
+| Context index | `docs/context/index.md` + group files | Domain & module vocabulary, semantically grouped | Live — edit freely |
+| Glossary | `docs/context/glossary.md` | Terms & acronyms defined once, in the doc language (acronym headwords as-is) | Live — edit freely |
+| Architecture | `docs/architecture.md` or `docs/architecture/` + index | Living Mermaid diagrams: structure, data model, flows, tool-calling | Live — must match code |
+| ADR | `docs/adr/NNNN-slug.md` | One architectural/implementation decision | Append-only (supersede) |
+| BDR | `docs/bdr/NNNN-slug.md` | One observable-behavior decision | Append-only (supersede or amend) |
+| PRD | `docs/prd/NNNN-slug.md` | One feature/product requirement spec | Append-only once accepted |
+| Issue | `docs/issues/NNNN-slug.md` | Tracker mirror (body), one per ticket | Body editable; published copy follows |
+| Research | `docs/research/NNNN-<slug>.md` (single file, no subfolder; sequential number leads, date in frontmatter `timestamp`; ends in `# References`) | External evidence with sourced claims | Append-only (evidence is dated) |
+
+Each directory carries its own `index.md` listing (OKF §6, no frontmatter). The project guide's "Docs index" links to the bundle-root `docs/index.md`. See `rules/semantic-index.md` for the indexing contract.
+
+---
+
+## Procedure
+
+### Setting up living docs in a new project
+
+1. Create the project guide (`CLAUDE.md` or equivalent) with a **Docs index** section and a **Maintenance rule** section (copy the wording from `rules/maintenance-invariant.md`). Use `templates/claude-hard-rules.md` as the starting point for the project guide's hard-rules section — fill in the placeholders before committing.
+2. Create `docs/` with the directories the project needs (`adr/`, `bdr/`, `issues/`, `prd/`, `research/`, `context/`). Seed `docs/constitution.md` from `templates/constitution.md`. Add the bundle-root `docs/index.md` (carrying `okf_version: "0.1"`), and give each directory its own `index.md` listing from day one — even if near-empty.
+3. Seed the context index (`docs/context/index.md`) with whatever domain vocabulary exists, and the glossary (`docs/context/glossary.md`) with the terms and acronyms the docs already assume (`rules/glossary-conventions.md`). Grow both as concepts are named.
+4. Seed the architecture doc (`docs/architecture.md`) with the high-level Mermaid views the system already has. Promote to a `docs/architecture/` directory + index once it grows (`rules/architecture-diagrams.md`).
+5. Record any already-made decisions as ADRs so they are not re-litigated.
+
+### Maintaining living docs (every task)
+
+1. **Before coding:** read the relevant constitution, ADRs, BDRs, and the context index. Decisions there are not to be re-opened casually.
+2. **While working:** if you name a new concept, add it to the context index; if you introduce a new term or acronym, define it once in the glossary. If you make a decision with a load-bearing rationale, write an ADR. If you specify observable behavior, write or amend a BDR.
+3. **In the same change:** update every doc the structural change touches — index rows, **architecture diagrams**, vocabulary. Run the maintenance checklist (`rules/maintenance-invariant.md`).
+4. **Never** leave an index stale, an orphan file unlinked, a diagram contradicting the code, or a superseded decision silently edited.
+
+---
+
+## Composition with other skills
+
+- **`grill-me`** — before writing a PRD or a load-bearing ADR, grill the design to surface the real decision and its alternatives. The grilling output becomes the ADR's Context/Consequences.
+- **`improve-codebase-architecture`** — reads the context index and ADRs to find deepening opportunities; emits new ADRs when a candidate is rejected for a load-bearing reason. This skill provides the ADR/context/architecture formats that one consumes.
+- **`research-artifacts`** — owns the research-note format and discipline (a single-file OKF `docs/research/NNNN-<slug>.md` — sequential number leads, date in frontmatter — with a trailing `# References`, plus the cross-research `docs/research/references.md` roll-up, source rules, the research → decision → issue chain). Living-docs delegates all research authoring to it and consumes its output: an accepted recommendation becomes an ADR/BDR here, which spawns issues. The links between the two are bidirectional.
+- **`deep-research`** — gathers and cross-verifies the evidence that lands in `docs/research/`; the `research-artifacts` skill defines how that evidence is formatted, indexed, and referenced from ADRs/PRDs.
+- **`init-codegraph`** — the structural index of *code*; the context index is the human-readable index of *concepts* and the architecture diagrams are the visual index of *structure*. Keep all current.
+- **`wave-execution`** — executes the issues these docs plan, one PR per wave. Wave execution is the implementation phase that consumes the ADRs, BDRs, and issues produced here.
+- **`implementation-review`** — verifies the implementation before it ships. Review checks that the code honors the ADRs and BDRs, and that every specified observable behavior (Given/When/Then) is tested.
+- **`okf-knowledge-format`** — the portable, exchange-oriented **format** standard (Open Knowledge Format: markdown + YAML frontmatter, required `type`, reserved `index.md`/`log.md`, bundle-relative links, conformance rules). Living-docs governs *which* docs exist and the no-drift discipline; OKF governs *how* a knowledge bundle's markdown and frontmatter are shaped. Author a shareable knowledge corpus — e.g. `docs/context/` vocabulary or a `docs/research/` catalog meant to be consumed by agents or exchanged across orgs — as an OKF bundle so its frontmatter and indexing are spec-conformant. The two compose; they do not overlap.
+
+---
+
+## Agent enforcement (refusal triggers)
+
+The value of this skill is not the discipline — humans abandon "nothing structural without
+its doc" at the first deadline. The value is an **agent that enforces it automatically**. So
+the invariants are not advice; they are **hard stops**. When acting as the agent, do **not**
+report a docs-touching task as complete if any of these hold — fix it or surface it first:
+
+1. **Orphan.** A new or moved concept file is not listed in its directory `index.md` (and that
+   directory is not reachable from the bundle-root `docs/index.md`). *Indexed or it doesn't exist.*
+2. **Stale diagram.** A structural change (schema, module layout, data flow, new component)
+   landed without updating its Mermaid diagram in the **same** change.
+3. **Silent rewrite.** A decision/requirement was edited in place instead of superseded — or a
+   record is `status: Superseded` with no `superseded_by`.
+4. **Untyped doc.** A non-reserved `.md` is missing frontmatter or a non-empty `type`; or an
+   `index.md`/`log.md` carries frontmatter (except the bundle-root `index.md`).
+5. **Broken link.** A bundle-relative (`/…`) or relative link points at a file that does not exist.
+6. **Duplicate home.** The same fact now lives in two files (cross-reference instead).
+
+Triggers **1, 3, 4, 5** are mechanical — run `scripts/lint-docs.sh` (below) and treat a non-zero
+exit as a blocked task, not a warning. Triggers **2** and **6** are semantic (no sound oracle) and
+stay a judgement call: inspect the diff before declaring done.
+
+### lint-docs — the deterministic instrument
+
+`scripts/lint-docs.sh [docs/]` mechanically validates invariants 2, 3, and 4 (the ones a
+machine checks better than prose): frontmatter/`type`, directory-index membership + root
+reachability, link resolution, and supersede integrity. *A constraint without an instrument is a
+vibe* — so the checkable invariants get a checker. Wire it into the project's quality gate / CI;
+a docs PR that fails it does not merge. It does **not** check docs-first mirroring or "one home
+per fact" semantics — those have no sound oracle and stay with the reviewer.
+
+```bash
+./scripts/lint-docs.sh docs          # lint the project's bundle; exit 1 on any violation
+```
+
+A worked, lint-clean corpus lives in [`examples/linkly/`](../../examples/linkly/) — copy its shapes.
+
+## Quality checks
+
+Before considering a docs change complete. The frontmatter, indexing, link-resolution, and
+supersede items are enforced by `scripts/lint-docs.sh` — run it rather than eyeballing them; the
+rest are judgement:
+
+- [ ] Every concept doc opens with OKF frontmatter carrying a non-empty `type`; `status` is in frontmatter, not a body line.
+- [ ] Directory listings are `index.md` with no frontmatter (except the bundle-root `docs/index.md` → `okf_version`); cross-links are bundle-relative (`/…`).
+- [ ] Every new doc is linked from its directory `index.md` **and** the bundle-root `docs/index.md`.
+- [ ] No concept appears in two files (cross-reference instead).
+- [ ] Every acronym the docs use has a glossary entry with its expansion **and** a definition in the doc language; the headword is the acronym as-is. Term names, identifiers, and acronym headwords/expansions stay in their original form — only the explanation is in the doc language.
+- [ ] Each term is defined once (in the glossary); other docs link to it rather than redefine.
+- [ ] Superseded ADRs/PRDs/BDRs carry frontmatter `status: Superseded` + `superseded_by: NNNN`; the superseding record sets `supersedes` and links back.
+- [ ] Any structural code change in the same task updated its doc **and its Mermaid diagram(s)**.
+- [ ] Architecture diagrams use Mermaid (in-repo text), match the code, and use context-index vocabulary for node/participant names.
+- [ ] Every BDR has a Mermaid diagram, a textual description, and numbered Given/When/Then scenarios.
+- [ ] The constitution is singular (`docs/constitution.md`) — no NNNN prefix, no index entry.
+- [ ] Each index file's links all resolve (no dangling references).
+- [ ] Docs-first respected: the repo body matches the published tracker/wiki copy.
+
+---
+
+## Notes
+
+- Keep individual docs scannable. When a context, vocabulary, or architecture file passes ~200 lines or mixes concerns, split it via `rules/semantic-index.md` rather than letting it grow.
+- This skill describes conventions, not tooling. Numbering schemes (`NNNN`), tracker choice (GitHub Issues, Jira), and directory names can be adapted per project — the invariants must not.
+- Templates in `templates/` are starting points. Trim sections that don't apply; never delete a section just to avoid filling it in if it's load-bearing.
+
+---
+
+## Provenance — instrumentalization, not invention
+
+Almost every doc type here is established prior art; this skill composes and enforces them, it does not invent them:
+
+- **"Living documentation"** is **Cyrille Martraire's** named methodology (*Living Documentation*, 2019) — we adopted the term.
+- **ADR** is **Michael Nygard's** (2011); the structured-markdown form is **MADR**; the *supersede-don't-delete* status convention is the **adr-tools** convention (**Nat Pryce**) — invariant 4 is that convention, not a new rule.
+- **BDR** is **Specification by Example / Given-When-Then** (**Adzic** 2011; **North** 2006) in an ADR-style record (recent third-party coinage, **Zanzal** 2026) — see `rules/bdr-conventions.md`.
+- The **problem-first PRD** and **vertical-slice issue** workflow are a kindred influence from **Matt Pocock's** `to-prd` / `to-issues` skills (github.com/mattpocock/skills, MIT); both instrumentalize older practice — product PRDs, user stories (**Cohn**; **Beck**), tracer-bullet vertical slices (**Hunt & Thomas**; **Cockburn**), and "make the change easy, then make the easy change" (**Beck**). Living-docs adds the OKF format, the docs-first mirror, and supersede governance.
+- The **format** is **OKF**, a published **Google Cloud Platform** standard (v0.1, 2026-06-12), not ours — see the `okf-knowledge-format` skill.
+- Neighbors we converge on: **Diátaxis** (Procida), **arc42** (Starke; Hruschka), **C4** (Brown), and **docs-as-code** (Write the Docs).
+
+The honest claim is **not invention** — arc42 + ADR + C4 + glossary + docs-as-code is the
+informal stack of plenty of mature teams. What this skill adds is the **explicit,
+agent-enforceable packaging** of that stack: the governance invariants
+(supersede-never-delete + one-home-per-fact + indexed-or-doesn't-exist) carried in frontmatter
+as a fact contract *and wired to a deterministic checker* (`scripts/lint-docs.sh`). The
+prior-art research found no prior assembly of that exact governance layer — but the value on
+offer is the enforcement, not the novelty. Full citations: `../../references/prior-art-landscape.md`.

--- a/plugins/living-docs-enforcer/skills/living-docs/SKILL.md
+++ b/plugins/living-docs-enforcer/skills/living-docs/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: living-docs
+description: Run a project's documentation as a living system — docs-first issues/PRDs, MADR-lite ADRs (supersede, never delete), Behavior Decision Records (BDRs), a project constitution, research artifacts, living Mermaid architecture diagrams, and semantic-index organization where every doc lands in exactly one place and indexes never drift. Use when setting up or maintaining project docs, writing an ADR/PRD/BDR/constitution/issue/research note, defining a term or acronym in the glossary, drawing or updating an architecture/flow/sequence diagram, splitting an oversized doc into an index, or enforcing the no-drift maintenance rule.
+version: "0.1.0"
+metadata:
+  type: skill
+  layer: procedural
+  tags: [documentation, adr, prd, bdr, constitution, issues, research, architecture, semantic-index]
+---
+
+# Living Docs
+
+Treat documentation as a living system that stays in sync with the code, not a write-once artifact that rots. The discipline has one spine — **every piece of knowledge has exactly one home, that home is indexed, and nothing structural ships without its doc** — and several document types that hang off it: a constitution, ADRs, BDRs, PRDs, issues, research, architecture diagrams, and a semantic context index.
+
+This skill is stack-agnostic. It governs *how* docs are organized and maintained, never *what* technology a project uses.
+
+---
+
+## Core invariants (the spine)
+
+These hold across every document type. Everything else is detail.
+
+1. **Docs-first.** Author the body in the repo (`docs/…`) *before* publishing anywhere external (tracker, wiki). The repo file is the source of truth; the external copy is a mirror.
+2. **One home per fact.** Each concept, decision, or requirement lives in exactly one file. No duplication — cross-reference instead of copying. Duplicated prose is drift waiting to happen.
+3. **Indexed or it doesn't exist.** Every doc is reachable from an index (an `index.md` listing in its directory, and the bundle-root `docs/index.md` that the project guide links). No orphan files.
+4. **Supersede, never rewrite history.** Decisions and requirements are append-only records. When something changes, mark the old record superseded and write a new one — never silently edit the past.
+5. **No structural change without its doc.** New module, moved files, schema change, new data flow → update the relevant doc *and its diagram* in the same change. No "I'll document it later."
+
+When in doubt, re-derive the right action from these five. The rules files below are just these invariants applied to each document type.
+
+---
+
+## Format: OKF-conformant
+
+The five invariants govern *organization and lifecycle*; the **Open Knowledge Format** governs the *file format* so the corpus stays portable and agent-parseable. Every doc in the system is also an OKF concept. Load the `okf-knowledge-format` skill (it vendors the spec) when authoring or checking format.
+
+> **OKF is a thin, swappable dependency — not a foundation (version risk).** OKF is **v0.1
+> from a single vendor**; a backward-incompatible v0.2 is a real possibility. The invariants
+> above do **not** depend on OKF — they depend only on a small set of frontmatter fields, so an
+> OKF break cannot take the governance layer down with it. Keep the boundary explicit:
+> - **Required by Living Docs** (the fact contract `scripts/lint-docs.sh` enforces): a non-empty
+>   `type`, and `status` + `superseded_by` on superseded records. These are *ours*; they survive
+>   regardless of OKF.
+> - **Inherited from OKF** (format conventions): reserved `index.md`/`log.md`, the bundle-root
+>   `okf_version`, bundle-relative links, the `# References` heading (§8). If OKF changes, only
+>   this row moves — re-pin the version in the `okf-knowledge-format` skill and adjust.
+
+Two rules apply to every concept file:
+
+1. **Frontmatter with a required `type`.** Every non-reserved `.md` doc opens with a YAML frontmatter block whose `type` names the doc kind (`Constitution`, `PRD`, `ADR`, `BDR`, `Issue`, `Context`, `Architecture View`, `Research`, `Reference`). Recommended: `title`, `description`, `tags`, `timestamp`. Living-docs adds producer keys: `status`, `supersedes`, `superseded_by`. **Status moves into frontmatter — no `**Status:**` body line.**
+2. **Reserved files + bundle-relative links.** The bundle root is `docs/`. Directory listings are `index.md` (OKF §6, no frontmatter — except the bundle-root `docs/index.md`, which carries `okf_version: "0.1"`). Optional `log.md` records directory history (§7). Cross-link with `/`-prefixed bundle-relative paths (`/adr/0007-slug.md`); list sources under a `# References` heading (§8), each entry formatted per `rules/citation-conventions.md` — **ABNT NBR 6023 structure, always carrying the link**, with connective labels in the project doc language (default English: `Available at: <URL>. Accessed on: <date>`) per `rules/doc-language.md`.
+
+---
+
+## Doc trail
+
+Every change follows this chain, from foundational source of truth down to code:
+
+```mermaid
+flowchart LR
+  C[constitution] --> P[PRD]
+  P --> A[ADR]
+  P --> B[BDR]
+  A --> I[issues]
+  B --> I
+  I --> K[code]
+```
+
+| Artifact | Role |
+|---|---|
+| **constitution** | Foundational source of truth: what the product is, core data model, non-negotiables. All other docs sit under it. |
+| **PRD** | What the system must do and why — feature/product requirement spec. |
+| **ADR** | How the system is structured — architectural/implementation decision and rationale. |
+| **BDR** | What the system must observably do — inputs, outputs, side effects, Given/When/Then scenarios. |
+| **issues** | Execution slices — discrete units of work that trace back to ADRs/BDRs. |
+| **code** | Implementation — every behavior, structure, and interface specified above, realized. |
+
+---
+
+## When to invoke
+
+- Standing up documentation for a project (creating `docs/` structure, the docs index, ADR/issue/BDR/constitution directories).
+- Writing or editing an **ADR** (an architectural/implementation decision) → load `rules/adr-conventions.md` + `templates/adr.md`.
+- Writing or editing a **PRD** (a product/feature requirement spec) → load `rules/prd-conventions.md` + `templates/prd.md`.
+- Writing or editing a **BDR** (observable behavior — inputs, outputs, Given/When/Then scenarios) → load `rules/bdr-conventions.md` + `templates/bdr.md`.
+- Establishing or amending the **constitution** (foundational scope, data model, non-negotiables) → load `rules/constitution-conventions.md` + `templates/constitution.md`.
+- Creating or editing an **issue/ticket** → load `rules/issue-workflow.md` + `templates/issue.md`.
+- Recording **research** (technology evaluation, external trade-offs) → load the **`research-artifacts`** skill. It owns the OKF research-note format (single file per note, no per-research subfolder), the source discipline, and the research → decision → issue traceable chain, and links back here for the ADR/BDR/issue artifacts. Pairs with the `deep-research` skill.
+- Drawing or updating an **architecture, data-flow, or tool-calling diagram** → load `rules/architecture-diagrams.md` + `templates/architecture-index.md`.
+- Defining a **term or acronym** the docs use → add it to the **glossary** (`docs/context/glossary.md`), one home per term → load `rules/glossary-conventions.md` + `templates/glossary.md`.
+- A doc has grown too large or mixes concerns → **split into a semantic index** → load `rules/semantic-index.md` + `templates/context-index.md`.
+- Enforcing the **no-drift maintenance rule** after any structural change → load `rules/maintenance-invariant.md`.
+- Authoring or checking the **OKF format** of any doc (frontmatter `type`, reserved `index.md`/`log.md`, bundle-relative links, `# References`) → load the **`okf-knowledge-format`** skill.
+- Deciding **which language** the docs are written in (default English; user may override at session start and pin it) → load `rules/doc-language.md`.
+
+---
+
+## Document map
+
+| Type | Lives in | Purpose | Mutability |
+|---|---|---|---|
+| Project guide | `CLAUDE.md` / `README.md` (root) | Entry point: scope, stack, docs index, mandatory workflows | Live — edit freely |
+| Constitution | `docs/constitution.md` | Foundational source of truth: product scope, data model, non-negotiables | Append-only once ratified (amendment log) |
+| Context index | `docs/context/index.md` + group files | Domain & module vocabulary, semantically grouped | Live — edit freely |
+| Glossary | `docs/context/glossary.md` | Terms & acronyms defined once, in the doc language (acronym headwords as-is) | Live — edit freely |
+| Architecture | `docs/architecture.md` or `docs/architecture/` + index | Living Mermaid diagrams: structure, data model, flows, tool-calling | Live — must match code |
+| ADR | `docs/adr/NNNN-slug.md` | One architectural/implementation decision | Append-only (supersede) |
+| BDR | `docs/bdr/NNNN-slug.md` | One observable-behavior decision | Append-only (supersede or amend) |
+| PRD | `docs/prd/NNNN-slug.md` | One feature/product requirement spec | Append-only once accepted |
+| Issue | `docs/issues/NNNN-slug.md` | Tracker mirror (body), one per ticket | Body editable; published copy follows |
+| Research | `docs/research/NNNN-<slug>.md` (single file, no subfolder; sequential number leads, date in frontmatter `timestamp`; ends in `# References`) | External evidence with sourced claims | Append-only (evidence is dated) |
+
+Each directory carries its own `index.md` listing (OKF §6, no frontmatter). The project guide's "Docs index" links to the bundle-root `docs/index.md`. See `rules/semantic-index.md` for the indexing contract.
+
+---
+
+## Procedure
+
+### Setting up living docs in a new project
+
+1. Create the project guide (`CLAUDE.md` or equivalent) with a **Docs index** section and a **Maintenance rule** section (copy the wording from `rules/maintenance-invariant.md`). Use `templates/claude-hard-rules.md` as the starting point for the project guide's hard-rules section — fill in the placeholders before committing.
+2. Create `docs/` with the directories the project needs (`adr/`, `bdr/`, `issues/`, `prd/`, `research/`, `context/`). Seed `docs/constitution.md` from `templates/constitution.md`. Add the bundle-root `docs/index.md` (carrying `okf_version: "0.1"`), and give each directory its own `index.md` listing from day one — even if near-empty.
+3. Seed the context index (`docs/context/index.md`) with whatever domain vocabulary exists, and the glossary (`docs/context/glossary.md`) with the terms and acronyms the docs already assume (`rules/glossary-conventions.md`). Grow both as concepts are named.
+4. Seed the architecture doc (`docs/architecture.md`) with the high-level Mermaid views the system already has. Promote to a `docs/architecture/` directory + index once it grows (`rules/architecture-diagrams.md`).
+5. Record any already-made decisions as ADRs so they are not re-litigated.
+
+### Maintaining living docs (every task)
+
+1. **Before coding:** read the relevant constitution, ADRs, BDRs, and the context index. Decisions there are not to be re-opened casually.
+2. **While working:** if you name a new concept, add it to the context index; if you introduce a new term or acronym, define it once in the glossary. If you make a decision with a load-bearing rationale, write an ADR. If you specify observable behavior, write or amend a BDR.
+3. **In the same change:** update every doc the structural change touches — index rows, **architecture diagrams**, vocabulary. Run the maintenance checklist (`rules/maintenance-invariant.md`).
+4. **Never** leave an index stale, an orphan file unlinked, a diagram contradicting the code, or a superseded decision silently edited.
+
+---
+
+## Composition with other skills
+
+- **`grill-me`** — before writing a PRD or a load-bearing ADR, grill the design to surface the real decision and its alternatives. The grilling output becomes the ADR's Context/Consequences.
+- **`improve-codebase-architecture`** — reads the context index and ADRs to find deepening opportunities; emits new ADRs when a candidate is rejected for a load-bearing reason. This skill provides the ADR/context/architecture formats that one consumes.
+- **`research-artifacts`** — owns the research-note format and discipline (a single-file OKF `docs/research/NNNN-<slug>.md` — sequential number leads, date in frontmatter — with a trailing `# References`, plus the cross-research `docs/research/references.md` roll-up, source rules, the research → decision → issue chain). Living-docs delegates all research authoring to it and consumes its output: an accepted recommendation becomes an ADR/BDR here, which spawns issues. The links between the two are bidirectional.
+- **`deep-research`** — gathers and cross-verifies the evidence that lands in `docs/research/`; the `research-artifacts` skill defines how that evidence is formatted, indexed, and referenced from ADRs/PRDs.
+- **`init-codegraph`** — the structural index of *code*; the context index is the human-readable index of *concepts* and the architecture diagrams are the visual index of *structure*. Keep all current.
+- **`wave-execution`** — executes the issues these docs plan, one PR per wave. Wave execution is the implementation phase that consumes the ADRs, BDRs, and issues produced here.
+- **`implementation-review`** — verifies the implementation before it ships. Review checks that the code honors the ADRs and BDRs, and that every specified observable behavior (Given/When/Then) is tested.
+- **`okf-knowledge-format`** — the portable, exchange-oriented **format** standard (Open Knowledge Format: markdown + YAML frontmatter, required `type`, reserved `index.md`/`log.md`, bundle-relative links, conformance rules). Living-docs governs *which* docs exist and the no-drift discipline; OKF governs *how* a knowledge bundle's markdown and frontmatter are shaped. Author a shareable knowledge corpus — e.g. `docs/context/` vocabulary or a `docs/research/` catalog meant to be consumed by agents or exchanged across orgs — as an OKF bundle so its frontmatter and indexing are spec-conformant. The two compose; they do not overlap.
+
+---
+
+## Agent enforcement (refusal triggers)
+
+The value of this skill is not the discipline — humans abandon "nothing structural without
+its doc" at the first deadline. The value is an **agent that enforces it automatically**. So
+the invariants are not advice; they are **hard stops**. When acting as the agent, do **not**
+report a docs-touching task as complete if any of these hold — fix it or surface it first:
+
+1. **Orphan.** A new or moved concept file is not listed in its directory `index.md` (and that
+   directory is not reachable from the bundle-root `docs/index.md`). *Indexed or it doesn't exist.*
+2. **Stale diagram.** A structural change (schema, module layout, data flow, new component)
+   landed without updating its Mermaid diagram in the **same** change.
+3. **Silent rewrite.** A decision/requirement was edited in place instead of superseded — or a
+   record is `status: Superseded` with no `superseded_by`.
+4. **Untyped doc.** A non-reserved `.md` is missing frontmatter or a non-empty `type`; or an
+   `index.md`/`log.md` carries frontmatter (except the bundle-root `index.md`).
+5. **Broken link.** A bundle-relative (`/…`) or relative link points at a file that does not exist.
+6. **Duplicate home.** The same fact now lives in two files (cross-reference instead).
+
+Triggers **1, 3, 4, 5** are mechanical — run `scripts/lint-docs.sh` (below) and treat a non-zero
+exit as a blocked task, not a warning. Triggers **2** and **6** are semantic (no sound oracle) and
+stay a judgement call: inspect the diff before declaring done.
+
+### lint-docs — the deterministic instrument
+
+`scripts/lint-docs.sh [docs/]` mechanically validates invariants 2, 3, and 4 (the ones a
+machine checks better than prose): frontmatter/`type`, directory-index membership + root
+reachability, link resolution, and supersede integrity. *A constraint without an instrument is a
+vibe* — so the checkable invariants get a checker. Wire it into the project's quality gate / CI;
+a docs PR that fails it does not merge. It does **not** check docs-first mirroring or "one home
+per fact" semantics — those have no sound oracle and stay with the reviewer.
+
+```bash
+./scripts/lint-docs.sh docs          # lint the project's bundle; exit 1 on any violation
+```
+
+A worked, lint-clean corpus lives in [`examples/linkly/`](../../examples/linkly/) — copy its shapes.
+
+## Quality checks
+
+Before considering a docs change complete. The frontmatter, indexing, link-resolution, and
+supersede items are enforced by `scripts/lint-docs.sh` — run it rather than eyeballing them; the
+rest are judgement:
+
+- [ ] Every concept doc opens with OKF frontmatter carrying a non-empty `type`; `status` is in frontmatter, not a body line.
+- [ ] Directory listings are `index.md` with no frontmatter (except the bundle-root `docs/index.md` → `okf_version`); cross-links are bundle-relative (`/…`).
+- [ ] Every new doc is linked from its directory `index.md` **and** the bundle-root `docs/index.md`.
+- [ ] No concept appears in two files (cross-reference instead).
+- [ ] Every acronym the docs use has a glossary entry with its expansion **and** a definition in the doc language; the headword is the acronym as-is. Term names, identifiers, and acronym headwords/expansions stay in their original form — only the explanation is in the doc language.
+- [ ] Each term is defined once (in the glossary); other docs link to it rather than redefine.
+- [ ] Superseded ADRs/PRDs/BDRs carry frontmatter `status: Superseded` + `superseded_by: NNNN`; the superseding record sets `supersedes` and links back.
+- [ ] Any structural code change in the same task updated its doc **and its Mermaid diagram(s)**.
+- [ ] Architecture diagrams use Mermaid (in-repo text), match the code, and use context-index vocabulary for node/participant names.
+- [ ] Every BDR has a Mermaid diagram, a textual description, and numbered Given/When/Then scenarios.
+- [ ] The constitution is singular (`docs/constitution.md`) — no NNNN prefix, no index entry.
+- [ ] Each index file's links all resolve (no dangling references).
+- [ ] Docs-first respected: the repo body matches the published tracker/wiki copy.
+
+---
+
+## Notes
+
+- Keep individual docs scannable. When a context, vocabulary, or architecture file passes ~200 lines or mixes concerns, split it via `rules/semantic-index.md` rather than letting it grow.
+- This skill describes conventions, not tooling. Numbering schemes (`NNNN`), tracker choice (GitHub Issues, Jira), and directory names can be adapted per project — the invariants must not.
+- Templates in `templates/` are starting points. Trim sections that don't apply; never delete a section just to avoid filling it in if it's load-bearing.
+
+---
+
+## Provenance — instrumentalization, not invention
+
+Almost every doc type here is established prior art; this skill composes and enforces them, it does not invent them:
+
+- **"Living documentation"** is **Cyrille Martraire's** named methodology (*Living Documentation*, 2019) — we adopted the term.
+- **ADR** is **Michael Nygard's** (2011); the structured-markdown form is **MADR**; the *supersede-don't-delete* status convention is the **adr-tools** convention (**Nat Pryce**) — invariant 4 is that convention, not a new rule.
+- **BDR** is **Specification by Example / Given-When-Then** (**Adzic** 2011; **North** 2006) in an ADR-style record (recent third-party coinage, **Zanzal** 2026) — see `rules/bdr-conventions.md`.
+- The **problem-first PRD** and **vertical-slice issue** workflow are a kindred influence from **Matt Pocock's** `to-prd` / `to-issues` skills (github.com/mattpocock/skills, MIT); both instrumentalize older practice — product PRDs, user stories (**Cohn**; **Beck**), tracer-bullet vertical slices (**Hunt & Thomas**; **Cockburn**), and "make the change easy, then make the easy change" (**Beck**). Living-docs adds the OKF format, the docs-first mirror, and supersede governance.
+- The **format** is **OKF**, a published **Google Cloud Platform** standard (v0.1, 2026-06-12), not ours — see the `okf-knowledge-format` skill.
+- Neighbors we converge on: **Diátaxis** (Procida), **arc42** (Starke; Hruschka), **C4** (Brown), and **docs-as-code** (Write the Docs).
+
+The honest claim is **not invention** — arc42 + ADR + C4 + glossary + docs-as-code is the
+informal stack of plenty of mature teams. What this skill adds is the **explicit,
+agent-enforceable packaging** of that stack: the governance invariants
+(supersede-never-delete + one-home-per-fact + indexed-or-doesn't-exist) carried in frontmatter
+as a fact contract *and wired to a deterministic checker* (`scripts/lint-docs.sh`). The
+prior-art research found no prior assembly of that exact governance layer — but the value on
+offer is the enforcement, not the novelty. Full citations: `../../references/prior-art-landscape.md`.

--- a/plugins/living-docs-enforcer/skills/living-docs/rules/adr-conventions.md
+++ b/plugins/living-docs-enforcer/skills/living-docs/rules/adr-conventions.md
@@ -1,0 +1,35 @@
+# ADR Conventions (MADR-lite)
+
+An Architecture Decision Record captures **one** decision: the context that forced it, the choice made, and the consequences accepted. ADRs are how a future reader understands *why* the code is the way it is — and why a tempting alternative was not taken.
+
+## Format
+
+Each ADR is an **OKF concept** (`type: ADR`) — see the `okf-knowledge-format` skill. Use a lightweight MADR structure — frontmatter plus three body sections, no ceremony:
+
+- **`status` (frontmatter)** — `Proposed` | `Accepted` | `Superseded` | `Deprecated`. Lives in the YAML frontmatter, not a body line. Supersession is recorded with the `supersedes` / `superseded_by` frontmatter keys (NNNN).
+- **Context** — the forces at play: the problem, constraints, and what made a decision necessary. Written so a newcomer understands the pressure without prior knowledge.
+- **Decision** — the choice, stated in active voice ("We will…"). Specific and testable.
+- **Consequences** — what becomes easier, what becomes harder, what is now forbidden. Include the trade-offs you are knowingly accepting, not just the upside.
+
+See `templates/adr.md` for the skeleton.
+
+## Rules
+
+1. **One decision per ADR.** If you are recording two decisions, write two ADRs. Bundled decisions can't be superseded independently.
+2. **Number sequentially, never reuse.** `docs/adr/NNNN-kebab-slug.md`. The number is permanent even after the ADR is superseded.
+3. **Supersede, never delete or rewrite.** When a decision changes:
+   - Set the old ADR's frontmatter `status: Superseded` and `superseded_by: NNNN` (do not edit its Decision/Context — that is history).
+   - Write a new ADR with `supersedes: NNNN` that references the one it supersedes in its Context.
+   - If the old ADR is only *partially* affected, annotate the affected section with a pointer to the new ADR rather than rewriting it.
+4. **Record load-bearing rejections.** When a design candidate is rejected for a reason a future explorer would otherwise re-discover the hard way, that reason is an ADR. Skip ephemeral ("not worth it now") or self-evident reasons.
+5. **Link the evidence.** If the decision rests on research, link the research artifact bundle-relative (`/research/<…>/report.md`). If it implements a requirement, link the PRD/issue.
+6. **Name the fitness function for measurable characteristics.** When an ADR decides a measurable architecture characteristic (a latency budget, a dependency-direction rule, a coupling/granularity constraint), the Consequences section SHOULD name the **fitness function** that enforces it — the executable check (a test, a build/lint rule, an arch-unit assertion) that lives in the suite and fails when the characteristic is violated. The ADR records *why*; the fitness function keeps it true. A measurable decision without an instrument is a vibe (see `memory/lessons.md`).
+7. **Index every ADR, and keep an active view.** Add a row to `docs/adr/index.md` (OKF reserved listing — number, title, status). The index carries no frontmatter; the decision log is the listing plus each ADR's `status`/`superseded_by` frontmatter. **As the corpus grows, split the listing by status** — an `## Active` section above a `## Superseded` section — so a reader sees what is *in force* without reading through history. Append-only + supersede means `docs/adr/` only grows; this convention keeps "indexed or it doesn't exist" from degrading into "indexed but unreadable by volume". `status` already lives in frontmatter, so the split is mechanical. See the worked [`examples/linkly/docs/adr/index.md`](../../../examples/linkly/docs/adr/index.md).
+8. **Bind measurable decisions to a check (optional `## Verification`).** When an ADR must be honored in code, add a `## Verification` block (see `templates/adr.md`): the files it touches and **checkable** verification criteria — ideally a named fitness function (rule 6). This closes the doc → implement → verify loop that `implementation-review` consumes; a structural decision a future agent must respect should not leave "did we honor it?" to inspection. Omit the block for a purely advisory record.
+
+## Anti-patterns
+
+- Editing an accepted ADR's Decision to reflect a new choice — that erases history. Supersede instead.
+- "Status: Accepted" with an empty Consequences section — every decision has trade-offs; if you can't name them, the decision isn't understood yet.
+- An ADR that restates the code. ADRs explain *why*, not *what*. The code says what.
+- Re-litigating a decision an existing ADR already settled without marking the contradiction explicitly.

--- a/plugins/living-docs-enforcer/skills/living-docs/rules/architecture-diagrams.md
+++ b/plugins/living-docs-enforcer/skills/living-docs/rules/architecture-diagrams.md
@@ -1,0 +1,57 @@
+# Architecture Docs & Diagrams
+
+Architecture documentation shows *how the system fits together* — the structure ADRs decide and the context index names, made visual. It is **living**: every diagram must match the code at all times, and a structural change updates its diagram in the same change (see `rules/maintenance-invariant.md`).
+
+Diagrams are authored in **Mermaid** so they live in version control as text, diff cleanly in PRs, and render in most viewers — no binary image drift.
+
+## Where it lives
+
+- **Small project:** a single `docs/architecture.md` holding all diagrams.
+- **Grown project:** an `docs/architecture/` directory with `index.md` + one file per view, organized by the same semantic-index contract as the context index (`rules/semantic-index.md`). Split when the single file passes ~200 lines or mixes unrelated views.
+
+The architecture index (`index.md`, OKF reserved listing, no frontmatter) is reachable from the bundle-root `docs/index.md`. Each view file is a standalone **OKF concept** (`type: Architecture View`): frontmatter, then a single `#` H1, then `##` sections.
+
+## The standard views
+
+Cover the views the system actually has — don't invent diagrams for their own sake. Common ones:
+
+| View | Mermaid type | Answers |
+|---|---|---|
+| **Context / high-level** | `flowchart` / `graph` | What are the major components and how do they connect to the outside world? |
+| **Data model** | `erDiagram` | What entities exist and how do they relate? (schema, FKs, cardinality) |
+| **Module layout** | `flowchart` | How is the code organized into modules and what depends on what? |
+| **Process / data flow** | `flowchart` with direction | How does data move through a key operation (ingest, backfill, request)? |
+| **Tool-calling / request flow** | `sequenceDiagram` | How does a request actually execute across actors over time? |
+| **State** | `stateDiagram-v2` | What states does an entity move through? (lifecycles, retention) |
+
+## Tool-calling / sequence diagrams (when applicable)
+
+When the system's behaviour is best understood as a *conversation between actors over time* — an MCP/tool call, an agent invoking tools, a client→server→DB round trip — use a `sequenceDiagram` to make the flow concrete. Show the actors as participants and each call/return as a message. This is the clearest way to evidence "how it actually works" for tool-driven or multi-actor systems.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server as MCP Server
+    participant DB as SQLite
+    Client->>Server: tool call (args)
+    Server->>DB: query / write
+    DB-->>Server: rows / result
+    Server-->>Client: structured result
+```
+
+Include a sequence diagram only where it earns its place — a tool surface, a lifecycle with ordering, a non-obvious multi-step flow. Skip it for trivially linear calls.
+
+## Rules
+
+1. **Mermaid, in-repo, text.** No exported PNG/SVG that can silently drift from the code.
+2. **No-drift.** A change to schema, data flow, module layout, or a component relationship updates the relevant diagram(s) in the *same* change. A structural PR with a stale diagram is incomplete.
+3. **Use context-index vocabulary.** Name nodes and participants with the project's domain/module terms, not ad-hoc labels — diagrams and prose must agree.
+4. **One view per diagram.** Don't cram the data model and the request flow into one graph. Split by concern; index each.
+5. **Indexed.** Every view file is listed in the architecture index, which is listed in the top-level Docs index.
+
+## Anti-patterns
+
+- A diagram that contradicts the code — worse than no diagram, because it misleads with authority.
+- Screenshot/exported-image diagrams that can't diff and rot immediately.
+- A single mega-diagram trying to show everything at once.
+- Diagrams added but never wired into the index (orphans).

--- a/plugins/living-docs-enforcer/skills/living-docs/rules/bdr-conventions.md
+++ b/plugins/living-docs-enforcer/skills/living-docs/rules/bdr-conventions.md
@@ -1,0 +1,52 @@
+# BDR Conventions
+
+A Behavior Decision Record specifies **what a system must observably do** — inputs, outputs, side effects, and the scenarios that constitute correct operation. A BDR answers *what and observable*; an ADR answers *how is it structured and why*.
+
+> **Provenance — instrumentalization, not invention.** A BDR's core — observable behavior captured as **Given/When/Then** scenarios written to convert verbatim into the test suite — is **Specification by Example / BDD** (ADZIC, *Specification by Example*, 2011; NORTH, *Introducing BDD*, 2006), not original here. "Behavior Decision Record" as a *named record type* is a recent third-party coinage (ZANZAL, 2026), itself an ADR-style wrapper over Specification by Example; treat it as such, not as an industry standard or a repo invention. Our only addition is binding the scenarios to the pipeline (verbatim → regression suite, mutation-gated). Full citations: `../../../references/prior-art-landscape.md`.
+
+## Why a separate record, not a section of the ADR/PRD
+
+A fair challenge: if a BDR is "Given/When/Then in an ADR-style file", why not make it a
+mandatory *Scenarios* section of the ADR or PRD instead of a new document type with its own
+numbering and directory? The split earns its keep on three counts — if none of them hold for
+your project, **do** fold scenarios into the PRD and skip the genre:
+
+1. **Different lifecycle.** An ADR is settled once and superseded as a whole. Behavior accretes:
+   one capability grows scenarios over many changes, and individual scenarios are amended or
+   superseded independently of the structural decision. Bundling them forces a structural
+   supersede every time an edge case is added.
+2. **Different cardinality.** One PRD spawns many behaviors, and one behavior may serve several
+   PRDs/ADRs. A separate record gives each behavior one home to link to (invariant 2) instead of
+   duplicating scenarios across the docs that touch them.
+3. **It is the test contract.** The scenarios convert *verbatim* into the regression suite and
+   are consumed by `implementation-review`. A standalone, addressable record (`/bdr/NNNN`) is
+   what code, tests, and review all point at — a buried PRD subsection is not.
+
+This is a packaging choice over Specification by Example, not a new method — see Provenance below.
+
+## Format
+
+Each BDR is an **OKF concept** (`type: BDR`) — see the `okf-knowledge-format` skill. `status` (`Draft` | `Accepted` | `Implemented` | `Superseded`) lives in the frontmatter, not a body line. See `templates/bdr.md`. Core sections:
+
+- **Context** — why this behavior needs to be specified, and the PRD/ADR/issue that motivated it.
+- **Behavior diagram** — a Mermaid flowchart or sequence diagram of the full observable flow.
+- **Textual description** — prose of the same behavior, written from the outside (inputs, outputs, side effects, error paths).
+- **Scenarios** — numbered Given/When/Then statements written to convert verbatim into the project's behavioral regression suite.
+- **Related** — links to the PRD, ADR, and issues that this BDR serves.
+
+## Rules
+
+1. **Every BDR has three required elements: a Mermaid diagram AND a textual description AND numbered Given/When/Then scenarios.** All three are mandatory; no section may be left empty or removed.
+2. **Scenarios are written to convert verbatim into the project's behavioral regression suite.** Use the exact wording a test author would need. Avoid implementation detail; describe what an external observer would verify.
+3. **BDRs answer *what*; ADRs answer *how*.** If the record is about structure, technology choice, or rationale — write an ADR. If it is about observable behavior a user or system can verify — write a BDR.
+4. **BDRs are spawned (or amended) by a PRD that changes expected behavior.** Every BDR must link to the PRD that produced it. A BDR written without a parent PRD is a sign the PRD is missing.
+5. **Diagrams are Mermaid only.** No ASCII art, no image attachments.
+6. **Numbered sequentially:** `docs/bdr/NNNN-slug.md`. Index in `docs/bdr/index.md` (OKF reserved listing, no frontmatter) with a one-line summary and a link per record.
+7. **Append-only once accepted.** After a BDR is accepted, changes to specified behavior are recorded as dated Amendment sections appended to the file, or the BDR is superseded by a new one (frontmatter `status: Superseded`, `superseded_by: NNNN`). Silent in-place edits are not allowed.
+
+## Anti-patterns
+
+- A BDR with no Mermaid diagram. If the behavior cannot be drawn, the behavior is not yet understood.
+- Scenarios that describe implementation steps ("Given the service calls the database..."). Scenarios describe observable outcomes, not internal mechanics.
+- A BDR written without a parent PRD. Trace back to the PRD and link it before marking the BDR Accepted.
+- Editing accepted scenarios in place when behavior changes — amend or supersede so the history of what was agreed survives.

--- a/plugins/living-docs-enforcer/skills/living-docs/rules/citation-conventions.md
+++ b/plugins/living-docs-enforcer/skills/living-docs/rules/citation-conventions.md
@@ -1,0 +1,43 @@
+# Citation Conventions (ABNT NBR 6023)
+
+Every doc that cites sources — **Research** above all, but also any **ADR**/**BDR** that rests on evidence — lists them under a `# References` heading (OKF §8). References follow the **ABNT NBR 6023 structure** and **always carry the link**. The connective **labels** follow the project doc language (default English) — see `rules/doc-language.md`.
+
+> **This is an opinionated house style, not a neutral default — and not part of the
+> stack-agnostic claim.** "Stack-agnostic" means Living Docs governs *how docs live*, not your
+> tech stack; it makes no claim of cultural neutrality, and a citation format is a deliberate
+> choice. ABNT NBR 6023 is the standard used across the authoring ecosystem this skill came
+> from, so it is the standard here. The portable, non-negotiable core is **"always carry the
+> link + access date"** (rule 1) — that is what makes a citation verifiable. The *structure* is
+> a convention: if a project prefers another style (IEEE, APA, plain link + accessed-on), it may
+> pin that instead, keeping rule 1. Don't sell ABNT as neutral; do keep the always-the-link rule.
+
+## The two iron rules
+
+1. **Always the link.** Every reference to anything with a URL (paper, blog, vendor doc, repo, standard) includes the URL and the access date. A citation without its link is not verifiable — it is hearsay. (For a print-only book with no online edition, the link is omitted; everything else carries it.)
+2. **ABNT NBR 6023 structure, labels in the doc language.** Author surnames in CAPS, title in **bold**, an ISO access date — these are invariant. The connective labels localize to the pinned doc language: **English** (default) → `Available at: <URL>. Accessed on: 2026-06-15.`; **Portuguese** (NBR native) → `Disponível em: <URL>. Acesso em: 2026-06-15.`. Don't mix languages within a corpus — the format is always NBR; only the labels follow `rules/doc-language.md`. The examples below use the English (default) labels.
+
+## Templates by source type
+
+- **Book** — `SURNAME, First name. **Title**: subtitle. Edition. City: Publisher, year.`
+  > FEATHERS, Michael. **Working Effectively with Legacy Code**. Upper Saddle River: Prentice Hall, 2004.
+
+- **Paper / preprint (online)** — `SURNAME, First name et al. **Title**. Year. Available at: <URL>. Accessed on: YYYY-MM-DD.`
+  > ALSHAHWAN, Nadia et al. **Automated Unit Test Improvement using Large Language Models at Meta**. 2024. Available at: https://arxiv.org/abs/2402.09171. Accessed on: 2026-06-15.
+
+- **Blog post / online article** — `SURNAME, First name. **Article title**. Site name, year. Available at: <URL>. Accessed on: YYYY-MM-DD.`
+  > GAUTHIER, Paul. **Separating code reasoning and editing**. Aider, 2024. Available at: https://aider.chat/2024/09/26/architect.html. Accessed on: 2026-06-15.
+
+- **Vendor / institutional doc (no personal author)** — `ORGANIZATION. **Title**. Year. Available at: <URL>. Accessed on: YYYY-MM-DD.`
+  > ANTHROPIC. **Building Effective Agents**. 2024. Available at: https://www.anthropic.com/research/building-effective-agents. Accessed on: 2026-06-15.
+
+- **Source code / repository** — `AUTHOR/ORG. **Repository name**. Year. Available at: <URL>. Accessed on: YYYY-MM-DD.`
+
+## Rules
+
+1. **Alphabetical by first element** (author surname or organization) within `# References`.
+2. **One entry per source.** If the same source is cited many times in the body, it appears once in `# References`.
+3. **Access date is the day you verified it** — not the publication date. When a primary URL was unreachable (e.g. HTTP 403) and the claim was triangulated, say so in the entry (`(verified via secondary sources)` / `(exact URL not captured — unverified)`) rather than implying you read the original. Never fabricate a link.
+4. **Append-only with the doc** — research is dated evidence (the living-docs maintenance invariant). When a source is superseded, annotate; do not silently rewrite a citation.
+5. In-body, refer to a source by `(SURNAME, year)` or a short marker; the full entry lives once under `# References`.
+
+Load `okf-knowledge-format` for the `# References` heading placement (§8); this file governs the *format of each entry*.

--- a/plugins/living-docs-enforcer/skills/living-docs/rules/constitution-conventions.md
+++ b/plugins/living-docs-enforcer/skills/living-docs/rules/constitution-conventions.md
@@ -1,0 +1,34 @@
+# Constitution Conventions
+
+The Product Constitution is the **foundational source of truth** for a project: what the product is, what it is not, the data model it is built on, and the invariants that hold in all circumstances. Every other document in the doc trail sits under it and must be consistent with it.
+
+The doc trail flows: **constitution → PRD → ADR + BDR → issues → code**.
+
+## Format
+
+The constitution is an **OKF concept** (`type: Constitution`) — see the `okf-knowledge-format` skill. `status` (`Draft` | `Ratified` | `Amended`) lives in the frontmatter, not a body line. See `templates/constitution.md`. Core sections:
+
+- **Product** — the core value and the audience in one or two sentences. The north star.
+- **Scope boundaries** — what is in scope, what is explicitly out, and what defers to which phase.
+- **Data model / schema foundation** — the core entities and relationships as a Mermaid diagram, with prose describing invariants.
+- **Non-negotiables** — constraints that hold regardless of feature, phase, or implementation. Each must be falsifiable.
+- **Amendment log** — dated amendments appended below the original content; sections above are immutable once ratified.
+
+## Rules
+
+1. **One per project.** The constitution lives at `docs/constitution.md`. There is no NNNN prefix and it is not listed as a concept in any `index.md` — it is singular, the bundle's root of trace.
+2. **PRDs sit under the constitution; they never replace it.** A PRD specifies a feature or capability within the scope the constitution defines. If a PRD requires expanding that scope, the constitution must be amended first.
+3. **Only foundational scope or schema shifts amend the constitution.** Adding a feature does not amend the constitution. Changing what the product fundamentally is, who it is for, or what its core data model looks like does.
+4. **Append-only once ratified.** After the constitution is ratified, changes are recorded as dated Amendment sections at the bottom (`## Amendment N — YYYY-MM-DD: <summary>`). The original sections above are never silently edited.
+5. **Diagrams are Mermaid only.** No ASCII art, no image attachments.
+6. **Non-negotiables are falsifiable.** "Be secure" is not a non-negotiable. "All user data at rest is encrypted with AES-256" is.
+7. **The constitution is the root of the trace.** When reviewing any PRD, ADR, BDR, or issue, the chain should resolve back to the constitution. Work that cannot be traced to the constitution is out of scope.
+8. **The doc language is a non-negotiable.** If the user has declared a documentation language (default English otherwise), pin it here as a non-negotiable line so it survives across sessions — see `rules/doc-language.md`.
+
+## Anti-patterns
+
+- Writing a constitution per feature instead of per project. One project, one constitution.
+- A PRD that implicitly changes scope without amending the constitution first — the constitution and PRD are then contradictory.
+- Treating the constitution as a living editable document after ratification. Silent edits break the paper trail; amend instead.
+- Non-negotiables that are aspirational rather than falsifiable — they provide no enforcement anchor.
+- An empty Scope Boundaries section. If the out-of-scope items are not named, scope is undefined and PRDs will drift.

--- a/plugins/living-docs-enforcer/skills/living-docs/rules/doc-language.md
+++ b/plugins/living-docs-enforcer/skills/living-docs/rules/doc-language.md
@@ -1,0 +1,34 @@
+# Documentation Language
+
+The language of the doc corpus is a **project-wide non-negotiable**, not a per-file choice. Pick it once, pin it, follow it everywhere.
+
+## The rule
+
+1. **Default is English.** If the user has not declared a documentation language, author every doc — constitution, PRD, ADR, BDR, issues, research, `# References` prose — in **English**. This keeps the corpus portable and matches the default tooling/templates.
+2. **The user may override at session start.** When the user names a documentation language while using the harness (e.g. "docs em português", "documentação em espanhol"), that language governs **all** docs from then on — not just the file in front of you.
+3. **Pin it the moment it's chosen.** A declared language is a standing rule, so record it where it survives across sessions (re-read from disk, per the compaction model):
+   - If the project has a **constitution**, add the language as a non-negotiable line there (`rules/constitution-conventions.md`).
+   - If there is no constitution yet, write it into the **project guide** hard-rules section (`CLAUDE.md` or equivalent, via `templates/claude-hard-rules.md`).
+   Once pinned, follow it without re-asking; the user does not have to repeat the choice every session.
+4. **Never mix.** One corpus, one language. Don't write the PRD in one language and its ADRs in another. If the pinned language changes, that is a normal supersede event — new docs in the new language, old docs left as frozen history (invariant 4).
+
+Terms and acronyms get their explanation in the pinned language — but the **name/headword stays as-is** — in the glossary; see `rules/glossary-conventions.md`.
+
+## What stays language-invariant
+
+These do **not** translate — they are structural identifiers, not prose:
+
+- OKF frontmatter **keys** (`type`, `status`, `title`, …) and their controlled values (`type: ADR`, `status: Superseded`).
+- The `# References` **heading** itself (OKF §8 reserved heading) and reserved filenames (`index.md`, `log.md`).
+- Code, identifiers, slugs, and the ABNT NBR 6023 **structure** of each reference (CAPS surnames, **bold** title, ISO access date, always-the-link).
+
+## Citations follow the doc language
+
+The reference *structure* is fixed (NBR 6023), but the connective **labels** localize to the pinned language — see `rules/citation-conventions.md`:
+
+| Doc language | URL label | Date label |
+|---|---|---|
+| English (default) | `Available at:` | `Accessed on:` |
+| Portuguese (NBR native) | `Disponível em:` | `Acesso em:` |
+
+For any other pinned language, use that language's natural equivalents; the structure never changes.

--- a/plugins/living-docs-enforcer/skills/living-docs/rules/glossary-conventions.md
+++ b/plugins/living-docs-enforcer/skills/living-docs/rules/glossary-conventions.md
@@ -1,0 +1,37 @@
+# Glossary Conventions
+
+The glossary is the project's single home for the **definition of every term and acronym** its docs use. It lives in the context bundle at `docs/context/glossary.md` (split into grouped files via `rules/semantic-index.md` once it outgrows ~200 lines). One term, one entry — every other doc *links* to the glossary instead of redefining.
+
+## What goes in
+
+- **Domain & product terms** the docs assume (the nouns of the system).
+- **Engineering / methodology terms** that aren't common knowledge on the team (e.g. *characterization test*, *walking skeleton*, *mutation score*).
+- **Acronyms & initialisms** (ADR, BDR, PRD, OKF, CC, …).
+
+Leave out words any reader of the doc language already knows, and don't restate a definition that has a clearer home — link to it instead.
+
+## Acronyms — headword as-is, expanded + explained in the doc language
+
+1. **The headword is the acronym verbatim** — `ADR`, not `Architecture Decision Record (ADR)`. The abbreviation is what readers meet in the text, so it is the lookup key.
+2. **Every acronym entry carries its expansion *and* a one-line definition.** The expansion may stay a proper noun in its original language (e.g. `OKF — Open Knowledge Format`); the **definition/explanation is written in the project doc language** (→ `rules/doc-language.md`, default English).
+3. In a body doc, spell it out **once** on first use with the acronym in parentheses — `Architecture Decision Record (ADR)` — then use the acronym; the glossary is the durable home.
+
+## Language (follows the doc-language rule)
+
+- **Definitions are in the project doc language** — default English, or whatever is pinned per `rules/doc-language.md`.
+- **Names stay in their original form.** You do not translate `TaskEnvelope`, `ADR`, or `OKF`. Translate the *explanation*, never the *name*, the *identifier*, or the *acronym headword/expansion*.
+
+## Format & order
+
+- One entry per term: **headword** · (expansion, for acronyms) · definition (doc language) · optional *See also* cross-links.
+- **Alphabetical by headword** for a flat glossary; **semantically grouped** (with an index) once it splits — the same machinery as the context vocabulary (`rules/semantic-index.md`).
+- Start from `templates/glossary.md`.
+
+## One home (no drift)
+
+- A term is defined **once**, in the glossary. ADRs/PRDs/BDRs/issues that use it **link** to its glossary entry; they never carry a competing definition (the one-home-per-fact invariant).
+- Vocabulary is **live**, not append-only: when a term's meaning changes, edit the entry and fix any now-wrong usages in the same change (don't supersede — that rule is for *decisions*, not definitions).
+
+## Relationship to the context index
+
+The glossary is part of the **context bundle** — it is the term/acronym layer of the domain & module vocabulary, not a second vocabulary. A small project keeps a single `docs/context/glossary.md`; a large vocabulary splits into grouped context files with the glossary as their alphabetical entry point. Either way there is exactly one home per term.

--- a/plugins/living-docs-enforcer/skills/living-docs/rules/issue-workflow.md
+++ b/plugins/living-docs-enforcer/skills/living-docs/rules/issue-workflow.md
@@ -1,0 +1,33 @@
+# Issue Workflow (docs-first)
+
+Issues are authored **in the repo first**, then published to the tracker. The repo file is the source of truth; the tracker entry is a mirror that must stay byte-identical in body. Each issue is an **OKF concept** (`type: Issue`) — see the `okf-knowledge-format` skill.
+
+## The workflow
+
+1. **Create** — write `docs/issues/NNNN-slug.md`: OKF frontmatter (`type`, `title`, `status`, `labels`, `blocked_by`, `tracker`) followed by the issue **body**. Add a row to `docs/issues/index.md`. *Then* publish to the tracker, stripping the frontmatter so only the body is sent (e.g. pipe the content below the closing `---` to `gh issue create --body-file -`).
+2. **Edit** — update the body file first, then push to the tracker (`gh issue edit <n> --body-file …`, frontmatter stripped).
+3. **Identical bodies** — the repo file's body (everything below the closing `---`) and the tracker issue body must match exactly. If they diverge, the repo wins; re-sync. Frontmatter is repo-only.
+4. **Metadata lives in frontmatter** — number, title, labels, blocked-by, status, and tracker number live in the issue file's **frontmatter** (and are mirrored into the `docs/issues/index.md` listing), *not* in the body. The body is portable prose; the frontmatter carries the tracker-specific fields.
+5. **Prefer editing the body over adding comments** — so each issue keeps a single, coherent source of truth rather than a scattered comment thread.
+
+See `templates/issue.md` for the body skeleton.
+
+## Body structure
+
+A good issue body states, in order:
+
+- **What / Why** — the change and its motivation. If it implements a PRD or ADR, link it ("Implements ADR NNNN").
+- **Scope** — what's included; for removals/refactors, what's explicitly kept.
+- **Acceptance** — observable, testable conditions for "done".
+- **Plan** — a short outline (and slicing, for large tasks) so a reader knows the approach.
+
+## Rules
+
+1. **Number consistently** with the project's scheme; index every issue.
+2. **Link bidirectionally** — body links to its PRD/ADR; the PRD/ADR's decision log or the issue index links back.
+3. **Closing keywords** belong in the PR that resolves the issue (`Closes #NN`), not scattered in the body.
+4. **Historical issue bodies are not rewritten** when superseded — set the frontmatter `status` (e.g. `superseded`) and annotate the `index.md` row, leaving the body as closed history.
+
+## Why docs-first
+
+A tracker is an external system that can change auth, API, or vendor. The repo is durable, diffable, and reviewable in the same PR as the code. Authoring in the repo means the issue is versioned alongside the work it describes, and the body survives any tracker migration.

--- a/plugins/living-docs-enforcer/skills/living-docs/rules/maintenance-invariant.md
+++ b/plugins/living-docs-enforcer/skills/living-docs/rules/maintenance-invariant.md
@@ -1,0 +1,47 @@
+# Maintenance Invariant (no-drift)
+
+The rule that keeps docs *living*: **no structural change ships without its doc, and no doc exists without being indexed.** Code, docs, and indexes stay in sync within the *same* change — never "documented later."
+
+## The invariant, stated for the project guide
+
+Paste a project-specific version of this into the project guide (`CLAUDE.md` / `README.md`) as a mandatory section:
+
+> **Maintenance rule (mandatory).** Whenever the project structure changes (new directory, moved/renamed files, a new top-level component) or a new doc is generated:
+>
+> 1. **Document the change** — create or update the relevant file under `docs/` (as an OKF concept: frontmatter with a non-empty `type`).
+> 2. **Update the indexes** — add the doc to the bundle-root `docs/index.md` and to its directory `index.md` listing.
+> 3. **Update architecture docs** — whenever the schema, data flow, module layout, or a component relationship changes, update the relevant diagram(s) in the same change. Diagrams must never drift from the code.
+> 4. **Update the context index** — whenever a new module or domain concept is named, add it to the vocabulary so naming stays consistent across code, docs, and reviews.
+>
+> No structural change ships without its doc, and no doc exists without being indexed.
+
+Adapt the specifics (diagram tooling, context index location) to the project. The invariant does not change.
+
+## What counts as a structural change
+
+- New directory, module, or top-level component.
+- Moved, renamed, or deleted files that other docs reference.
+- Schema change, new data flow, changed module boundary.
+- A new domain concept being named in code.
+- A new doc of any type (ADR/PRD/issue/research) being created.
+
+## The checklist (run before declaring a task done)
+
+- [ ] Did this change add/move/rename a file another doc points to? → update those pointers.
+- [ ] Did it name a new concept? → add it to the context index.
+- [ ] Did it change schema/data flow/module layout? → update the architecture diagram(s).
+- [ ] Did it create a new doc? → give it OKF frontmatter (`type`), then link it from its directory `index.md` *and* the bundle-root `docs/index.md`.
+- [ ] Did it change a decision? → supersede the ADR via frontmatter `status`/`superseded_by` (don't rewrite it).
+- [ ] Do all index links still resolve? (prefer bundle-relative `/…` links)
+
+## The instrument (don't eyeball what a script can check)
+
+The orphan, broken-link, untyped-doc, and supersede checks in the list above are mechanical —
+run them, don't re-read prose. `scripts/lint-docs.sh <docs/>` validates them and exits non-zero
+on any violation; wire it into the project's CI/quality gate so a structural PR with a docs
+violation cannot merge. *A constraint without an instrument is a vibe.* The stale-diagram and
+one-home-per-fact checks have no sound oracle and stay a reviewer judgement.
+
+## Why same-change, not later
+
+A doc update deferred to "later" is a doc update that never happens — and the gap between code and docs is exactly where the next person gets misled. Coupling the doc to the change that caused it is the only mechanism that survives turnover and time pressure. The reviewer enforces it: a structural PR with no doc delta is incomplete.

--- a/plugins/living-docs-enforcer/skills/living-docs/rules/prd-conventions.md
+++ b/plugins/living-docs-enforcer/skills/living-docs/rules/prd-conventions.md
@@ -1,0 +1,36 @@
+# PRD Conventions
+
+A Product Requirements Document specifies **one** feature or capability: the problem it solves, who it's for, what "done" means, and what is explicitly out of scope. A PRD answers *what and why*; the ADRs and issues it spawns answer *how*.
+
+## Format
+
+Each PRD is an **OKF concept** (`type: PRD`) — see the `okf-knowledge-format` skill. `status` (`Draft` | `Accepted` | `Implemented` | `Superseded`) lives in the frontmatter, not a body line. See `templates/prd.md`. Core sections:
+
+- **Problem / Motivation** — the user or system pain. Lead with the problem, not the solution. If you can't state the problem without naming a solution, grill it first (`grill-me`).
+- **Goals** — what success looks like, as outcomes (not tasks).
+- **Non-goals** — what this explicitly does *not* cover. The most valuable section: it bounds scope and prevents creep.
+- **Requirements** — numbered, testable statements. Each maps to acceptance criteria.
+- **Acceptance criteria** — observable conditions that prove the requirement is met.
+- **Open questions** — unresolved decisions, each ideally headed toward an ADR.
+- **Decision log** — links to the ADRs that resolved the open questions.
+
+## Relationship to the constitution
+
+A PRD sits **under** the constitution — it specifies a feature within the product's established principles and constraints. A PRD never replaces or overrides the constitution. If a PRD requires a change at constitution level, resolve that separately before accepting the PRD.
+
+## Rules
+
+1. **One capability per PRD.** Number sequentially: `docs/prd/NNNN-slug.md`. Index in `docs/prd/index.md` (OKF reserved listing, no frontmatter).
+2. **Problem before solution.** A PRD that opens with the implementation has skipped the thinking. Restate the underlying problem first.
+3. **Non-goals are mandatory.** An empty Non-goals section means scope is undefined. Name at least what tempting-but-excluded things are out.
+4. **Requirements are testable.** "The system should be fast" is not a requirement. "Search returns in <200ms at p95" is.
+5. **Success metrics are mandatory.** Each PRD must state how success will be measured after delivery — quantified outcomes (not task completion) that would confirm the problem is solved.
+6. **Append-only once accepted.** A PRD under active design is editable. Once accepted and being implemented, changes are recorded as amendments or new ADRs — not silent edits to the requirements.
+7. **PRDs spawn issues.** Each requirement becomes one or more issues (see `rules/issue-workflow.md`). The PRD links to them; the issues link back to the PRD.
+8. **Open questions resolve into ADRs (how) or BDRs (behavior).** When an open question is answered with a load-bearing rationale about architecture, write an ADR and link it from the decision log. When the question resolves observable behavior — what the system must do, with Given/When/Then scenarios — write or amend a BDR instead. Both artifact types are spawned by the PRD and link back to it.
+
+## Anti-patterns
+
+- A PRD that is a task list. Tasks are issues; the PRD is the spec they serve.
+- No acceptance criteria — then "done" is a matter of opinion.
+- Editing accepted requirements in place when scope changes — amend or supersede so the history of what was agreed survives.

--- a/plugins/living-docs-enforcer/skills/living-docs/rules/semantic-index.md
+++ b/plugins/living-docs-enforcer/skills/living-docs/rules/semantic-index.md
@@ -1,0 +1,35 @@
+# Semantic Index Organization
+
+Documentation is organized by **meaning, not by accident of growth**. When a body of knowledge is large, it is split into semantically coherent files, each with a single concern, all reachable from one index. The index is the entry point; the group files are the content.
+
+This applies to any large doc — most commonly the domain/module **context** (vocabulary), but equally to research, ADR collections, or any directory that accumulates files.
+
+## The indexing contract
+
+1. **Every directory has an `index.md`** — the OKF reserved directory listing (§6), for collections (ADRs/issues/research) and split single docs (context) alike. It lists every file with a one-line description and carries **no frontmatter** (the sole exception: the bundle-root `docs/index.md`, which may declare `okf_version: "0.1"`).
+2. **Every file is reachable from an index, and from the bundle-root `docs/index.md`** linked by the project guide. No orphans.
+3. **One concept, one file.** Each group file owns a coherent slice of the vocabulary or content. A concept appears in exactly one group file; other files cross-reference it. Every group/concept file opens with OKF frontmatter carrying a non-empty `type`.
+4. **The index carries no content** — only intro framing + a table/list of pointers. Content lives in the group files, never duplicated into the index.
+5. **Links resolve.** Every pointer in an index points to a file that exists; prefer bundle-relative (`/…`) links. Check after every split or move.
+
+## When and how to split a large doc
+
+Split when a doc passes ~200 lines or starts mixing unrelated concerns.
+
+1. **Map sections → groups.** Lay out a source map: each section of the old file → exactly one new group file. Decide group boundaries by *meaning* (write-path vs read-path, domain concepts vs storage shapes), not by length.
+2. **Content-preserving move.** Move vocabulary verbatim. Do not reword, add, or drop terms during a split — that conflates two changes and makes the diff unreviewable. Reword in a *separate* later change if needed.
+3. **One concept lands once.** If two sections discuss the same concept, pick its home and cross-reference from the other.
+4. **Build the index** — intro paragraph + a TOC table linking every group file with a one-line description. See `templates/context-index.md`.
+5. **Cut over.** Repoint the live pointers (project guide's Docs index, maintenance rules) to the new index. Delete the old monolith. Leave *historical* mentions (in ADR/issue "Consequences") untouched — they are history.
+6. **Completeness review.** Diff the old content against the union of new files: every term present exactly once, nothing lost or duplicated, all index links resolve, old file removed.
+
+## Heading discipline
+
+Each group file is a standalone document: it leads with a single `#` H1 title, then `##` sections. Do not carry over `##`-as-top-level headings from the section you extracted — promote them to H1 so the file reads as its own document.
+
+## Anti-patterns
+
+- An index that duplicates content from the group files — now there are two homes and they will drift.
+- Splitting by line count into arbitrary "part 1 / part 2" files instead of by meaning.
+- Rewording vocabulary during a split — bundles two changes, breaks the content-preserving guarantee.
+- A group file with two unrelated concerns because "it was already there."

--- a/plugins/living-docs-enforcer/skills/living-docs/scripts/lint-docs.sh
+++ b/plugins/living-docs-enforcer/skills/living-docs/scripts/lint-docs.sh
@@ -150,6 +150,20 @@ is_reserved() { # is_reserved <basename>
 	[[ "$1" == "index.md" || "$1" == "log.md" ]]
 }
 
+# Strip the bundle-root prefix from a path so it is bundle-relative. Used for any
+# path EMBEDDED IN A VIOLATION MESSAGE: report() only normalizes the file column
+# ($1), so an absolute/worktree path baked into the message ($2) would otherwise
+# differ between the current run ('docs/adr') and the ratchet's baseline worktree
+# ('/tmp/wt.../docs/adr'), misclassifying a pre-existing violation as [NEW].
+# Keeping the message itself bundle-relative makes the SAME violation byte-identical
+# across worktrees and also cleans up default-mode output.
+rel_to_bundle() { # rel_to_bundle <path>  → path with the bundle-root prefix dropped
+	local p="$1"
+	p="${p#"$BUNDLE"/}"
+	p="${p#"$BUNDLE"}"
+	printf '%s' "$p"
+}
+
 has_frontmatter() { # has_frontmatter <file>  → 0 if first line is '---'
 	[[ "$(head -n 1 "$1")" == "---" ]]
 }
@@ -283,7 +297,7 @@ for f in "${ALL_MD[@]}"; do
 	dir="$(dirname "$f")"
 	dir_index="$dir/index.md"
 	if [[ ! -f "$dir_index" ]]; then
-		report "$f" "no index.md in its directory ($dir) — orphan (invariant 3)"
+		report "$f" "no index.md in its directory ($(rel_to_bundle "$dir")) — orphan (invariant 3)"
 		continue
 	fi
 	listed=0
@@ -295,7 +309,7 @@ for f in "${ALL_MD[@]}"; do
 			break
 		fi
 	done < <(links_in "$dir_index")
-	((listed == 0)) && report "$f" "not listed in $dir_index — orphan (invariant 3)"
+	((listed == 0)) && report "$f" "not listed in $(rel_to_bundle "$dir_index") — orphan (invariant 3)"
 done
 
 # --- check: every directory index.md is reachable from the bundle root ------

--- a/plugins/living-docs-enforcer/skills/living-docs/scripts/lint-docs.sh
+++ b/plugins/living-docs-enforcer/skills/living-docs/scripts/lint-docs.sh
@@ -1,0 +1,484 @@
+#!/usr/bin/env bash
+#
+# lint-docs.sh — mechanically validate the Living Docs invariants on a docs bundle.
+#
+# The five invariants are a contract. Three of them are mechanical and should be
+# checked by a machine, not by an agent re-reading prose ("a constraint without an
+# instrument is a vibe"). This script is that instrument. It checks:
+#
+#   - Indexed or it doesn't exist (invariant 3): every concept file is listed in its
+#     directory's index.md, and every directory index is reachable from the bundle root.
+#   - Links resolve (invariants 2/3): every bundle-relative / relative link to a local
+#     file points at a file that exists.
+#   - Supersede, never rewrite (invariant 4): a Superseded record carries superseded_by,
+#     and the target exists.
+#   - OKF format: every non-reserved doc opens with frontmatter carrying a non-empty
+#     `type`; index.md/log.md carry no frontmatter (except the bundle-root index.md,
+#     which may declare okf_version).
+#
+# Invariants 1 (docs-first mirror) and 2's "one home per fact" semantic half are NOT
+# mechanical — they stay with the reviewing agent. This script never claims to check them.
+#
+# Usage:  lint-docs.sh [BUNDLE_ROOT]      (default: docs)
+#         lint-docs.sh --ratchet <baseline-ref> [BUNDLE_ROOT]
+#         lint-docs.sh --help
+#
+# Default (whole-bundle) mode:
+#   Exit 0 = clean, 1 = ANY violation, 2 = usage / bundle-not-found error.
+#
+# --ratchet <baseline-ref> mode (diff-aware):
+#   Lint the current bundle AND the bundle as of <baseline-ref> (a git ref), then
+#   exit 1 ONLY for violations present now that were ABSENT at baseline (NEW debt
+#   introduced by the change). Pre-existing violations are printed as informational
+#   "(pre-existing)" lines and do NOT fail the run — legacy debt is not held against
+#   the change. This mirrors the diff-aware ratchet the repo's other gates use:
+#   only NEW violations block; pre-existing debt is grandfathered.
+#
+#   These checks are whole-bundle (index reachability, orphan membership, link
+#   resolution, supersede integrity) — they are NOT file-local, so "lint only the
+#   touched files" cannot work. The ratchet therefore compares violation SETS, not
+#   files. The baseline bundle is materialized with `git worktree add` (robust for
+#   a whole directory) and removed afterward. Baseline ref absent / not a git repo /
+#   bundle missing at baseline → the baseline set is treated as EMPTY, so every
+#   current violation is considered NEW (fail-closed, documented in --help).
+
+set -uo pipefail
+
+if [[ -z "${BASH_VERSINFO:-}" || "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+	echo "lint-docs.sh requires bash 4+ (you have ${BASH_VERSION:-unknown}). On macOS: brew install bash." >&2
+	exit 2
+fi
+
+PROG="${0##*/}"
+
+usage() {
+	cat <<EOF
+$PROG — validate the mechanical Living Docs invariants on a docs bundle.
+
+Usage:
+  $PROG [BUNDLE_ROOT]               Lint the bundle (default: ./docs)
+  $PROG --ratchet <ref> [BUNDLE]    Diff-aware: fail only on NEW violations vs <ref>
+  $PROG --help                      Show this help
+
+Checks (mechanical invariants only):
+  * frontmatter      every non-reserved .md opens with frontmatter + non-empty type
+  * index format     index.md / log.md carry no frontmatter (bundle-root index.md
+                     may declare okf_version)
+  * directory index  every concept file is listed in its own directory's index.md
+  * reachable        every directory index.md is reachable from the bundle-root index.md
+  * links resolve    every local (/… or relative) markdown link points at a file
+  * supersede        a 'status: Superseded' record carries a resolvable superseded_by
+
+Diff-aware ratchet (--ratchet <baseline-ref>):
+  Lints the current bundle and the bundle as of <baseline-ref> (a git ref), and
+  fails (exit 1) ONLY for violations present now that were absent at the baseline —
+  i.e. NEW debt introduced by the change. Pre-existing violations are printed as
+  "(pre-existing)" and do NOT fail the run; a change that adds no new violation
+  passes even if the bundle carries legacy debt. The baseline is materialized with
+  'git worktree add'. If <baseline-ref> is absent, the tree is not a git repo, or
+  the bundle does not exist at the baseline, the baseline is treated as empty
+  (every current violation counts as NEW — fail-closed).
+
+  These checks are whole-bundle, not file-local, so the ratchet compares violation
+  SETS rather than touched files. One CLI enforced at the git boundary (pre-commit)
+  and in CI (a reusable Action) is harness-agnostic: it covers every AI harness AND
+  human commits with one mechanism, instead of a per-harness plugin.
+
+Exit: 0 clean (or no new violations) · 1 violations (or new violations) · 2 usage error.
+EOF
+}
+
+# --- argument parsing -------------------------------------------------------
+
+RATCHET=0
+BASELINE_REF=""
+
+case "${1:-}" in
+	-h | --help)
+		usage
+		exit 0
+		;;
+	--ratchet)
+		RATCHET=1
+		BASELINE_REF="${2:-}"
+		if [[ -z "$BASELINE_REF" ]]; then
+			echo "$PROG: --ratchet requires a <baseline-ref> argument" >&2
+			echo "       e.g. $PROG --ratchet HEAD docs" >&2
+			exit 2
+		fi
+		BUNDLE="${3:-docs}"
+		;;
+	*)
+		BUNDLE="${1:-docs}"
+		;;
+esac
+
+BUNDLE="${BUNDLE%/}"
+
+if [[ ! -d "$BUNDLE" ]]; then
+	echo "$PROG: bundle root not found: $BUNDLE" >&2
+	echo "       run from the repo root, or pass the docs directory: $PROG path/to/docs" >&2
+	exit 2
+fi
+
+# --- violation collection ---------------------------------------------------
+#
+# report() does double duty: it prints the human-readable line (as before) and,
+# when capturing for the ratchet, appends a NORMALIZED line to VIOL_LINES so the
+# same violation matches across two different worktrees. Normalization strips the
+# bundle-root prefix from the file path, so 'docs/adr/x.md' and
+# '/tmp/wt.../docs/adr/x.md' compare equal — the comparison key is
+# "<relpath-within-bundle>\t<message>".
+
+VIOLATIONS=0
+QUIET=""
+declare -a VIOL_LINES=()
+report() {
+	# report <file> <message>
+	[[ "$QUIET" != "quiet" ]] && printf '  %-44s %s\n' "$1" "$2"
+	VIOLATIONS=$((VIOLATIONS + 1))
+	# normalized key: drop the bundle prefix so paths are bundle-relative
+	local rel="$1"
+	rel="${rel#"$BUNDLE"/}"
+	rel="${rel#"$BUNDLE"}"
+	VIOL_LINES+=("$rel	$2")
+}
+
+# --- helpers ----------------------------------------------------------------
+
+is_reserved() { # is_reserved <basename>
+	[[ "$1" == "index.md" || "$1" == "log.md" ]]
+}
+
+has_frontmatter() { # has_frontmatter <file>  → 0 if first line is '---'
+	[[ "$(head -n 1 "$1")" == "---" ]]
+}
+
+fm_value() { # fm_value <file> <key>  → prints trimmed value within frontmatter block
+	awk -v key="$2" '
+		NR == 1 && $0 != "---" { exit }
+		NR == 1 { infm = 1; next }
+		infm && $0 == "---" { exit }
+		infm {
+			if ($0 ~ "^" key ":") {
+				sub("^" key ":[[:space:]]*", "")
+				gsub(/^[[:space:]]+|[[:space:]]+$/, "")
+				gsub(/^"|"$/, "")
+				print
+				exit
+			}
+		}
+	' "$1"
+}
+
+# Normalize a path: collapse '.' and '..' segments. Pure bash (portable).
+normpath() { # normpath <path>  → prints normalized path
+	local path="$1" abs="" seg out=()
+	[[ "$path" == /* ]] && abs="/"
+	local IFS=/
+	for seg in $path; do
+		case "$seg" in
+			"" | .) ;;
+			..)
+				if ((${#out[@]} > 0)) && [[ "${out[$((${#out[@]} - 1))]}" != ".." ]]; then
+					unset "out[$((${#out[@]} - 1))]"
+				elif [[ -z "$abs" ]]; then
+					out+=("..")
+				fi
+				;;
+			*) out+=("$seg") ;;
+		esac
+	done
+	local joined="${out[*]}"
+	printf '%s%s\n' "$abs" "$joined"
+}
+
+# Resolve a markdown link target (as written in <file>) to a filesystem path,
+# or print nothing if the link is external / a pure anchor / unsupported.
+resolve_link() { # resolve_link <file> <target>
+	local file="$1" target="$2"
+	target="${target%%#*}"      # drop anchor
+	[[ -z "$target" ]] && return        # pure anchor → in-doc, skip
+	case "$target" in
+		*://* | mailto:* | tel:*) return ;;   # external
+	esac
+	if [[ "$target" == /* ]]; then
+		# bundle-relative
+		normpath "$BUNDLE/$target"
+	else
+		normpath "$(dirname "$file")/$target"
+	fi
+}
+
+# Print every markdown link target in <file> (the bit inside the parentheses).
+links_in() { # links_in <file>
+	grep -oE '\]\([^)]+\)' "$1" 2>/dev/null | sed -E 's/^\]\(//; s/\)$//'
+}
+
+# --- the lint body, as a function so it can run against two trees ------------
+#
+# lint_run <bundle> [quiet]
+#   Lints <bundle>, appending normalized violations to the (caller-owned)
+#   VIOL_LINES array and bumping VIOLATIONS. When the second arg is "quiet" the
+#   per-violation human lines and the "bundle: …" header are suppressed (used for
+#   the baseline tree in ratchet mode — we only need its violation SET). Resets
+#   VIOLATIONS / VIOL_LINES at entry so it is safe to call twice.
+
+lint_run() { # lint_run <bundle> [quiet]
+	BUNDLE="${1%/}"
+	QUIET="${2:-}"
+	VIOLATIONS=0
+	VIOL_LINES=()
+
+	local ALL_MD ALL_INDEX ROOT_INDEX
+	mapfile -t ALL_MD < <(find "$BUNDLE" -type f -name '*.md' | sort)
+	ROOT_INDEX="$BUNDLE/index.md"
+
+	if [[ "$QUIET" != "quiet" ]]; then
+		echo "Living Docs lint — bundle: $BUNDLE"
+		echo
+	fi
+
+# --- check 1: bundle-root index exists --------------------------------------
+
+if [[ ! -f "$ROOT_INDEX" ]]; then
+	report "$ROOT_INDEX" "missing bundle-root index.md (invariant 3)"
+fi
+
+# --- per-file checks: frontmatter / type / index format ---------------------
+
+for f in "${ALL_MD[@]}"; do
+	base="${f##*/}"
+	if is_reserved "$base"; then
+		# index.md / log.md: no frontmatter, except bundle-root index.md (okf_version)
+		if has_frontmatter "$f"; then
+			if [[ "$f" == "$ROOT_INDEX" ]]; then
+				okf="$(fm_value "$f" okf_version)"
+				[[ -z "$okf" ]] && report "$f" "bundle-root index.md frontmatter lacks okf_version"
+			else
+				report "$f" "$base must not carry frontmatter (OKF §6)"
+			fi
+		fi
+		continue
+	fi
+	# non-reserved concept file: must have frontmatter with a non-empty type
+	if ! has_frontmatter "$f"; then
+		report "$f" "missing OKF frontmatter (needs a non-empty 'type')"
+		continue
+	fi
+	type_val="$(fm_value "$f" type)"
+	if [[ -z "$type_val" ]]; then
+		report "$f" "frontmatter has no non-empty 'type'"
+	fi
+done
+
+# --- check: every concept file is listed in its directory's index.md --------
+# The bundle-root constitution.md is the root of trace and is deliberately NOT indexed.
+
+for f in "${ALL_MD[@]}"; do
+	base="${f##*/}"
+	is_reserved "$base" && continue
+	[[ "$f" == "$BUNDLE/constitution.md" ]] && continue
+
+	dir="$(dirname "$f")"
+	dir_index="$dir/index.md"
+	if [[ ! -f "$dir_index" ]]; then
+		report "$f" "no index.md in its directory ($dir) — orphan (invariant 3)"
+		continue
+	fi
+	listed=0
+	while IFS= read -r tgt; do
+		resolved="$(resolve_link "$dir_index" "$tgt")"
+		[[ -z "$resolved" ]] && continue
+		if [[ "$(normpath "$f")" == "$resolved" ]]; then
+			listed=1
+			break
+		fi
+	done < <(links_in "$dir_index")
+	((listed == 0)) && report "$f" "not listed in $dir_index — orphan (invariant 3)"
+done
+
+# --- check: every directory index.md is reachable from the bundle root ------
+# BFS from the root index over index→index (and index→dir) links.
+
+if [[ -f "$ROOT_INDEX" ]]; then
+	mapfile -t ALL_INDEX < <(find "$BUNDLE" -type f -name 'index.md' | sort)
+	declare -A REACHED=()
+	queue=("$(normpath "$ROOT_INDEX")")
+	REACHED["$(normpath "$ROOT_INDEX")"]=1
+	while ((${#queue[@]} > 0)); do
+		cur="${queue[0]}"
+		queue=("${queue[@]:1}")
+		[[ -f "$cur" ]] || continue
+		while IFS= read -r tgt; do
+			resolved="$(resolve_link "$cur" "$tgt")"
+			[[ -z "$resolved" ]] && continue
+			# a link may point at a directory (→ its index.md) or directly at an index.md
+			if [[ -d "$resolved" ]]; then
+				resolved="$(normpath "$resolved/index.md")"
+			fi
+			[[ "${resolved##*/}" == "index.md" ]] || continue
+			if [[ -z "${REACHED[$resolved]:-}" ]]; then
+				REACHED["$resolved"]=1
+				queue+=("$resolved")
+			fi
+		done < <(links_in "$cur")
+	done
+	for idx in "${ALL_INDEX[@]}"; do
+		n="$(normpath "$idx")"
+		[[ -z "${REACHED[$n]:-}" ]] && report "$idx" "directory index not reachable from $ROOT_INDEX (invariant 3)"
+	done
+fi
+
+# --- check: every local link resolves ---------------------------------------
+
+for f in "${ALL_MD[@]}"; do
+	while IFS= read -r tgt; do
+		resolved="$(resolve_link "$f" "$tgt")"
+		[[ -z "$resolved" ]] && continue
+		if [[ ! -e "$resolved" ]]; then
+			report "$f" "broken link → $tgt"
+		fi
+	done < <(links_in "$f")
+done
+
+# --- check: supersede integrity (invariant 4) -------------------------------
+
+for f in "${ALL_MD[@]}"; do
+	base="${f##*/}"
+	is_reserved "$base" && continue
+	has_frontmatter "$f" || continue
+	status="$(fm_value "$f" status)"
+	# case-insensitive compare (portable to bash without ${,,})
+	status_lc="$(printf '%s' "$status" | tr '[:upper:]' '[:lower:]')"
+	if [[ "$status_lc" == "superseded" ]]; then
+		sb="$(fm_value "$f" superseded_by)"
+		if [[ -z "$sb" ]]; then
+			report "$f" "status: Superseded but superseded_by is empty (invariant 4)"
+			continue
+		fi
+		# resolve superseded_by (an NNNN) to a sibling file with that number prefix
+		dir="$(dirname "$f")"
+		if ! compgen -G "$dir/${sb}-*.md" >/dev/null && [[ ! -f "$dir/${sb}.md" ]]; then
+			report "$f" "superseded_by: $sb has no matching record in $dir (invariant 4)"
+		fi
+	fi
+done
+
+	LAST_MD_COUNT="${#ALL_MD[@]}"
+}
+
+# --- driver -----------------------------------------------------------------
+
+if ((RATCHET == 0)); then
+	# Default whole-bundle mode: lint the current tree, fail on ANY violation.
+	lint_run "$BUNDLE"
+	echo
+	if ((VIOLATIONS == 0)); then
+		echo "OK — ${LAST_MD_COUNT} docs, no invariant violations."
+		exit 0
+	else
+		echo "FAIL — $VIOLATIONS violation(s) across ${LAST_MD_COUNT} docs."
+		exit 1
+	fi
+fi
+
+# --- ratchet mode -----------------------------------------------------------
+#
+# Compare the current bundle's violation SET against the baseline tree's set.
+# Only violations that are NEW (present now, absent at baseline) fail the run.
+
+# 1. lint the CURRENT bundle (verbose) and snapshot its normalized set
+lint_run "$BUNDLE"
+CUR_COUNT="$LAST_MD_COUNT"
+declare -a CUR_VIOL=("${VIOL_LINES[@]}")
+
+# 2. materialize the baseline tree and lint it (quiet) for its set
+declare -a BASE_VIOL=()
+BASELINE_NOTE=""
+WORKTREE=""
+
+cleanup_worktree() {
+	if [[ -n "$WORKTREE" && -d "$WORKTREE" ]]; then
+		git -C "$REPO_TOPLEVEL" worktree remove --force "$WORKTREE" >/dev/null 2>&1 ||
+			rm -rf "$WORKTREE" 2>/dev/null
+	fi
+}
+trap cleanup_worktree EXIT
+
+REPO_TOPLEVEL="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+
+if [[ -z "$REPO_TOPLEVEL" ]]; then
+	BASELINE_NOTE="not a git repository — baseline treated as empty (all violations are NEW)"
+elif ! git -C "$REPO_TOPLEVEL" rev-parse --verify --quiet "$BASELINE_REF^{commit}" >/dev/null 2>&1; then
+	BASELINE_NOTE="baseline ref '$BASELINE_REF' not found — baseline treated as empty (all violations are NEW)"
+else
+	# Where does BUNDLE live relative to the repo root? (so we can find it in the worktree)
+	BUNDLE_ABS="$(cd "$BUNDLE" && pwd)"
+	BUNDLE_REL="${BUNDLE_ABS#"$REPO_TOPLEVEL"/}"
+	if [[ "$BUNDLE_REL" == "$BUNDLE_ABS" ]]; then
+		# bundle is outside the repo — cannot map into the worktree
+		BASELINE_NOTE="bundle is outside the git repo — baseline treated as empty (all violations are NEW)"
+	else
+		WORKTREE="$(mktemp -d "${TMPDIR:-/tmp}/lint-docs-baseline.XXXXXX")"
+		if git -C "$REPO_TOPLEVEL" worktree add --quiet --detach "$WORKTREE" "$BASELINE_REF" >/dev/null 2>&1; then
+			BASE_BUNDLE="$WORKTREE/$BUNDLE_REL"
+			if [[ -d "$BASE_BUNDLE" ]]; then
+				lint_run "$BASE_BUNDLE" quiet
+				BASE_VIOL=("${VIOL_LINES[@]}")
+			else
+				BASELINE_NOTE="bundle '$BUNDLE_REL' did not exist at '$BASELINE_REF' — baseline treated as empty (all violations are NEW)"
+			fi
+		else
+			BASELINE_NOTE="could not check out '$BASELINE_REF' — baseline treated as empty (all violations are NEW)"
+		fi
+	fi
+fi
+
+# 3. set difference: NEW = CUR \ BASE ; pre-existing = CUR ∩ BASE
+declare -A BASE_SET=()
+for v in "${BASE_VIOL[@]:-}"; do
+	[[ -n "$v" ]] && BASE_SET["$v"]=1
+done
+
+declare -a NEW_VIOL=()
+declare -a OLD_VIOL=()
+for v in "${CUR_VIOL[@]:-}"; do
+	[[ -z "$v" ]] && continue
+	if [[ -n "${BASE_SET[$v]:-}" ]]; then
+		OLD_VIOL+=("$v")
+	else
+		NEW_VIOL+=("$v")
+	fi
+done
+
+# 4. report
+echo
+echo "Ratchet — baseline: $BASELINE_REF"
+[[ -n "$BASELINE_NOTE" ]] && echo "  note: $BASELINE_NOTE"
+echo
+
+fmt_viol() { # fmt_viol <normalized-line> <tag>
+	# normalized line is "<relpath>\t<message>"; print it human-readably with a tag
+	local line="$1" tag="$2" rel msg
+	rel="${line%%$'\t'*}"
+	msg="${line#*$'\t'}"
+	printf '  %-7s %-40s %s\n' "$tag" "$rel" "$msg"
+}
+
+if ((${#OLD_VIOL[@]} > 0)); then
+	echo "Pre-existing violations (grandfathered — do NOT block this change):"
+	for v in "${OLD_VIOL[@]}"; do fmt_viol "$v" "[old]"; done
+	echo
+fi
+
+if ((${#NEW_VIOL[@]} > 0)); then
+	echo "NEW violations introduced by this change (these block):"
+	for v in "${NEW_VIOL[@]}"; do fmt_viol "$v" "[NEW]"; done
+	echo
+	echo "FAIL — ${#NEW_VIOL[@]} new violation(s) vs baseline $BASELINE_REF (${#OLD_VIOL[@]} pre-existing, not counted)."
+	exit 1
+else
+	echo "OK — no new violations vs baseline $BASELINE_REF (${#OLD_VIOL[@]} pre-existing, grandfathered)."
+	exit 0
+fi

--- a/plugins/living-docs-enforcer/skills/living-docs/templates/adr.md
+++ b/plugins/living-docs-enforcer/skills/living-docs/templates/adr.md
@@ -1,0 +1,55 @@
+---
+type: ADR
+title: <Short decision title>
+description: <One sentence — the decision and its scope.>
+status: Proposed            # Proposed | Accepted | Superseded | Deprecated
+supersedes:                 # NNNN of the ADR this replaces, if any
+superseded_by:              # NNNN, set when a later ADR replaces this one
+tags: []
+timestamp: <ISO 8601 datetime, e.g. 2026-06-13T00:00:00Z>
+---
+
+# NNNN. <Short decision title>
+
+<!-- Status lives in frontmatter (`status`), not a body line. When superseding a
+     prior ADR, set `supersedes` here and `superseded_by` on the old record. -->
+
+## Context
+
+<The forces at play. What problem forced a decision? What constraints bound it?
+Written so a newcomer understands the pressure without prior knowledge. Link any
+research artifact or PRD/issue that motivates it, bundle-relative:
+[research](/research/NNNN-<slug>.md), [PRD](/prd/NNNN-<slug>.md).>
+
+## Decision
+
+We will <the choice, in active voice — specific and testable>.
+
+## Consequences
+
+**Easier / gained:**
+- <what this unlocks>
+
+**Harder / accepted trade-offs:**
+- <what this costs or forbids>
+
+**Follow-ups:**
+- <issues spawned, ADRs this may later require>
+
+## Verification
+
+<!-- OPTIONAL — include when this decision must be honored in code, so the doc closes the
+     doc → implement → verify loop an agent (and `implementation-review`) can consume. Omit
+     for a purely advisory record. Keep criteria checkable, not aspirational. -->
+
+**Implementation impact:** <files / modules this decision touches, e.g. `src/store.py`.>
+
+**Verification criteria:**
+- <An observable, checkable condition proving the decision is honored.>
+- <Fitness function: the test / lint / arch-unit assertion that fails if it is violated
+  (see `rules/adr-conventions.md` rule 6).>
+
+# References
+
+<!-- Optional (OKF §8). External sources backing claims in Context. -->
+[1] [<source>](<url>)

--- a/plugins/living-docs-enforcer/skills/living-docs/templates/architecture-index.md
+++ b/plugins/living-docs-enforcer/skills/living-docs/templates/architecture-index.md
@@ -1,0 +1,44 @@
+<!-- OKF reserved index.md (§6): a directory listing — NO frontmatter. The view files
+     it links ARE concepts and each carries `type: Architecture View` frontmatter. -->
+
+# Architecture
+
+Living architecture of the project: how the components fit together, expressed as
+Mermaid diagrams that must always match the code. This index is the entry point; each
+view file owns one diagram/concern. Update the relevant view in the same change as any
+structural code change (see the maintenance rule in the project guide).
+
+## Views
+
+| File | View | Mermaid type |
+|---|---|---|
+| [context.md](context.md)         | High-level components & external world | `flowchart` |
+| [data-model.md](data-model.md)   | Entities & relationships               | `erDiagram` |
+| [modules.md](modules.md)         | Module layout & dependencies           | `flowchart` |
+| [<flow>.md](flow.md)             | <Key process / data flow>              | `flowchart` |
+| [<request>.md](request.md)       | <Tool-calling / request round trip>    | `sequenceDiagram` |
+
+<!-- Add a row whenever a new view file is created. -->
+
+## Example view file skeleton
+
+A view file is an OKF concept: it opens with frontmatter, then an H1 title, one sentence
+of orientation, then the Mermaid block:
+
+````markdown
+---
+type: Architecture View
+title: <View name>
+description: <One sentence — what this view shows.>
+timestamp: <ISO 8601 datetime>
+---
+
+# <View name>
+
+<One sentence: what this view shows and when to consult it.>
+
+```mermaid
+flowchart LR
+    A[Module A] --> B[Module B]
+```
+````

--- a/plugins/living-docs-enforcer/skills/living-docs/templates/bdr.md
+++ b/plugins/living-docs-enforcer/skills/living-docs/templates/bdr.md
@@ -1,0 +1,61 @@
+---
+type: BDR
+title: <Short behavior title>
+description: <One sentence — the observable behavior this specifies.>
+status: Draft               # Draft | Accepted | Implemented | Superseded
+superseded_by:              # NNNN, set when a later BDR replaces this one
+tags: []
+timestamp: <ISO 8601 datetime>
+---
+
+# NNNN. <Short behavior title>
+
+<!-- Status lives in frontmatter (`status`), not a body line. -->
+
+## Context
+
+<What observable behavior is being specified? What user need or system requirement
+demands it? Link the PRD or ADR that spawned this BDR, and any issue that tracks the
+work, bundle-relative: [PRD](/prd/NNNN-<slug>.md), [ADR](/adr/NNNN-<slug>.md).>
+
+## Behavior
+
+```mermaid
+flowchart TD
+    A[Trigger / input] --> B[Step]
+    B --> C{Decision}
+    C -->|yes| D[Outcome A]
+    C -->|no| E[Outcome B]
+```
+
+<Replace the diagram above with a flowchart or sequence diagram that shows the full
+observable flow. Use Mermaid only — no images, no ASCII art.>
+
+## Textual Description
+
+<Prose form of the behavior. Describe what the system does from the outside: inputs,
+outputs, side effects, error paths. Write as if the code does not exist yet — what an
+observer would verify by watching the running system.>
+
+## Scenarios
+
+Each scenario is written to convert verbatim into the project's behavioral regression
+suite. Number from 1; do not skip numbers.
+
+**Scenario 1: <happy-path name>**
+
+- Given <initial state or precondition>
+- When <the trigger or action>
+- Then <the observable outcome>
+
+**Scenario 2: <edge or error case>**
+
+- Given <initial state or precondition>
+- When <the trigger or action>
+- Then <the observable outcome>
+
+## Related
+
+- PRD: [/prd/NNNN-<slug>.md](/prd/NNNN-<slug>.md)
+- ADR: [/adr/NNNN-<slug>.md](/adr/NNNN-<slug>.md)
+- Issues: [/issues/NNNN-<slug>.md](/issues/NNNN-<slug>.md)

--- a/plugins/living-docs-enforcer/skills/living-docs/templates/claude-hard-rules.md
+++ b/plugins/living-docs-enforcer/skills/living-docs/templates/claude-hard-rules.md
@@ -1,0 +1,79 @@
+# CLAUDE.md — Hard Rules Template
+
+Copy this block into the project's `CLAUDE.md` and fill in the `<placeholders>`. Adapt the table of locations to match the project's actual directory structure.
+
+---
+
+## Doc-trail
+
+Every change follows this chain:
+
+```
+constitution → PRD → ADR (how) + BDR (behavior) → issues → code
+```
+
+No code change skips a link. A PR that changes behavior without a BDR, or architecture without an ADR, is incomplete.
+
+## Locations
+
+Adapt this table to the project's actual paths before committing the rules.
+
+| Artifact | Location |
+|---|---|
+| Constitution | `docs/constitution/` |
+| PRDs | `docs/prd/` |
+| ADRs | `docs/decisions/` |
+| BDRs | `docs/behavior/` |
+| Research | `docs/research/` |
+| Issue drafts | `docs/issues/drafts/` |
+
+---
+
+## Hard rules
+
+### 1. Docs-first change policy
+
+Any change that alters behavior, architecture, flows, endpoints, or schema MUST update the corresponding docs in the same PR. A PR that changes code without updating its affected docs is incomplete and must not be merged.
+
+### 2. Diagrams are always Mermaid
+
+All diagrams in documentation must be Mermaid. Existing ASCII diagrams are converted whenever their containing doc is touched. Never introduce image-based or ASCII diagrams.
+
+### 3. Semantic doc groups with OKF index files
+
+Every directory of documentation is a semantic group and must contain an `index.md` (the OKF reserved listing — no frontmatter, except the bundle-root `docs/index.md`, which declares `okf_version: "0.1"`). Every concept document opens with OKF frontmatter carrying a non-empty `type`; `status` and supersession live in frontmatter, never a body line. Every new document is linked from its group's `index.md` with bundle-relative (`/…`) links, and new groups are linked from the root docs index. No orphan documents. See the `okf-knowledge-format` skill.
+
+### 4. Architectural decisions require an ADR; expected behavior requires a BDR
+
+- A decision that changes structure, dependencies, or technical approach → write an ADR (`docs/decisions/NNNN-slug.md`).
+- A decision that defines or changes what the system must observably do → write or amend a BDR (`docs/behavior/NNNN-slug.md`). Every BDR carries a Mermaid diagram, a textual description, and numbered Given/When/Then scenarios.
+- Research informing decisions goes in `docs/research/` in the OKF format (dated session directory with a `report.md` concept and a `references.md` registry; see the `research-artifacts` skill).
+
+### 5. Issues local-first
+
+Draft the issue as `docs/issues/drafts/NNNN-slug.md` first, linked from the drafts index. Launch on the tracker, stripping the OKF frontmatter so only the body is sent. Backfill the tracker number into the issue's frontmatter (`tracker`) and the index. The local file is the trace; the tracker is execution state.
+
+### 6. No comments in code
+
+Self-documenting names, small single-purpose functions, and extracted variables replace comments. A comment is permitted only for a constraint the code cannot express — a non-obvious external contract, a deliberate workaround with its reason. Never comment to narrate what the code does, restate history, or address a reviewer. No commented-out code.
+
+### 7. All internal artifacts in English
+
+Code, documentation, commit messages, ADRs, BDRs, and issue drafts are written in English. Conversation language follows the user.
+
+### 8. Generated artifact names describe what they do
+
+Migrations, scripts, and auto-named artifacts use descriptive names. For example: `--name <what_it_does>`, never auto-generated whimsical names. The name must let a future reader understand the artifact's purpose without opening it.
+
+### 9. Quality gates — all must pass before merge
+
+All of the following must pass on every PR. No exceptions, no deferrals.
+
+| Gate | Command |
+|---|---|
+| Tests | `<test command>` |
+| Type checking | `<typecheck command>` |
+| Lint at zero warnings | `<lint command at zero warnings>` |
+| Mutation testing (changed code, per file) | `<mutation testing >= N% on changed code, per file>` |
+
+The docs-update rule from rule 1 is also a quality gate: a PR failing the docs check does not merge.

--- a/plugins/living-docs-enforcer/skills/living-docs/templates/constitution.md
+++ b/plugins/living-docs-enforcer/skills/living-docs/templates/constitution.md
@@ -1,0 +1,65 @@
+---
+type: Constitution
+title: <Product> Constitution
+description: Foundational scope, data model, and non-negotiables for <product>.
+status: Draft               # Draft | Ratified | Amended
+timestamp: <ISO 8601 datetime>
+---
+
+# Product Constitution
+
+<!-- Status lives in frontmatter (`status`). This file is singular — no NNNN prefix,
+     and it is NOT listed as a concept in any index.md. It is the bundle's root of trace. -->
+
+## Product
+
+<What the product is, in one or two sentences. State the core value it delivers and
+who it delivers it to. This is the north star — every PRD and ADR must be consistent
+with it.>
+
+## Scope Boundaries
+
+**In scope:**
+
+- <Capability or domain the product owns.>
+
+**Explicitly out of scope:**
+
+- <Tempting-but-excluded capability. Name it so it cannot silently creep in.>
+
+**Phase boundaries:**
+
+- Phase 1: <what is in scope for the current phase and what defers>
+- Phase 2: <…>
+
+## Data Model / Schema Foundation
+
+<The core entities and their relationships. This section fixes what the rest of the
+system is built on. Represent structure as a Mermaid entity-relationship or class
+diagram. Describe cardinalities and invariants in prose below the diagram.>
+
+```mermaid
+erDiagram
+    ENTITY_A {
+        type field "description"
+    }
+    ENTITY_B {
+        type field "description"
+    }
+    ENTITY_A ||--o{ ENTITY_B : "relationship"
+```
+
+## Non-negotiables
+
+<Constraints that hold regardless of feature set, phase, or implementation choice.
+Examples: compliance requirements, security invariants, performance floors, user-trust
+commitments. Each item should be falsifiable — someone could check the running system
+and say "violated" or "holds".>
+
+- <Non-negotiable 1>
+
+## Amendment Log
+
+<!-- Append amendments here; do not edit sections above once ratified.            -->
+<!-- Format: ## Amendment N — YYYY-MM-DD: <summary of what changed and why>        -->
+<!-- A directory-level log.md (OKF §7) MAY also record amendment history.          -->

--- a/plugins/living-docs-enforcer/skills/living-docs/templates/context-index.md
+++ b/plugins/living-docs-enforcer/skills/living-docs/templates/context-index.md
@@ -1,0 +1,26 @@
+<!-- OKF reserved index.md (§6): a directory listing — NO frontmatter. The group
+     files it links ARE concepts and each carries `type: Context` frontmatter. -->
+
+# Context — Domain & Module Vocabulary
+
+The shared language for this project: the names used consistently across code, docs,
+and reviews. This index is the entry point; each group file owns one coherent slice of
+the vocabulary. A concept lives in exactly one file — cross-reference, never duplicate.
+
+<!-- Optional: reference the architecture-glossary skill that defines cross-project
+     terms (module, seam, depth, …) so domain vocabulary and architecture vocabulary
+     stay distinct. -->
+
+## Groups
+
+| File | Covers |
+|---|---|
+| [domain-concepts.md](domain-concepts.md)         | Core domain entities and rules |
+| [modules-<group-a>.md](modules-group-a.md)        | <e.g. write-path modules> |
+| [modules-<group-b>.md](modules-group-b.md)        | <e.g. read-path modules> |
+| [<shapes>.md](shapes.md)                          | <e.g. read/response shapes> |
+| [<storage>.md](storage.md)                        | <e.g. storage internals> |
+
+<!-- Each group file is a standalone OKF concept: opens with `type: Context`
+     frontmatter, then a single `#` H1 title, then `##` sections. Add a row here
+     whenever a new group file is created. -->

--- a/plugins/living-docs-enforcer/skills/living-docs/templates/glossary.md
+++ b/plugins/living-docs-enforcer/skills/living-docs/templates/glossary.md
@@ -1,0 +1,27 @@
+---
+type: Context
+title: "Glossary"
+description: Definitions of the terms and acronyms used across the project docs.
+tags: [glossary, vocabulary, context]
+timestamp: 2026-06-15T00:00:00Z
+---
+# Glossary
+
+Single home for every term and acronym the docs use. **Definitions are in the project doc language** (see `rules/doc-language.md`); term names, code identifiers, and acronym headwords/expansions stay in their original form. Each term is defined **once** here — other docs link to it rather than redefine. Keep entries alphabetical; split into grouped context files (`rules/semantic-index.md`) once this passes ~200 lines.
+
+## Acronyms
+
+The headword is the acronym **as-is**; the expansion is the spelled-out form (may stay in its original language); the definition is in the doc language.
+
+| Acronym | Expansion | Definition |
+|---|---|---|
+| ADR | Architecture Decision Record | <one-line definition in the project doc language> |
+| BDR | Behavior Decision Record | <one-line definition in the project doc language> |
+| PRD | Product Requirements Document | <one-line definition in the project doc language> |
+| OKF | Open Knowledge Format | <one-line definition in the project doc language> |
+
+## Terms
+
+| Term | Definition | See also |
+|---|---|---|
+| <Term> | <one-line definition in the project doc language> | <links to related entries / ADRs> |

--- a/plugins/living-docs-enforcer/skills/living-docs/templates/issue.md
+++ b/plugins/living-docs-enforcer/skills/living-docs/templates/issue.md
@@ -1,0 +1,32 @@
+---
+type: Issue
+title: <Issue title>
+description: <One sentence — the change and its motivation.>
+status: open                # open | in-progress | closed | superseded
+labels: []                  # tracker labels
+blocked_by: []              # issue numbers this depends on
+tracker:                    # #NN once published to the tracker
+timestamp: <ISO 8601 datetime>
+---
+
+<!-- OKF frontmatter above carries the tracker metadata (number, labels, blocked-by,
+     status) that previously lived only in the directory index. Everything BELOW the
+     closing `---` is the issue body and MUST stay byte-identical to the published
+     tracker body — strip the frontmatter when publishing. -->
+
+## <Issue title>
+
+<What the change is and why. If it implements a PRD or ADR, link it bundle-relative:
+"Implements [ADR NNNN](/adr/NNNN-<slug>.md)" / "Part of [PRD NNNN](/prd/NNNN-<slug>.md)".>
+
+### Scope
+
+<What's included. For removals/refactors, state what is explicitly KEPT.>
+
+### Acceptance
+
+- <Observable, testable condition for "done".>
+
+### Plan
+
+<Short outline of the approach. For a large task, list the slices.>

--- a/plugins/living-docs-enforcer/skills/living-docs/templates/prd.md
+++ b/plugins/living-docs-enforcer/skills/living-docs/templates/prd.md
@@ -1,0 +1,61 @@
+---
+type: PRD
+title: <Feature / capability name>
+description: <One sentence — what capability this specifies.>
+status: Draft               # Draft | Accepted | Implemented | Superseded
+superseded_by:              # NNNN, set when a later PRD replaces this one
+tags: []
+timestamp: <ISO 8601 datetime>
+---
+
+# NNNN. <Feature / capability name>
+
+<!-- Status lives in frontmatter (`status`), not a body line. -->
+
+## Problem / Motivation
+
+<The user or system pain. Lead with the problem, not the solution. If you can only
+state it as a solution, grill it first to find the underlying need.>
+
+## Goals
+
+- <Outcome 1 — what success looks like, not a task>
+
+## Non-goals
+
+- <What this explicitly does NOT cover. Name the tempting-but-excluded things.>
+
+## Requirements
+
+1. <Numbered, testable statement.>
+2. <…>
+
+## Acceptance criteria
+
+- <Observable condition proving a requirement is met.>
+
+## Success metrics
+
+- <Quantified outcome that confirms the problem is solved after delivery — not task
+  completion. E.g. "Checkout abandonment rate drops by ≥10% within 30 days of launch.">
+
+## Behavior (BDRs)
+
+- <Link each BDR that specifies observable behavior this PRD defines or changes,
+  bundle-relative: [BDR](/bdr/NNNN-<slug>.md). BDRs carry Mermaid diagrams, textual
+  descriptions, and Given/When/Then scenarios.>
+
+## Open questions
+
+- <Unresolved decision — each ideally headed toward an ADR (how/architecture) or a
+  BDR (what the system must observably do).>
+
+## Decision log
+
+- <Link to the ADR(s) and BDR(s) that resolved the open questions, once made.>
+
+## Related
+
+- Constitution: [/constitution.md](/constitution.md)
+- Issues: [/issues/NNNN-<slug>.md](/issues/NNNN-<slug>.md)
+- Research: [/research/NNNN-<slug>.md](/research/NNNN-<slug>.md)

--- a/plugins/living-docs-enforcer/skills/rules/adr-conventions.md
+++ b/plugins/living-docs-enforcer/skills/rules/adr-conventions.md
@@ -1,0 +1,35 @@
+# ADR Conventions (MADR-lite)
+
+An Architecture Decision Record captures **one** decision: the context that forced it, the choice made, and the consequences accepted. ADRs are how a future reader understands *why* the code is the way it is — and why a tempting alternative was not taken.
+
+## Format
+
+Each ADR is an **OKF concept** (`type: ADR`) — see the `okf-knowledge-format` skill. Use a lightweight MADR structure — frontmatter plus three body sections, no ceremony:
+
+- **`status` (frontmatter)** — `Proposed` | `Accepted` | `Superseded` | `Deprecated`. Lives in the YAML frontmatter, not a body line. Supersession is recorded with the `supersedes` / `superseded_by` frontmatter keys (NNNN).
+- **Context** — the forces at play: the problem, constraints, and what made a decision necessary. Written so a newcomer understands the pressure without prior knowledge.
+- **Decision** — the choice, stated in active voice ("We will…"). Specific and testable.
+- **Consequences** — what becomes easier, what becomes harder, what is now forbidden. Include the trade-offs you are knowingly accepting, not just the upside.
+
+See `templates/adr.md` for the skeleton.
+
+## Rules
+
+1. **One decision per ADR.** If you are recording two decisions, write two ADRs. Bundled decisions can't be superseded independently.
+2. **Number sequentially, never reuse.** `docs/adr/NNNN-kebab-slug.md`. The number is permanent even after the ADR is superseded.
+3. **Supersede, never delete or rewrite.** When a decision changes:
+   - Set the old ADR's frontmatter `status: Superseded` and `superseded_by: NNNN` (do not edit its Decision/Context — that is history).
+   - Write a new ADR with `supersedes: NNNN` that references the one it supersedes in its Context.
+   - If the old ADR is only *partially* affected, annotate the affected section with a pointer to the new ADR rather than rewriting it.
+4. **Record load-bearing rejections.** When a design candidate is rejected for a reason a future explorer would otherwise re-discover the hard way, that reason is an ADR. Skip ephemeral ("not worth it now") or self-evident reasons.
+5. **Link the evidence.** If the decision rests on research, link the research artifact bundle-relative (`/research/<…>/report.md`). If it implements a requirement, link the PRD/issue.
+6. **Name the fitness function for measurable characteristics.** When an ADR decides a measurable architecture characteristic (a latency budget, a dependency-direction rule, a coupling/granularity constraint), the Consequences section SHOULD name the **fitness function** that enforces it — the executable check (a test, a build/lint rule, an arch-unit assertion) that lives in the suite and fails when the characteristic is violated. The ADR records *why*; the fitness function keeps it true. A measurable decision without an instrument is a vibe (see `memory/lessons.md`).
+7. **Index every ADR, and keep an active view.** Add a row to `docs/adr/index.md` (OKF reserved listing — number, title, status). The index carries no frontmatter; the decision log is the listing plus each ADR's `status`/`superseded_by` frontmatter. **As the corpus grows, split the listing by status** — an `## Active` section above a `## Superseded` section — so a reader sees what is *in force* without reading through history. Append-only + supersede means `docs/adr/` only grows; this convention keeps "indexed or it doesn't exist" from degrading into "indexed but unreadable by volume". `status` already lives in frontmatter, so the split is mechanical. See the worked [`examples/linkly/docs/adr/index.md`](../../../examples/linkly/docs/adr/index.md).
+8. **Bind measurable decisions to a check (optional `## Verification`).** When an ADR must be honored in code, add a `## Verification` block (see `templates/adr.md`): the files it touches and **checkable** verification criteria — ideally a named fitness function (rule 6). This closes the doc → implement → verify loop that `implementation-review` consumes; a structural decision a future agent must respect should not leave "did we honor it?" to inspection. Omit the block for a purely advisory record.
+
+## Anti-patterns
+
+- Editing an accepted ADR's Decision to reflect a new choice — that erases history. Supersede instead.
+- "Status: Accepted" with an empty Consequences section — every decision has trade-offs; if you can't name them, the decision isn't understood yet.
+- An ADR that restates the code. ADRs explain *why*, not *what*. The code says what.
+- Re-litigating a decision an existing ADR already settled without marking the contradiction explicitly.

--- a/plugins/living-docs-enforcer/skills/rules/architecture-diagrams.md
+++ b/plugins/living-docs-enforcer/skills/rules/architecture-diagrams.md
@@ -1,0 +1,57 @@
+# Architecture Docs & Diagrams
+
+Architecture documentation shows *how the system fits together* — the structure ADRs decide and the context index names, made visual. It is **living**: every diagram must match the code at all times, and a structural change updates its diagram in the same change (see `rules/maintenance-invariant.md`).
+
+Diagrams are authored in **Mermaid** so they live in version control as text, diff cleanly in PRs, and render in most viewers — no binary image drift.
+
+## Where it lives
+
+- **Small project:** a single `docs/architecture.md` holding all diagrams.
+- **Grown project:** an `docs/architecture/` directory with `index.md` + one file per view, organized by the same semantic-index contract as the context index (`rules/semantic-index.md`). Split when the single file passes ~200 lines or mixes unrelated views.
+
+The architecture index (`index.md`, OKF reserved listing, no frontmatter) is reachable from the bundle-root `docs/index.md`. Each view file is a standalone **OKF concept** (`type: Architecture View`): frontmatter, then a single `#` H1, then `##` sections.
+
+## The standard views
+
+Cover the views the system actually has — don't invent diagrams for their own sake. Common ones:
+
+| View | Mermaid type | Answers |
+|---|---|---|
+| **Context / high-level** | `flowchart` / `graph` | What are the major components and how do they connect to the outside world? |
+| **Data model** | `erDiagram` | What entities exist and how do they relate? (schema, FKs, cardinality) |
+| **Module layout** | `flowchart` | How is the code organized into modules and what depends on what? |
+| **Process / data flow** | `flowchart` with direction | How does data move through a key operation (ingest, backfill, request)? |
+| **Tool-calling / request flow** | `sequenceDiagram` | How does a request actually execute across actors over time? |
+| **State** | `stateDiagram-v2` | What states does an entity move through? (lifecycles, retention) |
+
+## Tool-calling / sequence diagrams (when applicable)
+
+When the system's behaviour is best understood as a *conversation between actors over time* — an MCP/tool call, an agent invoking tools, a client→server→DB round trip — use a `sequenceDiagram` to make the flow concrete. Show the actors as participants and each call/return as a message. This is the clearest way to evidence "how it actually works" for tool-driven or multi-actor systems.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server as MCP Server
+    participant DB as SQLite
+    Client->>Server: tool call (args)
+    Server->>DB: query / write
+    DB-->>Server: rows / result
+    Server-->>Client: structured result
+```
+
+Include a sequence diagram only where it earns its place — a tool surface, a lifecycle with ordering, a non-obvious multi-step flow. Skip it for trivially linear calls.
+
+## Rules
+
+1. **Mermaid, in-repo, text.** No exported PNG/SVG that can silently drift from the code.
+2. **No-drift.** A change to schema, data flow, module layout, or a component relationship updates the relevant diagram(s) in the *same* change. A structural PR with a stale diagram is incomplete.
+3. **Use context-index vocabulary.** Name nodes and participants with the project's domain/module terms, not ad-hoc labels — diagrams and prose must agree.
+4. **One view per diagram.** Don't cram the data model and the request flow into one graph. Split by concern; index each.
+5. **Indexed.** Every view file is listed in the architecture index, which is listed in the top-level Docs index.
+
+## Anti-patterns
+
+- A diagram that contradicts the code — worse than no diagram, because it misleads with authority.
+- Screenshot/exported-image diagrams that can't diff and rot immediately.
+- A single mega-diagram trying to show everything at once.
+- Diagrams added but never wired into the index (orphans).

--- a/plugins/living-docs-enforcer/skills/rules/bdr-conventions.md
+++ b/plugins/living-docs-enforcer/skills/rules/bdr-conventions.md
@@ -1,0 +1,52 @@
+# BDR Conventions
+
+A Behavior Decision Record specifies **what a system must observably do** — inputs, outputs, side effects, and the scenarios that constitute correct operation. A BDR answers *what and observable*; an ADR answers *how is it structured and why*.
+
+> **Provenance — instrumentalization, not invention.** A BDR's core — observable behavior captured as **Given/When/Then** scenarios written to convert verbatim into the test suite — is **Specification by Example / BDD** (ADZIC, *Specification by Example*, 2011; NORTH, *Introducing BDD*, 2006), not original here. "Behavior Decision Record" as a *named record type* is a recent third-party coinage (ZANZAL, 2026), itself an ADR-style wrapper over Specification by Example; treat it as such, not as an industry standard or a repo invention. Our only addition is binding the scenarios to the pipeline (verbatim → regression suite, mutation-gated). Full citations: `../../../references/prior-art-landscape.md`.
+
+## Why a separate record, not a section of the ADR/PRD
+
+A fair challenge: if a BDR is "Given/When/Then in an ADR-style file", why not make it a
+mandatory *Scenarios* section of the ADR or PRD instead of a new document type with its own
+numbering and directory? The split earns its keep on three counts — if none of them hold for
+your project, **do** fold scenarios into the PRD and skip the genre:
+
+1. **Different lifecycle.** An ADR is settled once and superseded as a whole. Behavior accretes:
+   one capability grows scenarios over many changes, and individual scenarios are amended or
+   superseded independently of the structural decision. Bundling them forces a structural
+   supersede every time an edge case is added.
+2. **Different cardinality.** One PRD spawns many behaviors, and one behavior may serve several
+   PRDs/ADRs. A separate record gives each behavior one home to link to (invariant 2) instead of
+   duplicating scenarios across the docs that touch them.
+3. **It is the test contract.** The scenarios convert *verbatim* into the regression suite and
+   are consumed by `implementation-review`. A standalone, addressable record (`/bdr/NNNN`) is
+   what code, tests, and review all point at — a buried PRD subsection is not.
+
+This is a packaging choice over Specification by Example, not a new method — see Provenance below.
+
+## Format
+
+Each BDR is an **OKF concept** (`type: BDR`) — see the `okf-knowledge-format` skill. `status` (`Draft` | `Accepted` | `Implemented` | `Superseded`) lives in the frontmatter, not a body line. See `templates/bdr.md`. Core sections:
+
+- **Context** — why this behavior needs to be specified, and the PRD/ADR/issue that motivated it.
+- **Behavior diagram** — a Mermaid flowchart or sequence diagram of the full observable flow.
+- **Textual description** — prose of the same behavior, written from the outside (inputs, outputs, side effects, error paths).
+- **Scenarios** — numbered Given/When/Then statements written to convert verbatim into the project's behavioral regression suite.
+- **Related** — links to the PRD, ADR, and issues that this BDR serves.
+
+## Rules
+
+1. **Every BDR has three required elements: a Mermaid diagram AND a textual description AND numbered Given/When/Then scenarios.** All three are mandatory; no section may be left empty or removed.
+2. **Scenarios are written to convert verbatim into the project's behavioral regression suite.** Use the exact wording a test author would need. Avoid implementation detail; describe what an external observer would verify.
+3. **BDRs answer *what*; ADRs answer *how*.** If the record is about structure, technology choice, or rationale — write an ADR. If it is about observable behavior a user or system can verify — write a BDR.
+4. **BDRs are spawned (or amended) by a PRD that changes expected behavior.** Every BDR must link to the PRD that produced it. A BDR written without a parent PRD is a sign the PRD is missing.
+5. **Diagrams are Mermaid only.** No ASCII art, no image attachments.
+6. **Numbered sequentially:** `docs/bdr/NNNN-slug.md`. Index in `docs/bdr/index.md` (OKF reserved listing, no frontmatter) with a one-line summary and a link per record.
+7. **Append-only once accepted.** After a BDR is accepted, changes to specified behavior are recorded as dated Amendment sections appended to the file, or the BDR is superseded by a new one (frontmatter `status: Superseded`, `superseded_by: NNNN`). Silent in-place edits are not allowed.
+
+## Anti-patterns
+
+- A BDR with no Mermaid diagram. If the behavior cannot be drawn, the behavior is not yet understood.
+- Scenarios that describe implementation steps ("Given the service calls the database..."). Scenarios describe observable outcomes, not internal mechanics.
+- A BDR written without a parent PRD. Trace back to the PRD and link it before marking the BDR Accepted.
+- Editing accepted scenarios in place when behavior changes — amend or supersede so the history of what was agreed survives.

--- a/plugins/living-docs-enforcer/skills/rules/citation-conventions.md
+++ b/plugins/living-docs-enforcer/skills/rules/citation-conventions.md
@@ -1,0 +1,43 @@
+# Citation Conventions (ABNT NBR 6023)
+
+Every doc that cites sources — **Research** above all, but also any **ADR**/**BDR** that rests on evidence — lists them under a `# References` heading (OKF §8). References follow the **ABNT NBR 6023 structure** and **always carry the link**. The connective **labels** follow the project doc language (default English) — see `rules/doc-language.md`.
+
+> **This is an opinionated house style, not a neutral default — and not part of the
+> stack-agnostic claim.** "Stack-agnostic" means Living Docs governs *how docs live*, not your
+> tech stack; it makes no claim of cultural neutrality, and a citation format is a deliberate
+> choice. ABNT NBR 6023 is the standard used across the authoring ecosystem this skill came
+> from, so it is the standard here. The portable, non-negotiable core is **"always carry the
+> link + access date"** (rule 1) — that is what makes a citation verifiable. The *structure* is
+> a convention: if a project prefers another style (IEEE, APA, plain link + accessed-on), it may
+> pin that instead, keeping rule 1. Don't sell ABNT as neutral; do keep the always-the-link rule.
+
+## The two iron rules
+
+1. **Always the link.** Every reference to anything with a URL (paper, blog, vendor doc, repo, standard) includes the URL and the access date. A citation without its link is not verifiable — it is hearsay. (For a print-only book with no online edition, the link is omitted; everything else carries it.)
+2. **ABNT NBR 6023 structure, labels in the doc language.** Author surnames in CAPS, title in **bold**, an ISO access date — these are invariant. The connective labels localize to the pinned doc language: **English** (default) → `Available at: <URL>. Accessed on: 2026-06-15.`; **Portuguese** (NBR native) → `Disponível em: <URL>. Acesso em: 2026-06-15.`. Don't mix languages within a corpus — the format is always NBR; only the labels follow `rules/doc-language.md`. The examples below use the English (default) labels.
+
+## Templates by source type
+
+- **Book** — `SURNAME, First name. **Title**: subtitle. Edition. City: Publisher, year.`
+  > FEATHERS, Michael. **Working Effectively with Legacy Code**. Upper Saddle River: Prentice Hall, 2004.
+
+- **Paper / preprint (online)** — `SURNAME, First name et al. **Title**. Year. Available at: <URL>. Accessed on: YYYY-MM-DD.`
+  > ALSHAHWAN, Nadia et al. **Automated Unit Test Improvement using Large Language Models at Meta**. 2024. Available at: https://arxiv.org/abs/2402.09171. Accessed on: 2026-06-15.
+
+- **Blog post / online article** — `SURNAME, First name. **Article title**. Site name, year. Available at: <URL>. Accessed on: YYYY-MM-DD.`
+  > GAUTHIER, Paul. **Separating code reasoning and editing**. Aider, 2024. Available at: https://aider.chat/2024/09/26/architect.html. Accessed on: 2026-06-15.
+
+- **Vendor / institutional doc (no personal author)** — `ORGANIZATION. **Title**. Year. Available at: <URL>. Accessed on: YYYY-MM-DD.`
+  > ANTHROPIC. **Building Effective Agents**. 2024. Available at: https://www.anthropic.com/research/building-effective-agents. Accessed on: 2026-06-15.
+
+- **Source code / repository** — `AUTHOR/ORG. **Repository name**. Year. Available at: <URL>. Accessed on: YYYY-MM-DD.`
+
+## Rules
+
+1. **Alphabetical by first element** (author surname or organization) within `# References`.
+2. **One entry per source.** If the same source is cited many times in the body, it appears once in `# References`.
+3. **Access date is the day you verified it** — not the publication date. When a primary URL was unreachable (e.g. HTTP 403) and the claim was triangulated, say so in the entry (`(verified via secondary sources)` / `(exact URL not captured — unverified)`) rather than implying you read the original. Never fabricate a link.
+4. **Append-only with the doc** — research is dated evidence (the living-docs maintenance invariant). When a source is superseded, annotate; do not silently rewrite a citation.
+5. In-body, refer to a source by `(SURNAME, year)` or a short marker; the full entry lives once under `# References`.
+
+Load `okf-knowledge-format` for the `# References` heading placement (§8); this file governs the *format of each entry*.

--- a/plugins/living-docs-enforcer/skills/rules/constitution-conventions.md
+++ b/plugins/living-docs-enforcer/skills/rules/constitution-conventions.md
@@ -1,0 +1,34 @@
+# Constitution Conventions
+
+The Product Constitution is the **foundational source of truth** for a project: what the product is, what it is not, the data model it is built on, and the invariants that hold in all circumstances. Every other document in the doc trail sits under it and must be consistent with it.
+
+The doc trail flows: **constitution → PRD → ADR + BDR → issues → code**.
+
+## Format
+
+The constitution is an **OKF concept** (`type: Constitution`) — see the `okf-knowledge-format` skill. `status` (`Draft` | `Ratified` | `Amended`) lives in the frontmatter, not a body line. See `templates/constitution.md`. Core sections:
+
+- **Product** — the core value and the audience in one or two sentences. The north star.
+- **Scope boundaries** — what is in scope, what is explicitly out, and what defers to which phase.
+- **Data model / schema foundation** — the core entities and relationships as a Mermaid diagram, with prose describing invariants.
+- **Non-negotiables** — constraints that hold regardless of feature, phase, or implementation. Each must be falsifiable.
+- **Amendment log** — dated amendments appended below the original content; sections above are immutable once ratified.
+
+## Rules
+
+1. **One per project.** The constitution lives at `docs/constitution.md`. There is no NNNN prefix and it is not listed as a concept in any `index.md` — it is singular, the bundle's root of trace.
+2. **PRDs sit under the constitution; they never replace it.** A PRD specifies a feature or capability within the scope the constitution defines. If a PRD requires expanding that scope, the constitution must be amended first.
+3. **Only foundational scope or schema shifts amend the constitution.** Adding a feature does not amend the constitution. Changing what the product fundamentally is, who it is for, or what its core data model looks like does.
+4. **Append-only once ratified.** After the constitution is ratified, changes are recorded as dated Amendment sections at the bottom (`## Amendment N — YYYY-MM-DD: <summary>`). The original sections above are never silently edited.
+5. **Diagrams are Mermaid only.** No ASCII art, no image attachments.
+6. **Non-negotiables are falsifiable.** "Be secure" is not a non-negotiable. "All user data at rest is encrypted with AES-256" is.
+7. **The constitution is the root of the trace.** When reviewing any PRD, ADR, BDR, or issue, the chain should resolve back to the constitution. Work that cannot be traced to the constitution is out of scope.
+8. **The doc language is a non-negotiable.** If the user has declared a documentation language (default English otherwise), pin it here as a non-negotiable line so it survives across sessions — see `rules/doc-language.md`.
+
+## Anti-patterns
+
+- Writing a constitution per feature instead of per project. One project, one constitution.
+- A PRD that implicitly changes scope without amending the constitution first — the constitution and PRD are then contradictory.
+- Treating the constitution as a living editable document after ratification. Silent edits break the paper trail; amend instead.
+- Non-negotiables that are aspirational rather than falsifiable — they provide no enforcement anchor.
+- An empty Scope Boundaries section. If the out-of-scope items are not named, scope is undefined and PRDs will drift.

--- a/plugins/living-docs-enforcer/skills/rules/doc-language.md
+++ b/plugins/living-docs-enforcer/skills/rules/doc-language.md
@@ -1,0 +1,34 @@
+# Documentation Language
+
+The language of the doc corpus is a **project-wide non-negotiable**, not a per-file choice. Pick it once, pin it, follow it everywhere.
+
+## The rule
+
+1. **Default is English.** If the user has not declared a documentation language, author every doc — constitution, PRD, ADR, BDR, issues, research, `# References` prose — in **English**. This keeps the corpus portable and matches the default tooling/templates.
+2. **The user may override at session start.** When the user names a documentation language while using the harness (e.g. "docs em português", "documentação em espanhol"), that language governs **all** docs from then on — not just the file in front of you.
+3. **Pin it the moment it's chosen.** A declared language is a standing rule, so record it where it survives across sessions (re-read from disk, per the compaction model):
+   - If the project has a **constitution**, add the language as a non-negotiable line there (`rules/constitution-conventions.md`).
+   - If there is no constitution yet, write it into the **project guide** hard-rules section (`CLAUDE.md` or equivalent, via `templates/claude-hard-rules.md`).
+   Once pinned, follow it without re-asking; the user does not have to repeat the choice every session.
+4. **Never mix.** One corpus, one language. Don't write the PRD in one language and its ADRs in another. If the pinned language changes, that is a normal supersede event — new docs in the new language, old docs left as frozen history (invariant 4).
+
+Terms and acronyms get their explanation in the pinned language — but the **name/headword stays as-is** — in the glossary; see `rules/glossary-conventions.md`.
+
+## What stays language-invariant
+
+These do **not** translate — they are structural identifiers, not prose:
+
+- OKF frontmatter **keys** (`type`, `status`, `title`, …) and their controlled values (`type: ADR`, `status: Superseded`).
+- The `# References` **heading** itself (OKF §8 reserved heading) and reserved filenames (`index.md`, `log.md`).
+- Code, identifiers, slugs, and the ABNT NBR 6023 **structure** of each reference (CAPS surnames, **bold** title, ISO access date, always-the-link).
+
+## Citations follow the doc language
+
+The reference *structure* is fixed (NBR 6023), but the connective **labels** localize to the pinned language — see `rules/citation-conventions.md`:
+
+| Doc language | URL label | Date label |
+|---|---|---|
+| English (default) | `Available at:` | `Accessed on:` |
+| Portuguese (NBR native) | `Disponível em:` | `Acesso em:` |
+
+For any other pinned language, use that language's natural equivalents; the structure never changes.

--- a/plugins/living-docs-enforcer/skills/rules/glossary-conventions.md
+++ b/plugins/living-docs-enforcer/skills/rules/glossary-conventions.md
@@ -1,0 +1,37 @@
+# Glossary Conventions
+
+The glossary is the project's single home for the **definition of every term and acronym** its docs use. It lives in the context bundle at `docs/context/glossary.md` (split into grouped files via `rules/semantic-index.md` once it outgrows ~200 lines). One term, one entry — every other doc *links* to the glossary instead of redefining.
+
+## What goes in
+
+- **Domain & product terms** the docs assume (the nouns of the system).
+- **Engineering / methodology terms** that aren't common knowledge on the team (e.g. *characterization test*, *walking skeleton*, *mutation score*).
+- **Acronyms & initialisms** (ADR, BDR, PRD, OKF, CC, …).
+
+Leave out words any reader of the doc language already knows, and don't restate a definition that has a clearer home — link to it instead.
+
+## Acronyms — headword as-is, expanded + explained in the doc language
+
+1. **The headword is the acronym verbatim** — `ADR`, not `Architecture Decision Record (ADR)`. The abbreviation is what readers meet in the text, so it is the lookup key.
+2. **Every acronym entry carries its expansion *and* a one-line definition.** The expansion may stay a proper noun in its original language (e.g. `OKF — Open Knowledge Format`); the **definition/explanation is written in the project doc language** (→ `rules/doc-language.md`, default English).
+3. In a body doc, spell it out **once** on first use with the acronym in parentheses — `Architecture Decision Record (ADR)` — then use the acronym; the glossary is the durable home.
+
+## Language (follows the doc-language rule)
+
+- **Definitions are in the project doc language** — default English, or whatever is pinned per `rules/doc-language.md`.
+- **Names stay in their original form.** You do not translate `TaskEnvelope`, `ADR`, or `OKF`. Translate the *explanation*, never the *name*, the *identifier*, or the *acronym headword/expansion*.
+
+## Format & order
+
+- One entry per term: **headword** · (expansion, for acronyms) · definition (doc language) · optional *See also* cross-links.
+- **Alphabetical by headword** for a flat glossary; **semantically grouped** (with an index) once it splits — the same machinery as the context vocabulary (`rules/semantic-index.md`).
+- Start from `templates/glossary.md`.
+
+## One home (no drift)
+
+- A term is defined **once**, in the glossary. ADRs/PRDs/BDRs/issues that use it **link** to its glossary entry; they never carry a competing definition (the one-home-per-fact invariant).
+- Vocabulary is **live**, not append-only: when a term's meaning changes, edit the entry and fix any now-wrong usages in the same change (don't supersede — that rule is for *decisions*, not definitions).
+
+## Relationship to the context index
+
+The glossary is part of the **context bundle** — it is the term/acronym layer of the domain & module vocabulary, not a second vocabulary. A small project keeps a single `docs/context/glossary.md`; a large vocabulary splits into grouped context files with the glossary as their alphabetical entry point. Either way there is exactly one home per term.

--- a/plugins/living-docs-enforcer/skills/rules/issue-workflow.md
+++ b/plugins/living-docs-enforcer/skills/rules/issue-workflow.md
@@ -1,0 +1,33 @@
+# Issue Workflow (docs-first)
+
+Issues are authored **in the repo first**, then published to the tracker. The repo file is the source of truth; the tracker entry is a mirror that must stay byte-identical in body. Each issue is an **OKF concept** (`type: Issue`) — see the `okf-knowledge-format` skill.
+
+## The workflow
+
+1. **Create** — write `docs/issues/NNNN-slug.md`: OKF frontmatter (`type`, `title`, `status`, `labels`, `blocked_by`, `tracker`) followed by the issue **body**. Add a row to `docs/issues/index.md`. *Then* publish to the tracker, stripping the frontmatter so only the body is sent (e.g. pipe the content below the closing `---` to `gh issue create --body-file -`).
+2. **Edit** — update the body file first, then push to the tracker (`gh issue edit <n> --body-file …`, frontmatter stripped).
+3. **Identical bodies** — the repo file's body (everything below the closing `---`) and the tracker issue body must match exactly. If they diverge, the repo wins; re-sync. Frontmatter is repo-only.
+4. **Metadata lives in frontmatter** — number, title, labels, blocked-by, status, and tracker number live in the issue file's **frontmatter** (and are mirrored into the `docs/issues/index.md` listing), *not* in the body. The body is portable prose; the frontmatter carries the tracker-specific fields.
+5. **Prefer editing the body over adding comments** — so each issue keeps a single, coherent source of truth rather than a scattered comment thread.
+
+See `templates/issue.md` for the body skeleton.
+
+## Body structure
+
+A good issue body states, in order:
+
+- **What / Why** — the change and its motivation. If it implements a PRD or ADR, link it ("Implements ADR NNNN").
+- **Scope** — what's included; for removals/refactors, what's explicitly kept.
+- **Acceptance** — observable, testable conditions for "done".
+- **Plan** — a short outline (and slicing, for large tasks) so a reader knows the approach.
+
+## Rules
+
+1. **Number consistently** with the project's scheme; index every issue.
+2. **Link bidirectionally** — body links to its PRD/ADR; the PRD/ADR's decision log or the issue index links back.
+3. **Closing keywords** belong in the PR that resolves the issue (`Closes #NN`), not scattered in the body.
+4. **Historical issue bodies are not rewritten** when superseded — set the frontmatter `status` (e.g. `superseded`) and annotate the `index.md` row, leaving the body as closed history.
+
+## Why docs-first
+
+A tracker is an external system that can change auth, API, or vendor. The repo is durable, diffable, and reviewable in the same PR as the code. Authoring in the repo means the issue is versioned alongside the work it describes, and the body survives any tracker migration.

--- a/plugins/living-docs-enforcer/skills/rules/maintenance-invariant.md
+++ b/plugins/living-docs-enforcer/skills/rules/maintenance-invariant.md
@@ -1,0 +1,47 @@
+# Maintenance Invariant (no-drift)
+
+The rule that keeps docs *living*: **no structural change ships without its doc, and no doc exists without being indexed.** Code, docs, and indexes stay in sync within the *same* change — never "documented later."
+
+## The invariant, stated for the project guide
+
+Paste a project-specific version of this into the project guide (`CLAUDE.md` / `README.md`) as a mandatory section:
+
+> **Maintenance rule (mandatory).** Whenever the project structure changes (new directory, moved/renamed files, a new top-level component) or a new doc is generated:
+>
+> 1. **Document the change** — create or update the relevant file under `docs/` (as an OKF concept: frontmatter with a non-empty `type`).
+> 2. **Update the indexes** — add the doc to the bundle-root `docs/index.md` and to its directory `index.md` listing.
+> 3. **Update architecture docs** — whenever the schema, data flow, module layout, or a component relationship changes, update the relevant diagram(s) in the same change. Diagrams must never drift from the code.
+> 4. **Update the context index** — whenever a new module or domain concept is named, add it to the vocabulary so naming stays consistent across code, docs, and reviews.
+>
+> No structural change ships without its doc, and no doc exists without being indexed.
+
+Adapt the specifics (diagram tooling, context index location) to the project. The invariant does not change.
+
+## What counts as a structural change
+
+- New directory, module, or top-level component.
+- Moved, renamed, or deleted files that other docs reference.
+- Schema change, new data flow, changed module boundary.
+- A new domain concept being named in code.
+- A new doc of any type (ADR/PRD/issue/research) being created.
+
+## The checklist (run before declaring a task done)
+
+- [ ] Did this change add/move/rename a file another doc points to? → update those pointers.
+- [ ] Did it name a new concept? → add it to the context index.
+- [ ] Did it change schema/data flow/module layout? → update the architecture diagram(s).
+- [ ] Did it create a new doc? → give it OKF frontmatter (`type`), then link it from its directory `index.md` *and* the bundle-root `docs/index.md`.
+- [ ] Did it change a decision? → supersede the ADR via frontmatter `status`/`superseded_by` (don't rewrite it).
+- [ ] Do all index links still resolve? (prefer bundle-relative `/…` links)
+
+## The instrument (don't eyeball what a script can check)
+
+The orphan, broken-link, untyped-doc, and supersede checks in the list above are mechanical —
+run them, don't re-read prose. `scripts/lint-docs.sh <docs/>` validates them and exits non-zero
+on any violation; wire it into the project's CI/quality gate so a structural PR with a docs
+violation cannot merge. *A constraint without an instrument is a vibe.* The stale-diagram and
+one-home-per-fact checks have no sound oracle and stay a reviewer judgement.
+
+## Why same-change, not later
+
+A doc update deferred to "later" is a doc update that never happens — and the gap between code and docs is exactly where the next person gets misled. Coupling the doc to the change that caused it is the only mechanism that survives turnover and time pressure. The reviewer enforces it: a structural PR with no doc delta is incomplete.

--- a/plugins/living-docs-enforcer/skills/rules/prd-conventions.md
+++ b/plugins/living-docs-enforcer/skills/rules/prd-conventions.md
@@ -1,0 +1,36 @@
+# PRD Conventions
+
+A Product Requirements Document specifies **one** feature or capability: the problem it solves, who it's for, what "done" means, and what is explicitly out of scope. A PRD answers *what and why*; the ADRs and issues it spawns answer *how*.
+
+## Format
+
+Each PRD is an **OKF concept** (`type: PRD`) — see the `okf-knowledge-format` skill. `status` (`Draft` | `Accepted` | `Implemented` | `Superseded`) lives in the frontmatter, not a body line. See `templates/prd.md`. Core sections:
+
+- **Problem / Motivation** — the user or system pain. Lead with the problem, not the solution. If you can't state the problem without naming a solution, grill it first (`grill-me`).
+- **Goals** — what success looks like, as outcomes (not tasks).
+- **Non-goals** — what this explicitly does *not* cover. The most valuable section: it bounds scope and prevents creep.
+- **Requirements** — numbered, testable statements. Each maps to acceptance criteria.
+- **Acceptance criteria** — observable conditions that prove the requirement is met.
+- **Open questions** — unresolved decisions, each ideally headed toward an ADR.
+- **Decision log** — links to the ADRs that resolved the open questions.
+
+## Relationship to the constitution
+
+A PRD sits **under** the constitution — it specifies a feature within the product's established principles and constraints. A PRD never replaces or overrides the constitution. If a PRD requires a change at constitution level, resolve that separately before accepting the PRD.
+
+## Rules
+
+1. **One capability per PRD.** Number sequentially: `docs/prd/NNNN-slug.md`. Index in `docs/prd/index.md` (OKF reserved listing, no frontmatter).
+2. **Problem before solution.** A PRD that opens with the implementation has skipped the thinking. Restate the underlying problem first.
+3. **Non-goals are mandatory.** An empty Non-goals section means scope is undefined. Name at least what tempting-but-excluded things are out.
+4. **Requirements are testable.** "The system should be fast" is not a requirement. "Search returns in <200ms at p95" is.
+5. **Success metrics are mandatory.** Each PRD must state how success will be measured after delivery — quantified outcomes (not task completion) that would confirm the problem is solved.
+6. **Append-only once accepted.** A PRD under active design is editable. Once accepted and being implemented, changes are recorded as amendments or new ADRs — not silent edits to the requirements.
+7. **PRDs spawn issues.** Each requirement becomes one or more issues (see `rules/issue-workflow.md`). The PRD links to them; the issues link back to the PRD.
+8. **Open questions resolve into ADRs (how) or BDRs (behavior).** When an open question is answered with a load-bearing rationale about architecture, write an ADR and link it from the decision log. When the question resolves observable behavior — what the system must do, with Given/When/Then scenarios — write or amend a BDR instead. Both artifact types are spawned by the PRD and link back to it.
+
+## Anti-patterns
+
+- A PRD that is a task list. Tasks are issues; the PRD is the spec they serve.
+- No acceptance criteria — then "done" is a matter of opinion.
+- Editing accepted requirements in place when scope changes — amend or supersede so the history of what was agreed survives.

--- a/plugins/living-docs-enforcer/skills/rules/semantic-index.md
+++ b/plugins/living-docs-enforcer/skills/rules/semantic-index.md
@@ -1,0 +1,35 @@
+# Semantic Index Organization
+
+Documentation is organized by **meaning, not by accident of growth**. When a body of knowledge is large, it is split into semantically coherent files, each with a single concern, all reachable from one index. The index is the entry point; the group files are the content.
+
+This applies to any large doc — most commonly the domain/module **context** (vocabulary), but equally to research, ADR collections, or any directory that accumulates files.
+
+## The indexing contract
+
+1. **Every directory has an `index.md`** — the OKF reserved directory listing (§6), for collections (ADRs/issues/research) and split single docs (context) alike. It lists every file with a one-line description and carries **no frontmatter** (the sole exception: the bundle-root `docs/index.md`, which may declare `okf_version: "0.1"`).
+2. **Every file is reachable from an index, and from the bundle-root `docs/index.md`** linked by the project guide. No orphans.
+3. **One concept, one file.** Each group file owns a coherent slice of the vocabulary or content. A concept appears in exactly one group file; other files cross-reference it. Every group/concept file opens with OKF frontmatter carrying a non-empty `type`.
+4. **The index carries no content** — only intro framing + a table/list of pointers. Content lives in the group files, never duplicated into the index.
+5. **Links resolve.** Every pointer in an index points to a file that exists; prefer bundle-relative (`/…`) links. Check after every split or move.
+
+## When and how to split a large doc
+
+Split when a doc passes ~200 lines or starts mixing unrelated concerns.
+
+1. **Map sections → groups.** Lay out a source map: each section of the old file → exactly one new group file. Decide group boundaries by *meaning* (write-path vs read-path, domain concepts vs storage shapes), not by length.
+2. **Content-preserving move.** Move vocabulary verbatim. Do not reword, add, or drop terms during a split — that conflates two changes and makes the diff unreviewable. Reword in a *separate* later change if needed.
+3. **One concept lands once.** If two sections discuss the same concept, pick its home and cross-reference from the other.
+4. **Build the index** — intro paragraph + a TOC table linking every group file with a one-line description. See `templates/context-index.md`.
+5. **Cut over.** Repoint the live pointers (project guide's Docs index, maintenance rules) to the new index. Delete the old monolith. Leave *historical* mentions (in ADR/issue "Consequences") untouched — they are history.
+6. **Completeness review.** Diff the old content against the union of new files: every term present exactly once, nothing lost or duplicated, all index links resolve, old file removed.
+
+## Heading discipline
+
+Each group file is a standalone document: it leads with a single `#` H1 title, then `##` sections. Do not carry over `##`-as-top-level headings from the section you extracted — promote them to H1 so the file reads as its own document.
+
+## Anti-patterns
+
+- An index that duplicates content from the group files — now there are two homes and they will drift.
+- Splitting by line count into arbitrary "part 1 / part 2" files instead of by meaning.
+- Rewording vocabulary during a split — bundles two changes, breaks the content-preserving guarantee.
+- A group file with two unrelated concerns because "it was already there."

--- a/plugins/living-docs-enforcer/skills/scripts/lint-docs.sh
+++ b/plugins/living-docs-enforcer/skills/scripts/lint-docs.sh
@@ -1,0 +1,484 @@
+#!/usr/bin/env bash
+#
+# lint-docs.sh — mechanically validate the Living Docs invariants on a docs bundle.
+#
+# The five invariants are a contract. Three of them are mechanical and should be
+# checked by a machine, not by an agent re-reading prose ("a constraint without an
+# instrument is a vibe"). This script is that instrument. It checks:
+#
+#   - Indexed or it doesn't exist (invariant 3): every concept file is listed in its
+#     directory's index.md, and every directory index is reachable from the bundle root.
+#   - Links resolve (invariants 2/3): every bundle-relative / relative link to a local
+#     file points at a file that exists.
+#   - Supersede, never rewrite (invariant 4): a Superseded record carries superseded_by,
+#     and the target exists.
+#   - OKF format: every non-reserved doc opens with frontmatter carrying a non-empty
+#     `type`; index.md/log.md carry no frontmatter (except the bundle-root index.md,
+#     which may declare okf_version).
+#
+# Invariants 1 (docs-first mirror) and 2's "one home per fact" semantic half are NOT
+# mechanical — they stay with the reviewing agent. This script never claims to check them.
+#
+# Usage:  lint-docs.sh [BUNDLE_ROOT]      (default: docs)
+#         lint-docs.sh --ratchet <baseline-ref> [BUNDLE_ROOT]
+#         lint-docs.sh --help
+#
+# Default (whole-bundle) mode:
+#   Exit 0 = clean, 1 = ANY violation, 2 = usage / bundle-not-found error.
+#
+# --ratchet <baseline-ref> mode (diff-aware):
+#   Lint the current bundle AND the bundle as of <baseline-ref> (a git ref), then
+#   exit 1 ONLY for violations present now that were ABSENT at baseline (NEW debt
+#   introduced by the change). Pre-existing violations are printed as informational
+#   "(pre-existing)" lines and do NOT fail the run — legacy debt is not held against
+#   the change. This mirrors the diff-aware ratchet the repo's other gates use:
+#   only NEW violations block; pre-existing debt is grandfathered.
+#
+#   These checks are whole-bundle (index reachability, orphan membership, link
+#   resolution, supersede integrity) — they are NOT file-local, so "lint only the
+#   touched files" cannot work. The ratchet therefore compares violation SETS, not
+#   files. The baseline bundle is materialized with `git worktree add` (robust for
+#   a whole directory) and removed afterward. Baseline ref absent / not a git repo /
+#   bundle missing at baseline → the baseline set is treated as EMPTY, so every
+#   current violation is considered NEW (fail-closed, documented in --help).
+
+set -uo pipefail
+
+if [[ -z "${BASH_VERSINFO:-}" || "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+	echo "lint-docs.sh requires bash 4+ (you have ${BASH_VERSION:-unknown}). On macOS: brew install bash." >&2
+	exit 2
+fi
+
+PROG="${0##*/}"
+
+usage() {
+	cat <<EOF
+$PROG — validate the mechanical Living Docs invariants on a docs bundle.
+
+Usage:
+  $PROG [BUNDLE_ROOT]               Lint the bundle (default: ./docs)
+  $PROG --ratchet <ref> [BUNDLE]    Diff-aware: fail only on NEW violations vs <ref>
+  $PROG --help                      Show this help
+
+Checks (mechanical invariants only):
+  * frontmatter      every non-reserved .md opens with frontmatter + non-empty type
+  * index format     index.md / log.md carry no frontmatter (bundle-root index.md
+                     may declare okf_version)
+  * directory index  every concept file is listed in its own directory's index.md
+  * reachable        every directory index.md is reachable from the bundle-root index.md
+  * links resolve    every local (/… or relative) markdown link points at a file
+  * supersede        a 'status: Superseded' record carries a resolvable superseded_by
+
+Diff-aware ratchet (--ratchet <baseline-ref>):
+  Lints the current bundle and the bundle as of <baseline-ref> (a git ref), and
+  fails (exit 1) ONLY for violations present now that were absent at the baseline —
+  i.e. NEW debt introduced by the change. Pre-existing violations are printed as
+  "(pre-existing)" and do NOT fail the run; a change that adds no new violation
+  passes even if the bundle carries legacy debt. The baseline is materialized with
+  'git worktree add'. If <baseline-ref> is absent, the tree is not a git repo, or
+  the bundle does not exist at the baseline, the baseline is treated as empty
+  (every current violation counts as NEW — fail-closed).
+
+  These checks are whole-bundle, not file-local, so the ratchet compares violation
+  SETS rather than touched files. One CLI enforced at the git boundary (pre-commit)
+  and in CI (a reusable Action) is harness-agnostic: it covers every AI harness AND
+  human commits with one mechanism, instead of a per-harness plugin.
+
+Exit: 0 clean (or no new violations) · 1 violations (or new violations) · 2 usage error.
+EOF
+}
+
+# --- argument parsing -------------------------------------------------------
+
+RATCHET=0
+BASELINE_REF=""
+
+case "${1:-}" in
+	-h | --help)
+		usage
+		exit 0
+		;;
+	--ratchet)
+		RATCHET=1
+		BASELINE_REF="${2:-}"
+		if [[ -z "$BASELINE_REF" ]]; then
+			echo "$PROG: --ratchet requires a <baseline-ref> argument" >&2
+			echo "       e.g. $PROG --ratchet HEAD docs" >&2
+			exit 2
+		fi
+		BUNDLE="${3:-docs}"
+		;;
+	*)
+		BUNDLE="${1:-docs}"
+		;;
+esac
+
+BUNDLE="${BUNDLE%/}"
+
+if [[ ! -d "$BUNDLE" ]]; then
+	echo "$PROG: bundle root not found: $BUNDLE" >&2
+	echo "       run from the repo root, or pass the docs directory: $PROG path/to/docs" >&2
+	exit 2
+fi
+
+# --- violation collection ---------------------------------------------------
+#
+# report() does double duty: it prints the human-readable line (as before) and,
+# when capturing for the ratchet, appends a NORMALIZED line to VIOL_LINES so the
+# same violation matches across two different worktrees. Normalization strips the
+# bundle-root prefix from the file path, so 'docs/adr/x.md' and
+# '/tmp/wt.../docs/adr/x.md' compare equal — the comparison key is
+# "<relpath-within-bundle>\t<message>".
+
+VIOLATIONS=0
+QUIET=""
+declare -a VIOL_LINES=()
+report() {
+	# report <file> <message>
+	[[ "$QUIET" != "quiet" ]] && printf '  %-44s %s\n' "$1" "$2"
+	VIOLATIONS=$((VIOLATIONS + 1))
+	# normalized key: drop the bundle prefix so paths are bundle-relative
+	local rel="$1"
+	rel="${rel#"$BUNDLE"/}"
+	rel="${rel#"$BUNDLE"}"
+	VIOL_LINES+=("$rel	$2")
+}
+
+# --- helpers ----------------------------------------------------------------
+
+is_reserved() { # is_reserved <basename>
+	[[ "$1" == "index.md" || "$1" == "log.md" ]]
+}
+
+has_frontmatter() { # has_frontmatter <file>  → 0 if first line is '---'
+	[[ "$(head -n 1 "$1")" == "---" ]]
+}
+
+fm_value() { # fm_value <file> <key>  → prints trimmed value within frontmatter block
+	awk -v key="$2" '
+		NR == 1 && $0 != "---" { exit }
+		NR == 1 { infm = 1; next }
+		infm && $0 == "---" { exit }
+		infm {
+			if ($0 ~ "^" key ":") {
+				sub("^" key ":[[:space:]]*", "")
+				gsub(/^[[:space:]]+|[[:space:]]+$/, "")
+				gsub(/^"|"$/, "")
+				print
+				exit
+			}
+		}
+	' "$1"
+}
+
+# Normalize a path: collapse '.' and '..' segments. Pure bash (portable).
+normpath() { # normpath <path>  → prints normalized path
+	local path="$1" abs="" seg out=()
+	[[ "$path" == /* ]] && abs="/"
+	local IFS=/
+	for seg in $path; do
+		case "$seg" in
+			"" | .) ;;
+			..)
+				if ((${#out[@]} > 0)) && [[ "${out[$((${#out[@]} - 1))]}" != ".." ]]; then
+					unset "out[$((${#out[@]} - 1))]"
+				elif [[ -z "$abs" ]]; then
+					out+=("..")
+				fi
+				;;
+			*) out+=("$seg") ;;
+		esac
+	done
+	local joined="${out[*]}"
+	printf '%s%s\n' "$abs" "$joined"
+}
+
+# Resolve a markdown link target (as written in <file>) to a filesystem path,
+# or print nothing if the link is external / a pure anchor / unsupported.
+resolve_link() { # resolve_link <file> <target>
+	local file="$1" target="$2"
+	target="${target%%#*}"      # drop anchor
+	[[ -z "$target" ]] && return        # pure anchor → in-doc, skip
+	case "$target" in
+		*://* | mailto:* | tel:*) return ;;   # external
+	esac
+	if [[ "$target" == /* ]]; then
+		# bundle-relative
+		normpath "$BUNDLE/$target"
+	else
+		normpath "$(dirname "$file")/$target"
+	fi
+}
+
+# Print every markdown link target in <file> (the bit inside the parentheses).
+links_in() { # links_in <file>
+	grep -oE '\]\([^)]+\)' "$1" 2>/dev/null | sed -E 's/^\]\(//; s/\)$//'
+}
+
+# --- the lint body, as a function so it can run against two trees ------------
+#
+# lint_run <bundle> [quiet]
+#   Lints <bundle>, appending normalized violations to the (caller-owned)
+#   VIOL_LINES array and bumping VIOLATIONS. When the second arg is "quiet" the
+#   per-violation human lines and the "bundle: …" header are suppressed (used for
+#   the baseline tree in ratchet mode — we only need its violation SET). Resets
+#   VIOLATIONS / VIOL_LINES at entry so it is safe to call twice.
+
+lint_run() { # lint_run <bundle> [quiet]
+	BUNDLE="${1%/}"
+	QUIET="${2:-}"
+	VIOLATIONS=0
+	VIOL_LINES=()
+
+	local ALL_MD ALL_INDEX ROOT_INDEX
+	mapfile -t ALL_MD < <(find "$BUNDLE" -type f -name '*.md' | sort)
+	ROOT_INDEX="$BUNDLE/index.md"
+
+	if [[ "$QUIET" != "quiet" ]]; then
+		echo "Living Docs lint — bundle: $BUNDLE"
+		echo
+	fi
+
+# --- check 1: bundle-root index exists --------------------------------------
+
+if [[ ! -f "$ROOT_INDEX" ]]; then
+	report "$ROOT_INDEX" "missing bundle-root index.md (invariant 3)"
+fi
+
+# --- per-file checks: frontmatter / type / index format ---------------------
+
+for f in "${ALL_MD[@]}"; do
+	base="${f##*/}"
+	if is_reserved "$base"; then
+		# index.md / log.md: no frontmatter, except bundle-root index.md (okf_version)
+		if has_frontmatter "$f"; then
+			if [[ "$f" == "$ROOT_INDEX" ]]; then
+				okf="$(fm_value "$f" okf_version)"
+				[[ -z "$okf" ]] && report "$f" "bundle-root index.md frontmatter lacks okf_version"
+			else
+				report "$f" "$base must not carry frontmatter (OKF §6)"
+			fi
+		fi
+		continue
+	fi
+	# non-reserved concept file: must have frontmatter with a non-empty type
+	if ! has_frontmatter "$f"; then
+		report "$f" "missing OKF frontmatter (needs a non-empty 'type')"
+		continue
+	fi
+	type_val="$(fm_value "$f" type)"
+	if [[ -z "$type_val" ]]; then
+		report "$f" "frontmatter has no non-empty 'type'"
+	fi
+done
+
+# --- check: every concept file is listed in its directory's index.md --------
+# The bundle-root constitution.md is the root of trace and is deliberately NOT indexed.
+
+for f in "${ALL_MD[@]}"; do
+	base="${f##*/}"
+	is_reserved "$base" && continue
+	[[ "$f" == "$BUNDLE/constitution.md" ]] && continue
+
+	dir="$(dirname "$f")"
+	dir_index="$dir/index.md"
+	if [[ ! -f "$dir_index" ]]; then
+		report "$f" "no index.md in its directory ($dir) — orphan (invariant 3)"
+		continue
+	fi
+	listed=0
+	while IFS= read -r tgt; do
+		resolved="$(resolve_link "$dir_index" "$tgt")"
+		[[ -z "$resolved" ]] && continue
+		if [[ "$(normpath "$f")" == "$resolved" ]]; then
+			listed=1
+			break
+		fi
+	done < <(links_in "$dir_index")
+	((listed == 0)) && report "$f" "not listed in $dir_index — orphan (invariant 3)"
+done
+
+# --- check: every directory index.md is reachable from the bundle root ------
+# BFS from the root index over index→index (and index→dir) links.
+
+if [[ -f "$ROOT_INDEX" ]]; then
+	mapfile -t ALL_INDEX < <(find "$BUNDLE" -type f -name 'index.md' | sort)
+	declare -A REACHED=()
+	queue=("$(normpath "$ROOT_INDEX")")
+	REACHED["$(normpath "$ROOT_INDEX")"]=1
+	while ((${#queue[@]} > 0)); do
+		cur="${queue[0]}"
+		queue=("${queue[@]:1}")
+		[[ -f "$cur" ]] || continue
+		while IFS= read -r tgt; do
+			resolved="$(resolve_link "$cur" "$tgt")"
+			[[ -z "$resolved" ]] && continue
+			# a link may point at a directory (→ its index.md) or directly at an index.md
+			if [[ -d "$resolved" ]]; then
+				resolved="$(normpath "$resolved/index.md")"
+			fi
+			[[ "${resolved##*/}" == "index.md" ]] || continue
+			if [[ -z "${REACHED[$resolved]:-}" ]]; then
+				REACHED["$resolved"]=1
+				queue+=("$resolved")
+			fi
+		done < <(links_in "$cur")
+	done
+	for idx in "${ALL_INDEX[@]}"; do
+		n="$(normpath "$idx")"
+		[[ -z "${REACHED[$n]:-}" ]] && report "$idx" "directory index not reachable from $ROOT_INDEX (invariant 3)"
+	done
+fi
+
+# --- check: every local link resolves ---------------------------------------
+
+for f in "${ALL_MD[@]}"; do
+	while IFS= read -r tgt; do
+		resolved="$(resolve_link "$f" "$tgt")"
+		[[ -z "$resolved" ]] && continue
+		if [[ ! -e "$resolved" ]]; then
+			report "$f" "broken link → $tgt"
+		fi
+	done < <(links_in "$f")
+done
+
+# --- check: supersede integrity (invariant 4) -------------------------------
+
+for f in "${ALL_MD[@]}"; do
+	base="${f##*/}"
+	is_reserved "$base" && continue
+	has_frontmatter "$f" || continue
+	status="$(fm_value "$f" status)"
+	# case-insensitive compare (portable to bash without ${,,})
+	status_lc="$(printf '%s' "$status" | tr '[:upper:]' '[:lower:]')"
+	if [[ "$status_lc" == "superseded" ]]; then
+		sb="$(fm_value "$f" superseded_by)"
+		if [[ -z "$sb" ]]; then
+			report "$f" "status: Superseded but superseded_by is empty (invariant 4)"
+			continue
+		fi
+		# resolve superseded_by (an NNNN) to a sibling file with that number prefix
+		dir="$(dirname "$f")"
+		if ! compgen -G "$dir/${sb}-*.md" >/dev/null && [[ ! -f "$dir/${sb}.md" ]]; then
+			report "$f" "superseded_by: $sb has no matching record in $dir (invariant 4)"
+		fi
+	fi
+done
+
+	LAST_MD_COUNT="${#ALL_MD[@]}"
+}
+
+# --- driver -----------------------------------------------------------------
+
+if ((RATCHET == 0)); then
+	# Default whole-bundle mode: lint the current tree, fail on ANY violation.
+	lint_run "$BUNDLE"
+	echo
+	if ((VIOLATIONS == 0)); then
+		echo "OK — ${LAST_MD_COUNT} docs, no invariant violations."
+		exit 0
+	else
+		echo "FAIL — $VIOLATIONS violation(s) across ${LAST_MD_COUNT} docs."
+		exit 1
+	fi
+fi
+
+# --- ratchet mode -----------------------------------------------------------
+#
+# Compare the current bundle's violation SET against the baseline tree's set.
+# Only violations that are NEW (present now, absent at baseline) fail the run.
+
+# 1. lint the CURRENT bundle (verbose) and snapshot its normalized set
+lint_run "$BUNDLE"
+CUR_COUNT="$LAST_MD_COUNT"
+declare -a CUR_VIOL=("${VIOL_LINES[@]}")
+
+# 2. materialize the baseline tree and lint it (quiet) for its set
+declare -a BASE_VIOL=()
+BASELINE_NOTE=""
+WORKTREE=""
+
+cleanup_worktree() {
+	if [[ -n "$WORKTREE" && -d "$WORKTREE" ]]; then
+		git -C "$REPO_TOPLEVEL" worktree remove --force "$WORKTREE" >/dev/null 2>&1 ||
+			rm -rf "$WORKTREE" 2>/dev/null
+	fi
+}
+trap cleanup_worktree EXIT
+
+REPO_TOPLEVEL="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+
+if [[ -z "$REPO_TOPLEVEL" ]]; then
+	BASELINE_NOTE="not a git repository — baseline treated as empty (all violations are NEW)"
+elif ! git -C "$REPO_TOPLEVEL" rev-parse --verify --quiet "$BASELINE_REF^{commit}" >/dev/null 2>&1; then
+	BASELINE_NOTE="baseline ref '$BASELINE_REF' not found — baseline treated as empty (all violations are NEW)"
+else
+	# Where does BUNDLE live relative to the repo root? (so we can find it in the worktree)
+	BUNDLE_ABS="$(cd "$BUNDLE" && pwd)"
+	BUNDLE_REL="${BUNDLE_ABS#"$REPO_TOPLEVEL"/}"
+	if [[ "$BUNDLE_REL" == "$BUNDLE_ABS" ]]; then
+		# bundle is outside the repo — cannot map into the worktree
+		BASELINE_NOTE="bundle is outside the git repo — baseline treated as empty (all violations are NEW)"
+	else
+		WORKTREE="$(mktemp -d "${TMPDIR:-/tmp}/lint-docs-baseline.XXXXXX")"
+		if git -C "$REPO_TOPLEVEL" worktree add --quiet --detach "$WORKTREE" "$BASELINE_REF" >/dev/null 2>&1; then
+			BASE_BUNDLE="$WORKTREE/$BUNDLE_REL"
+			if [[ -d "$BASE_BUNDLE" ]]; then
+				lint_run "$BASE_BUNDLE" quiet
+				BASE_VIOL=("${VIOL_LINES[@]}")
+			else
+				BASELINE_NOTE="bundle '$BUNDLE_REL' did not exist at '$BASELINE_REF' — baseline treated as empty (all violations are NEW)"
+			fi
+		else
+			BASELINE_NOTE="could not check out '$BASELINE_REF' — baseline treated as empty (all violations are NEW)"
+		fi
+	fi
+fi
+
+# 3. set difference: NEW = CUR \ BASE ; pre-existing = CUR ∩ BASE
+declare -A BASE_SET=()
+for v in "${BASE_VIOL[@]:-}"; do
+	[[ -n "$v" ]] && BASE_SET["$v"]=1
+done
+
+declare -a NEW_VIOL=()
+declare -a OLD_VIOL=()
+for v in "${CUR_VIOL[@]:-}"; do
+	[[ -z "$v" ]] && continue
+	if [[ -n "${BASE_SET[$v]:-}" ]]; then
+		OLD_VIOL+=("$v")
+	else
+		NEW_VIOL+=("$v")
+	fi
+done
+
+# 4. report
+echo
+echo "Ratchet — baseline: $BASELINE_REF"
+[[ -n "$BASELINE_NOTE" ]] && echo "  note: $BASELINE_NOTE"
+echo
+
+fmt_viol() { # fmt_viol <normalized-line> <tag>
+	# normalized line is "<relpath>\t<message>"; print it human-readably with a tag
+	local line="$1" tag="$2" rel msg
+	rel="${line%%$'\t'*}"
+	msg="${line#*$'\t'}"
+	printf '  %-7s %-40s %s\n' "$tag" "$rel" "$msg"
+}
+
+if ((${#OLD_VIOL[@]} > 0)); then
+	echo "Pre-existing violations (grandfathered — do NOT block this change):"
+	for v in "${OLD_VIOL[@]}"; do fmt_viol "$v" "[old]"; done
+	echo
+fi
+
+if ((${#NEW_VIOL[@]} > 0)); then
+	echo "NEW violations introduced by this change (these block):"
+	for v in "${NEW_VIOL[@]}"; do fmt_viol "$v" "[NEW]"; done
+	echo
+	echo "FAIL — ${#NEW_VIOL[@]} new violation(s) vs baseline $BASELINE_REF (${#OLD_VIOL[@]} pre-existing, not counted)."
+	exit 1
+else
+	echo "OK — no new violations vs baseline $BASELINE_REF (${#OLD_VIOL[@]} pre-existing, grandfathered)."
+	exit 0
+fi

--- a/plugins/living-docs-enforcer/skills/templates/adr.md
+++ b/plugins/living-docs-enforcer/skills/templates/adr.md
@@ -1,0 +1,55 @@
+---
+type: ADR
+title: <Short decision title>
+description: <One sentence — the decision and its scope.>
+status: Proposed            # Proposed | Accepted | Superseded | Deprecated
+supersedes:                 # NNNN of the ADR this replaces, if any
+superseded_by:              # NNNN, set when a later ADR replaces this one
+tags: []
+timestamp: <ISO 8601 datetime, e.g. 2026-06-13T00:00:00Z>
+---
+
+# NNNN. <Short decision title>
+
+<!-- Status lives in frontmatter (`status`), not a body line. When superseding a
+     prior ADR, set `supersedes` here and `superseded_by` on the old record. -->
+
+## Context
+
+<The forces at play. What problem forced a decision? What constraints bound it?
+Written so a newcomer understands the pressure without prior knowledge. Link any
+research artifact or PRD/issue that motivates it, bundle-relative:
+[research](/research/NNNN-<slug>.md), [PRD](/prd/NNNN-<slug>.md).>
+
+## Decision
+
+We will <the choice, in active voice — specific and testable>.
+
+## Consequences
+
+**Easier / gained:**
+- <what this unlocks>
+
+**Harder / accepted trade-offs:**
+- <what this costs or forbids>
+
+**Follow-ups:**
+- <issues spawned, ADRs this may later require>
+
+## Verification
+
+<!-- OPTIONAL — include when this decision must be honored in code, so the doc closes the
+     doc → implement → verify loop an agent (and `implementation-review`) can consume. Omit
+     for a purely advisory record. Keep criteria checkable, not aspirational. -->
+
+**Implementation impact:** <files / modules this decision touches, e.g. `src/store.py`.>
+
+**Verification criteria:**
+- <An observable, checkable condition proving the decision is honored.>
+- <Fitness function: the test / lint / arch-unit assertion that fails if it is violated
+  (see `rules/adr-conventions.md` rule 6).>
+
+# References
+
+<!-- Optional (OKF §8). External sources backing claims in Context. -->
+[1] [<source>](<url>)

--- a/plugins/living-docs-enforcer/skills/templates/architecture-index.md
+++ b/plugins/living-docs-enforcer/skills/templates/architecture-index.md
@@ -1,0 +1,44 @@
+<!-- OKF reserved index.md (§6): a directory listing — NO frontmatter. The view files
+     it links ARE concepts and each carries `type: Architecture View` frontmatter. -->
+
+# Architecture
+
+Living architecture of the project: how the components fit together, expressed as
+Mermaid diagrams that must always match the code. This index is the entry point; each
+view file owns one diagram/concern. Update the relevant view in the same change as any
+structural code change (see the maintenance rule in the project guide).
+
+## Views
+
+| File | View | Mermaid type |
+|---|---|---|
+| [context.md](context.md)         | High-level components & external world | `flowchart` |
+| [data-model.md](data-model.md)   | Entities & relationships               | `erDiagram` |
+| [modules.md](modules.md)         | Module layout & dependencies           | `flowchart` |
+| [<flow>.md](flow.md)             | <Key process / data flow>              | `flowchart` |
+| [<request>.md](request.md)       | <Tool-calling / request round trip>    | `sequenceDiagram` |
+
+<!-- Add a row whenever a new view file is created. -->
+
+## Example view file skeleton
+
+A view file is an OKF concept: it opens with frontmatter, then an H1 title, one sentence
+of orientation, then the Mermaid block:
+
+````markdown
+---
+type: Architecture View
+title: <View name>
+description: <One sentence — what this view shows.>
+timestamp: <ISO 8601 datetime>
+---
+
+# <View name>
+
+<One sentence: what this view shows and when to consult it.>
+
+```mermaid
+flowchart LR
+    A[Module A] --> B[Module B]
+```
+````

--- a/plugins/living-docs-enforcer/skills/templates/bdr.md
+++ b/plugins/living-docs-enforcer/skills/templates/bdr.md
@@ -1,0 +1,61 @@
+---
+type: BDR
+title: <Short behavior title>
+description: <One sentence — the observable behavior this specifies.>
+status: Draft               # Draft | Accepted | Implemented | Superseded
+superseded_by:              # NNNN, set when a later BDR replaces this one
+tags: []
+timestamp: <ISO 8601 datetime>
+---
+
+# NNNN. <Short behavior title>
+
+<!-- Status lives in frontmatter (`status`), not a body line. -->
+
+## Context
+
+<What observable behavior is being specified? What user need or system requirement
+demands it? Link the PRD or ADR that spawned this BDR, and any issue that tracks the
+work, bundle-relative: [PRD](/prd/NNNN-<slug>.md), [ADR](/adr/NNNN-<slug>.md).>
+
+## Behavior
+
+```mermaid
+flowchart TD
+    A[Trigger / input] --> B[Step]
+    B --> C{Decision}
+    C -->|yes| D[Outcome A]
+    C -->|no| E[Outcome B]
+```
+
+<Replace the diagram above with a flowchart or sequence diagram that shows the full
+observable flow. Use Mermaid only — no images, no ASCII art.>
+
+## Textual Description
+
+<Prose form of the behavior. Describe what the system does from the outside: inputs,
+outputs, side effects, error paths. Write as if the code does not exist yet — what an
+observer would verify by watching the running system.>
+
+## Scenarios
+
+Each scenario is written to convert verbatim into the project's behavioral regression
+suite. Number from 1; do not skip numbers.
+
+**Scenario 1: <happy-path name>**
+
+- Given <initial state or precondition>
+- When <the trigger or action>
+- Then <the observable outcome>
+
+**Scenario 2: <edge or error case>**
+
+- Given <initial state or precondition>
+- When <the trigger or action>
+- Then <the observable outcome>
+
+## Related
+
+- PRD: [/prd/NNNN-<slug>.md](/prd/NNNN-<slug>.md)
+- ADR: [/adr/NNNN-<slug>.md](/adr/NNNN-<slug>.md)
+- Issues: [/issues/NNNN-<slug>.md](/issues/NNNN-<slug>.md)

--- a/plugins/living-docs-enforcer/skills/templates/claude-hard-rules.md
+++ b/plugins/living-docs-enforcer/skills/templates/claude-hard-rules.md
@@ -1,0 +1,79 @@
+# CLAUDE.md — Hard Rules Template
+
+Copy this block into the project's `CLAUDE.md` and fill in the `<placeholders>`. Adapt the table of locations to match the project's actual directory structure.
+
+---
+
+## Doc-trail
+
+Every change follows this chain:
+
+```
+constitution → PRD → ADR (how) + BDR (behavior) → issues → code
+```
+
+No code change skips a link. A PR that changes behavior without a BDR, or architecture without an ADR, is incomplete.
+
+## Locations
+
+Adapt this table to the project's actual paths before committing the rules.
+
+| Artifact | Location |
+|---|---|
+| Constitution | `docs/constitution/` |
+| PRDs | `docs/prd/` |
+| ADRs | `docs/decisions/` |
+| BDRs | `docs/behavior/` |
+| Research | `docs/research/` |
+| Issue drafts | `docs/issues/drafts/` |
+
+---
+
+## Hard rules
+
+### 1. Docs-first change policy
+
+Any change that alters behavior, architecture, flows, endpoints, or schema MUST update the corresponding docs in the same PR. A PR that changes code without updating its affected docs is incomplete and must not be merged.
+
+### 2. Diagrams are always Mermaid
+
+All diagrams in documentation must be Mermaid. Existing ASCII diagrams are converted whenever their containing doc is touched. Never introduce image-based or ASCII diagrams.
+
+### 3. Semantic doc groups with OKF index files
+
+Every directory of documentation is a semantic group and must contain an `index.md` (the OKF reserved listing — no frontmatter, except the bundle-root `docs/index.md`, which declares `okf_version: "0.1"`). Every concept document opens with OKF frontmatter carrying a non-empty `type`; `status` and supersession live in frontmatter, never a body line. Every new document is linked from its group's `index.md` with bundle-relative (`/…`) links, and new groups are linked from the root docs index. No orphan documents. See the `okf-knowledge-format` skill.
+
+### 4. Architectural decisions require an ADR; expected behavior requires a BDR
+
+- A decision that changes structure, dependencies, or technical approach → write an ADR (`docs/decisions/NNNN-slug.md`).
+- A decision that defines or changes what the system must observably do → write or amend a BDR (`docs/behavior/NNNN-slug.md`). Every BDR carries a Mermaid diagram, a textual description, and numbered Given/When/Then scenarios.
+- Research informing decisions goes in `docs/research/` in the OKF format (dated session directory with a `report.md` concept and a `references.md` registry; see the `research-artifacts` skill).
+
+### 5. Issues local-first
+
+Draft the issue as `docs/issues/drafts/NNNN-slug.md` first, linked from the drafts index. Launch on the tracker, stripping the OKF frontmatter so only the body is sent. Backfill the tracker number into the issue's frontmatter (`tracker`) and the index. The local file is the trace; the tracker is execution state.
+
+### 6. No comments in code
+
+Self-documenting names, small single-purpose functions, and extracted variables replace comments. A comment is permitted only for a constraint the code cannot express — a non-obvious external contract, a deliberate workaround with its reason. Never comment to narrate what the code does, restate history, or address a reviewer. No commented-out code.
+
+### 7. All internal artifacts in English
+
+Code, documentation, commit messages, ADRs, BDRs, and issue drafts are written in English. Conversation language follows the user.
+
+### 8. Generated artifact names describe what they do
+
+Migrations, scripts, and auto-named artifacts use descriptive names. For example: `--name <what_it_does>`, never auto-generated whimsical names. The name must let a future reader understand the artifact's purpose without opening it.
+
+### 9. Quality gates — all must pass before merge
+
+All of the following must pass on every PR. No exceptions, no deferrals.
+
+| Gate | Command |
+|---|---|
+| Tests | `<test command>` |
+| Type checking | `<typecheck command>` |
+| Lint at zero warnings | `<lint command at zero warnings>` |
+| Mutation testing (changed code, per file) | `<mutation testing >= N% on changed code, per file>` |
+
+The docs-update rule from rule 1 is also a quality gate: a PR failing the docs check does not merge.

--- a/plugins/living-docs-enforcer/skills/templates/constitution.md
+++ b/plugins/living-docs-enforcer/skills/templates/constitution.md
@@ -1,0 +1,65 @@
+---
+type: Constitution
+title: <Product> Constitution
+description: Foundational scope, data model, and non-negotiables for <product>.
+status: Draft               # Draft | Ratified | Amended
+timestamp: <ISO 8601 datetime>
+---
+
+# Product Constitution
+
+<!-- Status lives in frontmatter (`status`). This file is singular — no NNNN prefix,
+     and it is NOT listed as a concept in any index.md. It is the bundle's root of trace. -->
+
+## Product
+
+<What the product is, in one or two sentences. State the core value it delivers and
+who it delivers it to. This is the north star — every PRD and ADR must be consistent
+with it.>
+
+## Scope Boundaries
+
+**In scope:**
+
+- <Capability or domain the product owns.>
+
+**Explicitly out of scope:**
+
+- <Tempting-but-excluded capability. Name it so it cannot silently creep in.>
+
+**Phase boundaries:**
+
+- Phase 1: <what is in scope for the current phase and what defers>
+- Phase 2: <…>
+
+## Data Model / Schema Foundation
+
+<The core entities and their relationships. This section fixes what the rest of the
+system is built on. Represent structure as a Mermaid entity-relationship or class
+diagram. Describe cardinalities and invariants in prose below the diagram.>
+
+```mermaid
+erDiagram
+    ENTITY_A {
+        type field "description"
+    }
+    ENTITY_B {
+        type field "description"
+    }
+    ENTITY_A ||--o{ ENTITY_B : "relationship"
+```
+
+## Non-negotiables
+
+<Constraints that hold regardless of feature set, phase, or implementation choice.
+Examples: compliance requirements, security invariants, performance floors, user-trust
+commitments. Each item should be falsifiable — someone could check the running system
+and say "violated" or "holds".>
+
+- <Non-negotiable 1>
+
+## Amendment Log
+
+<!-- Append amendments here; do not edit sections above once ratified.            -->
+<!-- Format: ## Amendment N — YYYY-MM-DD: <summary of what changed and why>        -->
+<!-- A directory-level log.md (OKF §7) MAY also record amendment history.          -->

--- a/plugins/living-docs-enforcer/skills/templates/context-index.md
+++ b/plugins/living-docs-enforcer/skills/templates/context-index.md
@@ -1,0 +1,26 @@
+<!-- OKF reserved index.md (§6): a directory listing — NO frontmatter. The group
+     files it links ARE concepts and each carries `type: Context` frontmatter. -->
+
+# Context — Domain & Module Vocabulary
+
+The shared language for this project: the names used consistently across code, docs,
+and reviews. This index is the entry point; each group file owns one coherent slice of
+the vocabulary. A concept lives in exactly one file — cross-reference, never duplicate.
+
+<!-- Optional: reference the architecture-glossary skill that defines cross-project
+     terms (module, seam, depth, …) so domain vocabulary and architecture vocabulary
+     stay distinct. -->
+
+## Groups
+
+| File | Covers |
+|---|---|
+| [domain-concepts.md](domain-concepts.md)         | Core domain entities and rules |
+| [modules-<group-a>.md](modules-group-a.md)        | <e.g. write-path modules> |
+| [modules-<group-b>.md](modules-group-b.md)        | <e.g. read-path modules> |
+| [<shapes>.md](shapes.md)                          | <e.g. read/response shapes> |
+| [<storage>.md](storage.md)                        | <e.g. storage internals> |
+
+<!-- Each group file is a standalone OKF concept: opens with `type: Context`
+     frontmatter, then a single `#` H1 title, then `##` sections. Add a row here
+     whenever a new group file is created. -->

--- a/plugins/living-docs-enforcer/skills/templates/glossary.md
+++ b/plugins/living-docs-enforcer/skills/templates/glossary.md
@@ -1,0 +1,27 @@
+---
+type: Context
+title: "Glossary"
+description: Definitions of the terms and acronyms used across the project docs.
+tags: [glossary, vocabulary, context]
+timestamp: 2026-06-15T00:00:00Z
+---
+# Glossary
+
+Single home for every term and acronym the docs use. **Definitions are in the project doc language** (see `rules/doc-language.md`); term names, code identifiers, and acronym headwords/expansions stay in their original form. Each term is defined **once** here — other docs link to it rather than redefine. Keep entries alphabetical; split into grouped context files (`rules/semantic-index.md`) once this passes ~200 lines.
+
+## Acronyms
+
+The headword is the acronym **as-is**; the expansion is the spelled-out form (may stay in its original language); the definition is in the doc language.
+
+| Acronym | Expansion | Definition |
+|---|---|---|
+| ADR | Architecture Decision Record | <one-line definition in the project doc language> |
+| BDR | Behavior Decision Record | <one-line definition in the project doc language> |
+| PRD | Product Requirements Document | <one-line definition in the project doc language> |
+| OKF | Open Knowledge Format | <one-line definition in the project doc language> |
+
+## Terms
+
+| Term | Definition | See also |
+|---|---|---|
+| <Term> | <one-line definition in the project doc language> | <links to related entries / ADRs> |

--- a/plugins/living-docs-enforcer/skills/templates/issue.md
+++ b/plugins/living-docs-enforcer/skills/templates/issue.md
@@ -1,0 +1,32 @@
+---
+type: Issue
+title: <Issue title>
+description: <One sentence — the change and its motivation.>
+status: open                # open | in-progress | closed | superseded
+labels: []                  # tracker labels
+blocked_by: []              # issue numbers this depends on
+tracker:                    # #NN once published to the tracker
+timestamp: <ISO 8601 datetime>
+---
+
+<!-- OKF frontmatter above carries the tracker metadata (number, labels, blocked-by,
+     status) that previously lived only in the directory index. Everything BELOW the
+     closing `---` is the issue body and MUST stay byte-identical to the published
+     tracker body — strip the frontmatter when publishing. -->
+
+## <Issue title>
+
+<What the change is and why. If it implements a PRD or ADR, link it bundle-relative:
+"Implements [ADR NNNN](/adr/NNNN-<slug>.md)" / "Part of [PRD NNNN](/prd/NNNN-<slug>.md)".>
+
+### Scope
+
+<What's included. For removals/refactors, state what is explicitly KEPT.>
+
+### Acceptance
+
+- <Observable, testable condition for "done".>
+
+### Plan
+
+<Short outline of the approach. For a large task, list the slices.>

--- a/plugins/living-docs-enforcer/skills/templates/prd.md
+++ b/plugins/living-docs-enforcer/skills/templates/prd.md
@@ -1,0 +1,61 @@
+---
+type: PRD
+title: <Feature / capability name>
+description: <One sentence — what capability this specifies.>
+status: Draft               # Draft | Accepted | Implemented | Superseded
+superseded_by:              # NNNN, set when a later PRD replaces this one
+tags: []
+timestamp: <ISO 8601 datetime>
+---
+
+# NNNN. <Feature / capability name>
+
+<!-- Status lives in frontmatter (`status`), not a body line. -->
+
+## Problem / Motivation
+
+<The user or system pain. Lead with the problem, not the solution. If you can only
+state it as a solution, grill it first to find the underlying need.>
+
+## Goals
+
+- <Outcome 1 — what success looks like, not a task>
+
+## Non-goals
+
+- <What this explicitly does NOT cover. Name the tempting-but-excluded things.>
+
+## Requirements
+
+1. <Numbered, testable statement.>
+2. <…>
+
+## Acceptance criteria
+
+- <Observable condition proving a requirement is met.>
+
+## Success metrics
+
+- <Quantified outcome that confirms the problem is solved after delivery — not task
+  completion. E.g. "Checkout abandonment rate drops by ≥10% within 30 days of launch.">
+
+## Behavior (BDRs)
+
+- <Link each BDR that specifies observable behavior this PRD defines or changes,
+  bundle-relative: [BDR](/bdr/NNNN-<slug>.md). BDRs carry Mermaid diagrams, textual
+  descriptions, and Given/When/Then scenarios.>
+
+## Open questions
+
+- <Unresolved decision — each ideally headed toward an ADR (how/architecture) or a
+  BDR (what the system must observably do).>
+
+## Decision log
+
+- <Link to the ADR(s) and BDR(s) that resolved the open questions, once made.>
+
+## Related
+
+- Constitution: [/constitution.md](/constitution.md)
+- Issues: [/issues/NNNN-<slug>.md](/issues/NNNN-<slug>.md)
+- Research: [/research/NNNN-<slug>.md](/research/NNNN-<slug>.md)


### PR DESCRIPTION
**This supersedes the scaffold in #3.** It rebuilds the `living-docs-enforcer` Claude Code plugin on top of the #4 diff-aware branch (which carries the `lint-docs.sh --ratchet` CLI + corpus + the `enforcement/` triggers). Base is **`claude/living-docs-diff-aware-enforcement`** so this PR is only the delta (stack: #2 → #4 → this).

## Four finalizations

**1. Self-contained packaging (replaces the symlink).** The scaffold bundled the skill by a symlink pointing *outside* the plugin dir, which breaks for any install that isn't a full-repo clone (zip / copy-of-just-the-plugin). Replaced with a **real vendored copy** at `plugins/living-docs-enforcer/skills/living-docs/`. Drift is neutralized by an instrument (the repo's "a constraint without an instrument is a vibe" rule):
- `make sync-plugin-skill` regenerates the vendored copy from the canonical `skills/living-docs/` (`cp -R`).
- `make check-plugin-skill-sync` runs `diff -r` and exits non-zero on drift.
- Wired into **`make check`** *and* an additive step in **`.github/workflows/ci.yml`**, so a drifted copy fails CI.
- README documents the "edit source → `make sync-plugin-skill`" workflow.

**2. Hook uses the ratchet (so block is safe).** `hooks/block-docs-drift.sh` now runs `${CLAUDE_PLUGIN_ROOT}/skills/living-docs/scripts/lint-docs.sh --ratchet HEAD <bundle>` instead of the bundle-wide lint — it blocks **only new** violations and grandfathers pre-existing legacy debt, which is what makes block-by-default adoption-safe. Applies the same `GIT_INDEX_FILE`/`GIT_DIR`/`GIT_WORK_TREE`/`GIT_PREFIX` unset fix that #4's `enforcement/pre-commit.sh` needed (a PreToolUse hook firing during a commit inherits the same ambient git env that corrupts the ratchet's `git worktree add`). Contract preserved: exit 2 = block, exit 0 = allow, reason on stderr; the absence proxy stays WARN-only/never-blocks; defensive on missing git/lint-docs/bundle (always allows).

**3. block is the settled default.** Removed all "open maintainer decision" framing from `plugin.json`, the hook header comment, and the README. Documented `block` as the decided policy, with `LIVING_DOCS_ENFORCE=warn` as the documented opt-out. The `LIVING_DOCS_ENFORCE` and `LIVING_DOCS_BUNDLE` knobs are kept.

**4. README truth-up.** Self-contained install (no symlink caveat; works for clone/zip/copy), the settled `block` default + `warn` opt-out, the ratchet behavior (blocks new debt, grandfathers legacy), the honest "enforces the verifiable floor / warns the absence proxy / cannot force a meaningful ADR in flow order" section, and a cross-reference to the `enforcement/` pre-commit hook + Action (from #4) as the harness-agnostic siblings — this plugin is the Claude-Code in-loop layer + the skill bundle, all calling the same `--ratchet` CLI.

## Scope
Only `plugins/living-docs-enforcer/`, the two new Makefile targets, and the additive ci.yml drift-check step. `lint-docs.sh`, the `tests/lint-docs/` corpus, and the `enforcement/` triggers from #4 are **reused, not modified**.

## Verification (bash 5.2, local)
- `make check` exits 0.
- `make check-plugin-skill-sync` passes when synced, fails on a deliberately-edited vendored file (exit 2), passes again after `make sync-plugin-skill`.
- Hook smoke test, all paths: a NEW broken link **blocks** (exit 2, marks the legacy one `[old]`); pre-existing broken-link debt on an unrelated change **does not block** (exit 0, grandfathered); `LIVING_DOCS_ENFORCE=warn` **allows** with a warning; the absence proxy and non-commit Bash both **allow** (exit 0).
- All JSON/YAML validates.

## Judgment call to flag
The grandfather path was first smoke-tested with an **orphan** violation, which surfaced a **pre-existing bug in #4's `lint-docs.sh --ratchet`**, not in this plugin: the orphan violation message embeds the directory-index path (`not listed in <dir>/index.md`), which is **absolute inside the baseline `git worktree`** but **relative in the current run**, so the two normalized keys differ and an orphan present in HEAD is misclassified `[NEW]`. Broken-link / frontmatter violations normalize cleanly (their messages carry only bundle-relative strings), which is why #4's own ratchet corpus (`run-ratchet.sh`, which uses a broken link) passes. Per the scope constraint I did **not** modify `lint-docs.sh`; the hook wiring is correct and the smoke test above proves grandfathering with a CLI-supported violation type. This same latent bug also affects `enforcement/pre-commit.sh` and the CI Action for orphan-type debt — worth a follow-up fix in the linter (normalize the message to a bundle-relative path before the ratchet set-compare).

The marketplace `source: "./"` install path is unchanged from the scaffold and is correct for a single-plugin-per-repo-subdir layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeRKqhb8HLdFQw6npouwTC

---
_Generated by [Claude Code](https://claude.ai/code/session_01TeRKqhb8HLdFQw6npouwTC)_