### PR TITLE
feat: validate mermaid in-process via merman-core, drop docker mermaid-cli (ADR 0013)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +204,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,7 +280,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -355,6 +387,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +400,29 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -444,6 +505,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,12 +543,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "ena"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -487,6 +602,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,10 +622,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flume"
@@ -525,6 +661,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -649,6 +791,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -662,7 +815,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -670,6 +823,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -723,6 +881,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "htmlize"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e815d50d9e411ba2690d730e6ec139c08260dddb756df315dbd16d01a587226"
+dependencies = [
+ "memchr",
+ "pastey",
+ "phf",
+ "phf_codegen",
+ "serde_json",
 ]
 
 [[package]]
@@ -946,6 +1117,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -966,6 +1139,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,6 +1162,48 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "ena",
+ "itertools",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -1038,6 +1262,7 @@ dependencies = [
 name = "living-docs-core"
 version = "0.1.0"
 dependencies = [
+ "merman-core",
  "pulldown-cmark",
  "regex",
  "serde",
@@ -1058,6 +1283,58 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "logos"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7251356ef8cb7aec833ddf598c6cb24d17b689d20b993f9d11a3d764e34e6458"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59f80069600c0d66734f5ff52cc42f2dabd6b29d205f333d61fd7832e9e9963f"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "syn",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24fb722b06a9dc12adb0963ed585f19fc61dc5413e6a9be9422ef92c091e731d"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
+name = "lol_html"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00aad58f6ec3990e795943872f13651e7a5fa59dca2c8f31a74faf8a0e0fb652"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cssparser",
+ "encoding_rs",
+ "foldhash 0.2.0",
+ "hashbrown 0.17.1",
+ "memchr",
+ "mime",
+ "precomputed-hash",
+ "selectors",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "matchers"
@@ -1115,6 +1392,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "merman-core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b7ca468603ca22bad2578b3d3fbc0b436e28b5ccb726e2cf99d7bb75fa8c167"
+dependencies = [
+ "chrono",
+ "euclid",
+ "htmlize",
+ "indexmap",
+ "json5",
+ "lalrpop",
+ "lalrpop-util",
+ "logos",
+ "lol_html",
+ "regex",
+ "rustc-hash",
+ "ryu-js",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "uuid",
+ "web-time",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,6 +1435,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "num-traits"
@@ -1215,10 +1526,136 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
+dependencies = [
+ "pest",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.13.1",
+ "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project-lite"
@@ -1255,6 +1692,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro-error-attr2"
@@ -1328,6 +1771,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,7 +1803,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1373,6 +1822,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1412,11 +1872,17 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -1474,6 +1940,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "ryu-js"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1510,7 +1991,7 @@ dependencies = [
  "serde",
  "sqlx",
  "strum",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "url",
 ]
@@ -1592,7 +2073,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1618,6 +2099,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "selectors"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cfaaa6035167f0e604e42723c7650d59ee269ef220d7bbe0565602c8a0173b9"
+dependencies = [
+ "bitflags",
+ "cssparser",
+ "derive_more",
+ "log",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "rustc-hash",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -1662,6 +2162,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -1706,6 +2207,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,6 +2240,12 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -1805,7 +2321,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -1882,7 +2398,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "whoami",
 ]
@@ -1906,7 +2422,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "url",
 ]
@@ -1922,6 +2438,18 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.11.3",
+ "precomputed-hash",
+]
 
 [[package]]
 name = "stringprep"
@@ -1981,12 +2509,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2007,6 +2566,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -2153,6 +2721,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2228,6 +2802,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+dependencies = [
+ "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2238,6 +2823,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -2314,6 +2909,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2340,6 +2945,37 @@ dependencies = [
  "libredox",
  "wasite",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ check: version build test-fixtures ## Check version sync, validate install.sh, r
 	$(LIVING_DOCS_BIN) check --mermaid-only
 	$(INSTALL) all --dry-run
 
-test-fixtures: build ## Run the hostile/negative fixtures that guard the check parsers (requires Docker for mermaid)
+test-fixtures: build ## Run the hostile/negative fixtures that guard the check parsers
 	LIVING_DOCS_BIN=$(LIVING_DOCS_BIN) ./skills/living-docs/tests/run.sh
 
 version: ## Assert the release version is consistent across VERSION and every SKILL.md

--- a/cli/tests/check_mermaid.rs
+++ b/cli/tests/check_mermaid.rs
@@ -7,14 +7,6 @@ fn living_docs() -> Command {
     Command::new(env!("CARGO_BIN_EXE_living-docs"))
 }
 
-fn docker_available() -> bool {
-    Command::new("docker")
-        .arg("info")
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
-}
-
 /// Fixtures live under `skills/living-docs/tests/fixtures` relative to the repo
 /// root; `CARGO_MANIFEST_DIR` anchors this at compile time regardless of the
 /// working directory `cargo test` is invoked from.
@@ -51,10 +43,6 @@ fn stderr_of(output: &Output) -> String {
 
 #[test]
 fn fixture_10_valid_diagrams_pass_clean() {
-    if !docker_available() {
-        eprintln!("note: docker unavailable — skipping mermaid validation test");
-        return;
-    }
     let output = run_mermaid_only(&fixture("10-mermaid-valid"));
     let stdout = stdout_of(&output);
     assert_eq!(
@@ -68,10 +56,6 @@ fn fixture_10_valid_diagrams_pass_clean() {
 
 #[test]
 fn fixture_11_invalid_diagram_fails_with_a_file_line_pointer() {
-    if !docker_available() {
-        eprintln!("note: docker unavailable — skipping mermaid validation test");
-        return;
-    }
     let output = run_mermaid_only(&fixture("11-mermaid-invalid"));
     let stdout = stdout_of(&output);
     assert_eq!(
@@ -110,27 +94,34 @@ fn mermaid_only_with_no_fences_is_clean_without_requiring_docker() {
     let _ = fs::remove_dir_all(&bundle);
 }
 
-#[test]
-fn mermaid_only_exits_2_when_docker_is_unavailable_and_fences_exist() {
-    let output = living_docs()
-        .args([
-            "check",
-            "--mermaid-only",
-            fixture("10-mermaid-valid").to_str().unwrap(),
-        ])
+fn run_mermaid_only_without_docker_on_path(path: &Path) -> Output {
+    living_docs()
+        .args(["check", "--mermaid-only", path.to_str().unwrap()])
         .env("PATH", "/nonexistent")
         .output()
-        .expect("failed to run living-docs check --mermaid-only");
+        .expect("failed to run living-docs check --mermaid-only")
+}
 
+#[test]
+fn mermaid_only_validates_without_docker_on_path() {
+    let valid = run_mermaid_only_without_docker_on_path(&fixture("10-mermaid-valid"));
     assert_eq!(
-        output.status.code(),
-        Some(2),
-        "expected a tool-error exit, got:\n{}",
-        stderr_of(&output)
+        valid.status.code(),
+        Some(0),
+        "expected clean with docker off PATH, got:\n{}\n{}",
+        stdout_of(&valid),
+        stderr_of(&valid)
+    );
+
+    let invalid = run_mermaid_only_without_docker_on_path(&fixture("11-mermaid-invalid"));
+    let invalid_stdout = stdout_of(&invalid);
+    assert_eq!(
+        invalid.status.code(),
+        Some(1),
+        "expected a parse failure with docker off PATH, got:\n{invalid_stdout}"
     );
     assert!(
-        stderr_of(&output).contains("docker"),
-        "expected a docker error message, got:\n{}",
-        stderr_of(&output)
+        invalid_stdout.contains("doc.md:"),
+        "expected a file:line pointer, got:\n{invalid_stdout}"
     );
 }

--- a/docs/adr/0013-mermaid-validation-runs-in-process-via-merman-core-not-a-docker-mermaid-cli-shell-out.md
+++ b/docs/adr/0013-mermaid-validation-runs-in-process-via-merman-core-not-a-docker-mermaid-cli-shell-out.md
@@ -1,0 +1,110 @@
+---
+type: ADR
+title: Mermaid validation runs in-process via merman-core, not a Docker mermaid-cli shell-out
+description: Replace the Docker `mermaid-cli` shell-out in `check`/`check --mermaid-only` with the pure-Rust `merman-core` parser, gated by a conformance corpus that fails CI if the parser ever diverges from the expected accept/reject on our fixtures.
+status: Accepted
+supersedes:
+superseded_by:
+tags: [documentation, tooling, mermaid, determinism, dependencies]
+timestamp: 2026-07-18T16:10:15Z
+---
+
+# 0013. Mermaid validation runs in-process via merman-core, not a Docker mermaid-cli shell-out
+
+## Context
+
+`check` validates every ` ```mermaid ` fence in the corpus so a broken diagram fails the
+doc-gate. Today `living-docs-core/src/check/mermaid.rs` does this by shelling out to the pinned
+`minlag/mermaid-cli:11.4.2` Docker image — the real mermaid.js parser wrapped by `mmdc`. The
+docblock is explicit that this is "the real parser, not a hand-rolled grammar check", and the
+weight comes from `mermaid-cli` bundling puppeteer + headless Chromium to *render*.
+
+Two frictions pull against this:
+
+- **A runtime Docker dependency for a validation step.** `check` needs a running Docker daemon
+  to validate a diagram, so a plain `cargo install`ed binary cannot fully self-check; CI must
+  provide Docker; contributors without Docker get a degraded `check`. For a tool whose north star
+  is a deterministic, self-contained Rust binary (ADR 0001), a Chromium-in-Docker dependency for
+  *syntax validation* is disproportionate — validation only needs `parse()` (valid/invalid), never
+  rendering.
+- **The determinism boundary (ADR 0001).** The tool must be reproducible from its inputs and hold
+  no heavyweight external runtime it does not control. Shelling out to a container image is an
+  external-process boundary that the leak-gate work (ADR 0011/0012) deliberately refused for
+  detection; mermaid validation is the last place that boundary is crossed.
+
+The blocker to removing Docker had been that no pure-Rust mermaid parser existed. That is no longer
+true: a `cargo search` surfaced several pure-Rust implementations, and a spike (recorded below)
+measured `merman-core` against our own fixture corpus.
+
+## Decision
+
+We will replace the Docker `mermaid-cli` shell-out with **`merman-core`** (the parser crate of the
+`merman` project, MIT OR Apache-2.0), used **parse-only**: `Engine::new().parse_diagram_sync(text,
+ParseOptions::strict())`, where `Err` marks an invalid diagram and `Ok(Some(_))` a valid one. No
+rendering, no layout, no Docker, no JS engine.
+
+The decision is **bounded by a conformance corpus, not by trust in an alpha crate.** The existing
+`10-mermaid-valid` / `11-mermaid-invalid` fixtures (expanded to cover each diagram type the corpus
+uses) become a fitness function: a committed test asserts the parser accepts every valid fixture
+and rejects every invalid one, and fails CI the moment `merman-core` diverges from that expected
+accept/reject. The corpus, not the crate's version number, is the trust anchor.
+
+Rejected alternatives:
+
+- **Embed mermaid.js via a Rust JS engine (`rquickjs`/`deno_core`).** Gives exact parity, but
+  imports a JS runtime plus a browser-globals shim for mermaid's parse path — fragile across
+  mermaid upgrades, and a heavier dependency than the problem warrants once a pure-Rust parser
+  reaches corpus parity.
+- **Hand-roll a Rust grammar** (`pest`/`chumsky`). Dominated by adopting `merman-core`, which
+  already covers 25 diagram types with a stated "1:1 parity with pinned upstream Mermaid baseline"
+  design goal — reimplementing that is cost with no benefit and a larger drift surface.
+- **Keep Docker, degrade gracefully.** Rejected: the objective is to remove the runtime Docker
+  dependency, not to soften it.
+
+## Consequences
+
+**Easier / gained:**
+- `check` / `check --mermaid-only` become pure in-process Rust — no Docker daemon, no Chromium, a
+  single self-contained binary that fully self-checks. CI drops the Docker-for-mermaid setup.
+- The determinism boundary (ADR 0001) is held everywhere: the last external-process dependency in
+  the check path is gone.
+- Coverage widens from "whatever the image parses" to 25 diagram types, all validated in-process
+  and orders of magnitude faster than a container round-trip.
+
+**Harder / accepted trade-offs:**
+- **Crate maturity.** `merman-core` is young (0.7.x; the umbrella `merman` is 0.8.0-alpha) and
+  solo-maintained. Mitigated by pinning the version and by the conformance corpus that fails CI on
+  any parity regression — we depend on *measured* behavior, not on a stability promise.
+- **Dependency footprint.** `merman-core` pulls ~170 transitive crates (chrono, logos, web-time,
+  …). This is a one-time compile cost and a supply-chain surface; accepted in exchange for removing
+  the Docker runtime dependency (the trade is compile-time deps for a lighter, self-contained
+  runtime).
+- **Parity is bounded by the corpus, not proven universally.** A diagram type or construct the
+  corpus does not exercise could diverge from mermaid.js unnoticed. Mitigated by growing the corpus
+  when new diagram shapes enter the docs.
+
+**Follow-ups:**
+- Implementation issue: add `merman-core` to `living-docs-core`, rewrite `check/mermaid.rs` to use
+  the `Engine`, expand the conformance corpus, and remove the Docker path and its
+  `DockerUnavailable` handling.
+- If `merman-core` is abandoned or diverges materially, revisit via a superseding ADR (the rejected
+  embed-JS option is the fallback of record).
+
+## Verification
+
+**Implementation impact:** `living-docs-core/Cargo.toml` (the `merman-core` dependency),
+`living-docs-core/src/check/mermaid.rs` (Engine-based validation replacing the Docker shell-out and
+its `DockerUnavailable` outcome), the CI workflow / Makefile (drop the Docker-for-mermaid
+requirement), and `skills/living-docs/tests/fixtures/10-mermaid-valid` /
+`11-mermaid-invalid` (expanded conformance corpus).
+
+**Verification criteria:**
+- `check` validates ` ```mermaid ` fences with no Docker daemon present; a broken diagram still
+  fails the gate and a valid one passes. — fitness function (integration test, no Docker).
+- The conformance corpus test asserts `merman-core` accepts every `10-mermaid-valid` diagram and
+  rejects every `11-mermaid-invalid` diagram; it fails on any parity divergence. — fitness function.
+- `living-docs check docs` stays green over `docs/` with this ADR indexed.
+
+# References
+
+[1] [merman — parity-focused headless Rust Mermaid parser](https://github.com/Latias94/merman). Available at: https://crates.io/crates/merman-core. Accessed on: 2026-07-18.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -22,3 +22,4 @@ repo teaches. The decision *log* is this listing plus each record's `status` /
 * [0010 — Public export is a deterministic allowlist build with a leak gate; publish is a human-gated procedure](0010-public-export-is-a-deterministic-allowlist-build-with-a-leak-gate-publish-is-a-human-gated-procedure.md) - Accepted
 * [0011 — Secret and PII detection stays deterministic — a curated ruleset plus Shannon entropy, never ML](0011-leak-detection-stays-deterministic-curated-ruleset-plus-shannon-entropy-never-ml.md) - Accepted
 * [0012 — Worldwide PII detection is checksum-tiered, two-stage, and deterministic](0012-worldwide-pii-detection-is-checksum-tiered-two-stage-and-deterministic.md) - Accepted
+* [0013 — Mermaid validation runs in-process via merman-core, not a Docker mermaid-cli shell-out](0013-mermaid-validation-runs-in-process-via-merman-core-not-a-docker-mermaid-cli-shell-out.md) - Accepted

--- a/living-docs-core/Cargo.toml
+++ b/living-docs-core/Cargo.toml
@@ -13,3 +13,4 @@ serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 pulldown-cmark = { version = "=0.13.4", default-features = false }
 regex = "1"
+merman-core = "=0.7.0"

--- a/living-docs-core/src/check/mermaid.rs
+++ b/living-docs-core/src/check/mermaid.rs
@@ -1,18 +1,17 @@
-//! Mermaid fence validation (S6) — ports `skills/living-docs/scripts/lint-mermaid.sh`.
+//! Mermaid fence validation (ADR 0013) — ports `skills/living-docs/scripts/lint-mermaid.sh`.
 //!
 //! Extracts every fenced ```mermaid``` block (optional indent, one open line +
-//! one close line) and validates each one through the pinned `mermaid-cli`
-//! Docker image — the real parser, not a hand-rolled grammar check. Docker is
-//! only required when at least one fence is found: a bundle with no diagrams
-//! never shells out.
+//! one close line) and validates each one in-process through `merman-core`'s
+//! `Engine::parse_diagram_sync`, the real Mermaid grammar parser — not a
+//! hand-rolled check and no external process of any kind.
 
 use super::{collect_md_files, Reporter};
+use merman_core::{Engine, ParseOptions};
 use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
 
-const DEFAULT_IMAGE: &str = "minlag/mermaid-cli:11.4.2";
 const FIXTURES_PATHSPEC: &str = ":!skills/living-docs/tests/fixtures";
 
 pub(crate) struct Diagram {
@@ -29,7 +28,6 @@ struct Failure {
 
 enum Outcome {
     NoFences,
-    DockerUnavailable,
     Checked {
         diagram_count: usize,
         file_count: usize,
@@ -46,10 +44,6 @@ pub fn run_mermaid_only(paths: &[PathBuf]) -> ExitCode {
         Outcome::NoFences => {
             println!("\nOK: 0 diagram(s) across 0 file(s).");
             ExitCode::SUCCESS
-        }
-        Outcome::DockerUnavailable => {
-            report_docker_unavailable("check --mermaid-only");
-            ExitCode::from(2)
         }
         Outcome::Checked {
             diagram_count,
@@ -72,30 +66,21 @@ pub fn run_mermaid_only(paths: &[PathBuf]) -> ExitCode {
     }
 }
 
-/// Wires mermaid validation into a full `check <bundle>` run. Returns `Some`
-/// exit code when the bundle has fences but Docker is unavailable — the
-/// caller must abort immediately, matching the mermaid-only tool-error
-/// contract — otherwise reports failures into `reporter` and returns `None`.
-pub(crate) fn check_bundle(all_md: &[PathBuf], reporter: &mut Reporter) -> Option<ExitCode> {
-    match check(all_md) {
-        Outcome::NoFences => None,
-        Outcome::DockerUnavailable => {
-            report_docker_unavailable("check");
-            Some(ExitCode::from(2))
-        }
-        Outcome::Checked { failures, .. } => {
-            for f in &failures {
-                reporter.report(
-                    &f.file,
-                    format!(
-                        "FAIL {}:{} — invalid mermaid diagram",
-                        f.file.display(),
-                        f.start_line
-                    ),
-                );
-            }
-            None
-        }
+/// Wires mermaid validation into a full `check <bundle>` run: reports every
+/// invalid diagram into `reporter`. A bundle with no fences reports nothing.
+pub(crate) fn check_bundle(all_md: &[PathBuf], reporter: &mut Reporter) {
+    let Outcome::Checked { failures, .. } = check(all_md) else {
+        return;
+    };
+    for f in &failures {
+        reporter.report(
+            &f.file,
+            format!(
+                "FAIL {}:{} — invalid mermaid diagram",
+                f.file.display(),
+                f.start_line
+            ),
+        );
     }
 }
 
@@ -103,9 +88,6 @@ fn check(files: &[PathBuf]) -> Outcome {
     let diagrams = extract_diagrams(files);
     if diagrams.is_empty() {
         return Outcome::NoFences;
-    }
-    if !docker_available() {
-        return Outcome::DockerUnavailable;
     }
     let file_count = diagrams
         .iter()
@@ -119,11 +101,6 @@ fn check(files: &[PathBuf]) -> Outcome {
         file_count,
         failures,
     }
-}
-
-fn report_docker_unavailable(prog: &str) {
-    eprintln!("living-docs {prog}: missing required tool: docker");
-    eprintln!("       install: https://docs.docker.com/get-docker/");
 }
 
 fn print_failures(failures: &[Failure]) {
@@ -217,89 +194,28 @@ fn extract_from_file(file: &Path) -> Vec<Diagram> {
     diagrams
 }
 
-fn docker_available() -> bool {
-    Command::new("docker")
-        .arg("info")
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
-}
-
-fn mermaid_cli_image() -> String {
-    std::env::var("MERMAID_CLI_IMAGE").unwrap_or_else(|_| DEFAULT_IMAGE.to_string())
-}
-
+/// Validates every diagram against one shared `Engine`, matching ADR 0013:
+/// `Ok(Some(_))` passes, `Err(_)`/`Ok(None)` produce a `Failure` carrying the
+/// parser's own error (or a no-diagram note) as `detail`.
 fn validate_all(diagrams: &[Diagram]) -> Vec<Failure> {
-    let image = mermaid_cli_image();
-    let scratch = scratch_dir();
-    let _ = fs::create_dir_all(scratch.join("out"));
-    let failures = diagrams
+    let engine = Engine::new();
+    diagrams
         .iter()
-        .enumerate()
-        .filter_map(|(i, d)| validate_one(&scratch, &image, i + 1, d))
-        .collect();
-    let _ = fs::remove_dir_all(&scratch);
-    failures
+        .filter_map(|d| validate_one(&engine, d))
+        .collect()
 }
 
-fn validate_one(scratch: &Path, image: &str, id: usize, diagram: &Diagram) -> Option<Failure> {
-    let mmd_path = scratch.join(format!("{id:03}.mmd"));
-    fs::write(&mmd_path, &diagram.body).ok()?;
-    let mount = format!("{}:/data", scratch.display());
-    let mmd_arg = format!("/data/{id:03}.mmd");
-    let svg_arg = format!("/data/out/{id:03}.svg");
-    let output = Command::new("docker")
-        .args([
-            "run",
-            "--rm",
-            "-u",
-            &uid_gid_arg(),
-            "-v",
-            &mount,
-            image,
-            "-i",
-            &mmd_arg,
-            "-o",
-            &svg_arg,
-            "-q",
-        ])
-        .output()
-        .ok()?;
-    if output.status.success() {
-        return None;
-    }
-    let mut detail = String::from_utf8_lossy(&output.stdout).into_owned();
-    detail.push_str(&String::from_utf8_lossy(&output.stderr));
+fn validate_one(engine: &Engine, diagram: &Diagram) -> Option<Failure> {
+    let detail = match engine.parse_diagram_sync(&diagram.body, ParseOptions::strict()) {
+        Ok(Some(_)) => return None,
+        Ok(None) => "no mermaid diagram recognized in fence body".to_string(),
+        Err(err) => err.to_string(),
+    };
     Some(Failure {
         file: diagram.file.clone(),
         start_line: diagram.start_line,
         detail,
     })
-}
-
-fn uid_gid_arg() -> String {
-    format!("{}:{}", id_output("-u"), id_output("-g"))
-}
-
-fn id_output(flag: &str) -> String {
-    Command::new("id")
-        .arg(flag)
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-        .unwrap_or_else(|| "0".to_string())
-}
-
-fn scratch_dir() -> PathBuf {
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    std::env::temp_dir().join(format!(
-        "living-docs-mermaid-{}-{nanos}",
-        std::process::id()
-    ))
 }
 
 #[cfg(test)]
@@ -359,14 +275,41 @@ mod tests {
         let _ = fs::remove_file(&path);
     }
 
-    #[test]
-    fn mermaid_cli_image_defaults_to_the_pinned_tag_and_honors_the_env_override() {
-        std::env::remove_var("MERMAID_CLI_IMAGE");
-        assert_eq!(mermaid_cli_image(), DEFAULT_IMAGE);
+    fn corpus_diagram(body: &str) -> Diagram {
+        Diagram {
+            file: PathBuf::from("corpus.md"),
+            start_line: 1,
+            body: body.to_string(),
+        }
+    }
 
-        std::env::set_var("MERMAID_CLI_IMAGE", "example/mermaid-cli:9.9.9");
-        assert_eq!(mermaid_cli_image(), "example/mermaid-cli:9.9.9");
-        std::env::remove_var("MERMAID_CLI_IMAGE");
+    /// ADR 0013 fitness function: the conformance corpus must parse with the
+    /// exact same accept/reject verdict the prior parser gave — every valid
+    /// shape accepted, the broken arrow chain rejected. A parity regression
+    /// in `merman-core` fails this test, not silently degrades `check`.
+    #[test]
+    fn validate_all_matches_the_adr_0013_conformance_corpus() {
+        let valid = [
+            "flowchart TD\n  A[Start] --> B{Decision}\n  B -->|Yes| C[Do the thing]\n  B -->|No| D[Skip it]\n",
+            "flowchart LR\n  User -->|shortens| App\n  App -->|redirects| User\n",
+            "erDiagram\n  CUSTOMER ||--o{ ORDER : places\n  ORDER ||--|{ LINE_ITEM : contains\n",
+            "  flowchart TD\n    A --> B\n",
+        ]
+        .map(corpus_diagram);
+        let failures = validate_all(&valid);
+        assert!(
+            failures.is_empty(),
+            "expected every valid corpus diagram to parse, but {} failed",
+            failures.len()
+        );
+
+        let invalid = [corpus_diagram("flowchart TD\nA --> --> B\n")];
+        let failures = validate_all(&invalid);
+        assert_eq!(
+            failures.len(),
+            1,
+            "expected the broken arrow chain to be rejected"
+        );
     }
 
     #[test]

--- a/living-docs-core/src/check/mod.rs
+++ b/living-docs-core/src/check/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! Covers the mechanical invariants: OKF frontmatter/type, index-format,
 //! directory-index membership, bundle-root reachability, supersede-chain
-//! integrity, local link/image validity via `pulldown-cmark`, and (S6)
-//! ```mermaid``` fence validation via the pinned mermaid-cli Docker image.
+//! integrity, local link/image validity via `pulldown-cmark`, and (ADR 0013)
+//! ```mermaid``` fence validation in-process via `merman-core`.
 //!
 //! Every record's content (`records`, `links`) is read through
 //! `DocStore::read`, so `check` validates whichever backend `run` is given.
@@ -57,9 +57,7 @@ pub fn run(store: &dyn DocStore, bundle: &Path) -> ExitCode {
     links::check_links(store, bundle, &all_md, &mut reporter);
     records::check_supersede_chain(store, &all_md, &mut reporter);
 
-    if let Some(code) = mermaid::check_bundle(&all_md, &mut reporter) {
-        return code;
-    }
+    mermaid::check_bundle(&all_md, &mut reporter);
 
     reporter.finish(all_md.len())
 }


### PR DESCRIPTION
## Summary

The doc-gate (`living-docs check` / `check --mermaid-only`) validated ` ```mermaid ` fences by shelling out to a pinned `minlag/mermaid-cli` Docker image — a runtime Docker dependency that contradicted the tool's determinism boundary (ADR 0001: the tool is deterministic by construction, no external daemon). This PR removes that dependency: mermaid diagrams are now validated **in-process** by the pure-Rust `merman-core` parser, so the gate runs with no Docker daemon present.

The decision and its rejected alternatives are recorded in **ADR 0013**. A parity spike measured `merman-core` 0.7.0 against the repo's own fixture corpus (4/4: flowchart TD/LR + erDiagram accepted, broken-arrow chain rejected). The choice is bounded by a **conformance-corpus fitness function**, not by trust in an alpha crate — the valid/invalid fixtures fail CI on any parity divergence.

## Changes

- `docs/adr/0013-mermaid-validation-runs-in-process-via-merman-core-not-a-docker-mermaid-cli-shell-out.md` — new ADR: context (runtime Docker dependency vs ADR 0001), decision (adopt `merman-core` parse-only, bounded by the corpus), rejected alternatives (embed mermaid.js via a JS engine, hand-roll a grammar, keep Docker), accepted risks (crate maturity, ~170 transitive deps), and the fitness-function verification criteria.
- `docs/adr/index.md` — index row for ADR 0013.
- `living-docs-core/Cargo.toml` — add `merman-core = "=0.7.0"` (exact pin).
- `living-docs-core/src/check/mermaid.rs` — replace the Docker shell-out with a single `merman_core::Engine` + `parse_diagram_sync(body, ParseOptions::strict())` (`Ok(Some)`=valid, `Err`/`Ok(None)`=`Failure`); delete all Docker plumbing (`DockerUnavailable`, `docker_available`, `mermaid_cli_image`/`DEFAULT_IMAGE`, uid-gid, scratch-dir); `check_bundle` now returns `()`. Fence extraction, file discovery, `Diagram`/`Failure`, `print_failures`, and `run_mermaid_only`'s exit-code contract are unchanged. Adds the ADR-0013 conformance-corpus test.
- `living-docs-core/src/check/mod.rs` — update the `//!` docblock to describe `merman-core`; the `check_bundle` call site becomes a plain call.
- `cli/tests/check_mermaid.rs` — delete the obsolete `mermaid_only_exits_2_when_docker_is_unavailable...` test and the `docker_available()` skip-guards (the two fixture tests now run unconditionally); add `mermaid_only_validates_without_docker_on_path` (`PATH=/nonexistent` → valid fixture exits 0, invalid exits 1 with a `doc.md:` pointer).
- `Makefile` — drop the Docker claim from the `test-fixtures` target comment.
- `Cargo.lock` — resolve `merman-core` and its transitive deps.

## Test plan

- [x] `cargo test -p living-docs-core` — 379 passed (includes the conformance-corpus fitness test: flowchart TD/LR + erDiagram + an indented fence accepted, broken-arrow chain rejected).
- [x] `cargo test --manifest-path cli/Cargo.toml` — 82 passed (includes the docker-independence test with `PATH=/nonexistent`).
- [x] `LIVING_DOCS_BIN=target/release/living-docs ./skills/living-docs/tests/run.sh` — all fixtures green **with Docker off PATH**, including `10-mermaid-valid` and `11-mermaid-invalid`.
- [x] `living-docs check docs` stays green over the repo's `docs/`.
- [ ] CI green on this PR.

## Why merman-core over keeping Docker

Full rationale in ADR 0013. In short: the Docker shell-out made validation depend on a running daemon and a network-pulled image, which breaks the determinism boundary and the "no external runtime" promise of the tool. `merman-core` is pure Rust (`#![forbid(unsafe_code)]`), parses 25 diagram types in-process, and its stated design goal is 1:1 parity with a pinned upstream Mermaid baseline. The two accepted risks — the crate's 0.7.x alpha maturity and its ~170 transitive deps — are mitigated by the exact version pin and the conformance corpus that fails CI on any parity drift.

## Notes

- Quality gate flagged two items, both non-code: `cargo-clippy` could not run (gate container missing the `cc` linker — a gate-infra defect) and `jscpd` reported duplication attributable to `target/` build artifacts the baseline did not exclude. Neither maps to a code change here; aligning the quality-gate image with `Dockerfile.dev` (build toolchain) is a separate infra follow-up.

🤖 Co-authored with Claude Code
