### PR TITLE
fix: package release binary from workspace-root target, not cli/target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           set -euo pipefail
           asset="living-docs-${{ matrix.target }}"
-          cp "cli/target/${{ matrix.target }}/release/living-docs" "$asset"
+          cp "target/${{ matrix.target }}/release/living-docs" "$asset"
           if command -v sha256sum >/dev/null 2>&1; then
             sha256sum "$asset" > "$asset.sha256"
           else

--- a/install.sh
+++ b/install.sh
@@ -197,7 +197,7 @@ build_cli_from_source() {
     || die "cargo not found; install Rust or drop --from-source once a release asset exists"
   run "cargo build --release --manifest-path '$SCRIPT_DIR/cli/Cargo.toml'"
   run "mkdir -p '$dest'"
-  run "install -m 755 '$SCRIPT_DIR/cli/target/release/living-docs' '$dest/living-docs'"
+  run "install -m 755 '$SCRIPT_DIR/target/release/living-docs' '$dest/living-docs'"
   note "living-docs (built from source) -> $dest/living-docs"
 }
 


### PR DESCRIPTION
## Summary

Hotfix for the failed **v0.6.0** release run. The binary cross-compile jobs built the `living-docs` binary successfully, but the *Package asset* step could not find it: after the `living-docs-core` workspace extraction, `cargo build --manifest-path cli/Cargo.toml --target <triple>` writes the binary to the **workspace-root** `target/<triple>/release/living-docs`, not `cli/target/...`. Two files still pointed at the stale per-crate path. This repoints both.

The `release` job (skills zip + GitHub Release object) had already succeeded on v0.6.0; only the four `release binary` jobs failed, so the 0.6.0 release currently has no prebuilt binaries attached. Re-tagging v0.6.0 onto the merge of this fix re-runs the workflow and uploads them.

## Changes

- `.github/workflows/release.yml` — Package asset step copies from `target/${{ matrix.target }}/release/living-docs` (workspace-root) instead of `cli/target/...`.
- `install.sh` — `build_cli_from_source` installs from `$SCRIPT_DIR/target/release/living-docs` (same workspace-root path), fixing the `install.sh cli --from-source` fallback.

## Test plan

- [x] `bash -n install.sh` exit 0; `release.yml` parses as valid YAML; shellcheck + actionlint clean.
- [x] No `cli/target` references remain in `.github/`, `install.sh`, or `Makefile`.
- [x] `./install.sh cli --from-source --dir <tmp>` builds and installs a working binary; `<tmp>/living-docs skill --list --plain` exits 0 and lists the three skills.
- [ ] CI green; re-tagged v0.6.0 release run uploads the four `living-docs-<triple>` assets.

🤖 Co-authored with Claude Code
