### PR TITLE
docs: reword okf-format topic to drop positional reference

### DIFF
--- a/skills/living-docs/rules/okf-format.md
+++ b/skills/living-docs/rules/okf-format.md
@@ -3,8 +3,8 @@
 The five Core invariants (in the living-docs SKILL.md) govern *organization and lifecycle*; the **Open Knowledge Format** governs the *file format* so the corpus stays portable and agent-parseable. Every doc in the system is also an OKF concept. Load the `okf-knowledge-format` skill (it vendors the spec) when authoring or checking format.
 
 > **OKF is a thin, swappable dependency — not a foundation (version risk).** OKF is **v0.1
-> from a single vendor**; a backward-incompatible v0.2 is a real possibility. The invariants
-> above do **not** depend on OKF — they depend only on a small set of frontmatter fields, so an
+> from a single vendor**; a backward-incompatible v0.2 is a real possibility. The five Core
+> invariants do **not** depend on OKF — they depend only on a small set of frontmatter fields, so an
 > OKF break cannot take the governance layer down with it. Keep the boundary explicit:
 > - **Required by Living Docs** (the fact contract `living-docs check` enforces): a non-empty
 >   `type`, and `status` + `superseded_by` on superseded records. These are *ours*; they survive


### PR DESCRIPTION
## Summary

The `okf-format` topic is served **standalone, per-topic** via `living-docs skill living-docs --topic okf-format` (the slim-SKILL.md + CLI-served-corpus model, ADR 0014). A topic served on its own must read coherently without the surrounding document. The blockquote still carried a **positional reference** — "The invariants **above**" — a leftover from the pre-slim fat `SKILL.md`, where the five invariants were literally listed above that line. They now live in `SKILL.md` and are only *referenced* at the top of this topic, so "above" points at nothing when the topic is loaded on its own.

This names them directly instead: **"The five Core invariants"** — matching how the topic's opening line already refers to them ("The five Core invariants (in the living-docs SKILL.md)").

## Changes

- `skills/living-docs/rules/okf-format.md` — blockquote line: "The invariants above do **not** depend on OKF" → "The five Core invariants do **not** depend on OKF". Drops the positional "above" so the topic is standalone-coherent when served per-topic.

## Test plan

- [x] `grep` over the served topics (`skills/living-docs/rules/*.md`) confirms no remaining positional reference to the five invariants ("above"/"below"); the other mentions in `enforcement-modes.md` are referential-by-name, not positional.
- [x] Inert Markdown change — no test in `cli/tests/` asserts this prose, and `rust-embed` embeds file bytes verbatim, so the corpus continues to build and serve unchanged.

## Notes

This closes the **last of the three S2 Reviewer nits** on the living-docs topics. The other two were already resolved by later db-mode work:
- `check.md` heading nesting (`###` → `##`) — already consistent (`##` only).
- `SKILL.md` "When to invoke" bullets — already carry `--topic` pointers.

Evaldo Klock <neto.nemesis@gmail.com>
