### PR TITLE
feat: three-pane web shell with metadata panel and cmd+k palette

### DIFF
--- a/db-store/src/entity.rs
+++ b/db-store/src/entity.rs
@@ -39,7 +39,9 @@ pub mod records {
     /// project (`UNIQUE(project_id, path)`, not globally). `identity_kind`
     /// discriminates which of `number`/`concept_id` is the record's
     /// identity (ADR 0007 decision 2); this slice populates both fields
-    /// from `doc_type` without yet enforcing the XOR.
+    /// from `doc_type` without yet enforcing the XOR. `status` is the
+    /// frontmatter `status:` value, `None` when the doc carries no such key
+    /// (issue 0008, ADR 0015, S1).
     #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
     #[sea_orm(table_name = "records")]
     pub struct Model {
@@ -54,6 +56,7 @@ pub mod records {
         pub title: String,
         pub description: String,
         pub body: String,
+        pub status: Option<String>,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/db-store/src/lib.rs
+++ b/db-store/src/lib.rs
@@ -19,7 +19,7 @@ use std::path::{Path, PathBuf};
 use living_docs_core::store::{DocStore, SearchIndex};
 use sea_orm::{
     ColumnTrait, ConnectionTrait, Database, DatabaseConnection, DbBackend, DbErr, EntityTrait,
-    QueryFilter, QueryOrder,
+    FromQueryResult, QueryFilter, QueryOrder, QuerySelect,
 };
 use sea_orm_migration::MigratorTrait;
 
@@ -103,6 +103,154 @@ fn project_to_view(model: entity::projects::Model) -> ProjectView {
         slug: model.slug,
         name: model.name,
     }
+}
+
+/// One record's nav-tree entry: enough to group and order the web three-pane
+/// shell's sidebar by doc type without a second lookup (issue 0008, ADR
+/// 0015, S1).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NavEntry {
+    pub doc_type: String,
+    pub number: Option<i32>,
+    pub title: String,
+    pub path: String,
+}
+
+/// A [`NavEntry`]'s raw column projection, used to select `DISTINCT` rows
+/// over just the nav-relevant columns rather than the full [`entity::Model`]
+/// (whose `project_id` would defeat cross-project dedup).
+#[derive(Debug, FromQueryResult)]
+struct NavRow {
+    doc_type: String,
+    number: Option<i32>,
+    title: String,
+    path: String,
+}
+
+/// Lists every distinct record path, spanning every project, ordered by
+/// `doc_type` then `number` then `path` — the order the web three-pane
+/// shell's nav tree groups and renders by (issue 0008, ADR 0015, S1). The
+/// web front's nav links are path-addressed with no project dimension
+/// (`/record/<path>`, issue 0005), so two projects synced from identical
+/// bundles must collapse to one [`NavEntry`] per distinct `path` here —
+/// project-scoped nav is an explicitly deferred follow-up (issue 0008, ADR
+/// 0015, S2 browser-gate finding).
+pub async fn records_by_type(conn: &DatabaseConnection) -> Result<Vec<NavEntry>> {
+    let rows = Records::find()
+        .select_only()
+        .column(Column::DocType)
+        .column(Column::Number)
+        .column(Column::Title)
+        .column(Column::Path)
+        .distinct()
+        .order_by_asc(Column::DocType)
+        .order_by_asc(Column::Number)
+        .order_by_asc(Column::Path)
+        .into_model::<NavRow>()
+        .all(conn)
+        .await?;
+    Ok(rows.into_iter().map(nav_row_to_nav_entry).collect())
+}
+
+fn nav_row_to_nav_entry(row: NavRow) -> NavEntry {
+    NavEntry {
+        doc_type: row.doc_type,
+        number: row.number,
+        title: row.title,
+        path: row.path,
+    }
+}
+
+/// A record related to another by a supersede edge, carrying the target's
+/// path and title rather than its raw `NNNN` number — the shape the web
+/// front's supersede-chain link needs to render a clickable reference
+/// (issue 0008, ADR 0015, S1), unlike [`resolve_supersedes`]/
+/// [`resolve_superseded_by`] which resolve to the raw frontmatter number for
+/// [`load_record`]'s canonical round trip.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RelatedRef {
+    pub path: String,
+    pub title: String,
+}
+
+/// A record's metadata for the web three-pane shell's detail pane: its doc
+/// type, status, both supersede directions (as path+title link targets),
+/// and its tags (issue 0008, ADR 0015, S1).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecordMeta {
+    pub doc_type: String,
+    pub status: Option<String>,
+    pub supersedes: Vec<RelatedRef>,
+    pub superseded_by: Vec<RelatedRef>,
+    pub tags: Vec<String>,
+}
+
+/// Looks up `path`'s metadata, spanning every project like [`record_by_path`]
+/// (kept unscoped for the web front, which is not project-aware until issue
+/// 0005 slice 0005-C). Returns `None` when no record exists at that path,
+/// never an error.
+pub async fn record_meta(conn: &DatabaseConnection, path: &str) -> Result<Option<RecordMeta>> {
+    let Some(model) = Records::find()
+        .filter(Column::Path.eq(path))
+        .one(conn)
+        .await?
+    else {
+        return Ok(None);
+    };
+
+    let supersedes = related_refs_from(conn, model.id).await?;
+    let superseded_by = related_refs_to(conn, model.id).await?;
+    let tags = load_sorted_tags(conn, model.id).await?;
+
+    Ok(Some(RecordMeta {
+        doc_type: model.doc_type,
+        status: model.status,
+        supersedes,
+        superseded_by,
+        tags,
+    }))
+}
+
+/// `record_id`'s outgoing supersede edges (this record supersedes the
+/// targets), resolved to each target's path+title.
+async fn related_refs_from(conn: &DatabaseConnection, record_id: i32) -> Result<Vec<RelatedRef>> {
+    let target_ids: Vec<i32> = relations::Entity::find()
+        .filter(relations::Column::Kind.eq(SUPERSEDE_RELATION_KIND))
+        .filter(relations::Column::FromRecordId.eq(record_id))
+        .all(conn)
+        .await?
+        .into_iter()
+        .map(|relation| relation.to_record_id)
+        .collect();
+    related_refs_for_ids(conn, &target_ids).await
+}
+
+/// `record_id`'s incoming supersede edges (this record is superseded by the
+/// sources), resolved to each source's path+title.
+async fn related_refs_to(conn: &DatabaseConnection, record_id: i32) -> Result<Vec<RelatedRef>> {
+    let source_ids: Vec<i32> = relations::Entity::find()
+        .filter(relations::Column::Kind.eq(SUPERSEDE_RELATION_KIND))
+        .filter(relations::Column::ToRecordId.eq(record_id))
+        .all(conn)
+        .await?
+        .into_iter()
+        .map(|relation| relation.from_record_id)
+        .collect();
+    related_refs_for_ids(conn, &source_ids).await
+}
+
+async fn related_refs_for_ids(conn: &DatabaseConnection, ids: &[i32]) -> Result<Vec<RelatedRef>> {
+    let records = Records::find()
+        .filter(Column::Id.is_in(ids.to_owned()))
+        .all(conn)
+        .await?;
+    Ok(records
+        .into_iter()
+        .map(|record| RelatedRef {
+            path: record.path,
+            title: record.title,
+        })
+        .collect())
 }
 
 /// Result alias for this crate's fallible operations, using SeaORM's own
@@ -379,6 +527,7 @@ async fn load_record(
         supersedes,
         superseded_by,
         tags: record_tags,
+        status: model.status,
         frontmatter_tail,
     }))
 }
@@ -627,6 +776,146 @@ mod tests {
         let projects = list_projects(&conn).await.expect("list projects");
 
         assert!(projects.is_empty());
+    }
+
+    #[tokio::test]
+    async fn records_by_type_orders_by_doc_type_then_number_then_path() {
+        let conn = connect_in_memory().await.expect("connect");
+        migrate(&conn).await.expect("migrate");
+        let (store, bundle) = sync::test_support::mixed_type_corpus();
+        sync::sync(&conn, &store, &bundle).await.expect("sync");
+
+        let entries = records_by_type(&conn).await.expect("records_by_type");
+
+        assert_eq!(
+            entries,
+            vec![
+                NavEntry {
+                    doc_type: "ADR".to_owned(),
+                    number: Some(1),
+                    title: "First ADR".to_owned(),
+                    path: "adr/0001-first-adr.md".to_owned(),
+                },
+                NavEntry {
+                    doc_type: "ADR".to_owned(),
+                    number: Some(2),
+                    title: "Second ADR".to_owned(),
+                    path: "adr/0002-second-adr.md".to_owned(),
+                },
+                NavEntry {
+                    doc_type: "BDR".to_owned(),
+                    number: Some(1),
+                    title: "First BDR".to_owned(),
+                    path: "bdr/0001-first-bdr.md".to_owned(),
+                },
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn records_by_type_dedupes_identical_paths_synced_into_two_projects() {
+        let conn = connect_in_memory().await.expect("connect");
+        migrate(&conn).await.expect("migrate");
+        let (store_a, bundle_a) = sync::test_support::mixed_type_corpus();
+        sync::sync_project(&conn, &store_a, &bundle_a, "team-a")
+            .await
+            .expect("sync team-a");
+        let (store_b, bundle_b) = sync::test_support::mixed_type_corpus();
+        sync::sync_project(&conn, &store_b, &bundle_b, "team-b")
+            .await
+            .expect("sync team-b");
+
+        let entries = records_by_type(&conn).await.expect("records_by_type");
+
+        assert_eq!(
+            entries,
+            vec![
+                NavEntry {
+                    doc_type: "ADR".to_owned(),
+                    number: Some(1),
+                    title: "First ADR".to_owned(),
+                    path: "adr/0001-first-adr.md".to_owned(),
+                },
+                NavEntry {
+                    doc_type: "ADR".to_owned(),
+                    number: Some(2),
+                    title: "Second ADR".to_owned(),
+                    path: "adr/0002-second-adr.md".to_owned(),
+                },
+                NavEntry {
+                    doc_type: "BDR".to_owned(),
+                    number: Some(1),
+                    title: "First BDR".to_owned(),
+                    path: "bdr/0001-first-bdr.md".to_owned(),
+                },
+            ],
+            "records_by_type must return each distinct path exactly once even when \
+             two projects sync from identical bundles"
+        );
+    }
+
+    #[tokio::test]
+    async fn records_by_type_returns_an_empty_vector_when_nothing_has_synced() {
+        let conn = connect_in_memory().await.expect("connect");
+        migrate(&conn).await.expect("migrate");
+
+        let entries = records_by_type(&conn).await.expect("records_by_type");
+
+        assert!(entries.is_empty());
+    }
+
+    #[tokio::test]
+    async fn record_meta_resolves_both_supersede_directions_with_status_and_tags() {
+        let conn = connect_in_memory().await.expect("connect");
+        migrate(&conn).await.expect("migrate");
+        let (store, bundle) = sync::test_support::superseding_corpus();
+        sync::sync(&conn, &store, &bundle).await.expect("sync");
+
+        let superseded = record_meta(&conn, "adr/0001-quokka-caching.md")
+            .await
+            .expect("query record_meta for superseded record")
+            .expect("superseded record exists");
+        assert_eq!(superseded.doc_type, "ADR");
+        assert_eq!(superseded.status, None);
+        assert!(superseded.supersedes.is_empty());
+        assert_eq!(
+            superseded.superseded_by,
+            vec![RelatedRef {
+                path: "adr/0002-quokka-caching-v2.md".to_owned(),
+                title: "Quokka Caching V2".to_owned(),
+            }]
+        );
+        assert_eq!(superseded.tags, vec!["caching".to_owned()]);
+
+        let superseding = record_meta(&conn, "adr/0002-quokka-caching-v2.md")
+            .await
+            .expect("query record_meta for superseding record")
+            .expect("superseding record exists");
+        assert_eq!(superseding.status, Some("Accepted".to_owned()));
+        assert_eq!(
+            superseding.supersedes,
+            vec![RelatedRef {
+                path: "adr/0001-quokka-caching.md".to_owned(),
+                title: "Quokka Caching".to_owned(),
+            }]
+        );
+        assert!(superseding.superseded_by.is_empty());
+        assert_eq!(
+            superseding.tags,
+            vec!["caching".to_owned(), "performance".to_owned()]
+        );
+    }
+
+    #[tokio::test]
+    async fn record_meta_returns_none_for_an_unknown_path() {
+        let conn = connect_in_memory().await.expect("connect");
+        migrate(&conn).await.expect("migrate");
+
+        let meta = record_meta(&conn, "adr/9999-missing.md")
+            .await
+            .expect("record_meta on an unknown path is not an error");
+
+        assert!(meta.is_none());
     }
 
     #[test]

--- a/db-store/src/migration.rs
+++ b/db-store/src/migration.rs
@@ -16,6 +16,7 @@ impl MigratorTrait for Migrator {
             Box::new(CreateRecords),
             Box::new(CreateMultiProjectSchema),
             Box::new(CreateAuthoringSchema),
+            Box::new(AddRecordStatus),
         ]
     }
 }
@@ -226,6 +227,46 @@ async fn create_authoring_records_table(manager: &SchemaManager<'_>) -> Result<(
                 .to_owned(),
         )
         .await
+}
+
+/// Adds a nullable `status` column to `records`, extracted from the
+/// frontmatter `status:` key the same way `title`/`description` already are
+/// (issue 0008, ADR 0015, S1). `records` is a derived read-model rebuilt in
+/// full by [`crate::sync::sync`], but this column arrives as a genuine
+/// additive migration — never by editing [`CreateAuthoringSchema`] — so a
+/// database that has already applied earlier migrations only gains the
+/// column, it is not recreated.
+struct AddRecordStatus;
+
+impl MigrationName for AddRecordStatus {
+    fn name(&self) -> &str {
+        "m20260718_000004_add_record_status"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for AddRecordStatus {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Records::Table)
+                    .add_column(ColumnDef::new(Records::Status).text())
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Records::Table)
+                    .drop_column(Records::Status)
+                    .to_owned(),
+            )
+            .await
+    }
 }
 
 /// Creates the ordered EAV frontmatter tail: one row per non-typed
@@ -523,6 +564,7 @@ enum Records {
     Title,
     Description,
     Body,
+    Status,
 }
 
 #[derive(DeriveIden)]

--- a/db-store/src/record.rs
+++ b/db-store/src/record.rs
@@ -30,7 +30,7 @@ const NUMBERED_DOC_TYPES: [&str; 4] = ["adr", "bdr", "prd", "issue"];
 /// Frontmatter keys that already have a universal typed column or dedicated
 /// handling elsewhere, and therefore never land in the EAV
 /// [`ExtractedRecord::frontmatter_tail`] (ADR 0007 decision 1).
-const TYPED_FRONTMATTER_KEYS: [&str; 8] = [
+const TYPED_FRONTMATTER_KEYS: [&str; 9] = [
     "type",
     "title",
     "description",
@@ -39,6 +39,7 @@ const TYPED_FRONTMATTER_KEYS: [&str; 8] = [
     "supersedes",
     "superseded_by",
     "tags",
+    "status",
 ];
 
 /// A single ranked full-text search hit: the record's bundle-relative path,
@@ -66,9 +67,11 @@ pub struct SearchHit {
 /// (unresolved to a record id — that
 /// resolution happens against a project's other records in
 /// [`crate::sync::sync_project`]); `tags` is the frontmatter's `tags`
-/// sequence, empty when absent. `frontmatter_tail` is every remaining
-/// frontmatter key with no typed column, in source encounter order, ready
-/// to insert into `frontmatter_fields` with the index as `ordinal`.
+/// sequence, empty when absent. `status` is the frontmatter `status:`
+/// value, `None` when the key is absent (issue 0008, ADR 0015, S1).
+/// `frontmatter_tail` is every remaining frontmatter key with no typed
+/// column, in source encounter order, ready to insert into
+/// `frontmatter_fields` with the index as `ordinal`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ExtractedRecord {
     pub doc_type: String,
@@ -81,6 +84,7 @@ pub struct ExtractedRecord {
     pub supersedes: Option<String>,
     pub superseded_by: Option<String>,
     pub tags: Vec<String>,
+    pub status: Option<String>,
     pub frontmatter_tail: Vec<(String, String)>,
 }
 
@@ -110,6 +114,7 @@ pub fn extract_record(path: &Path, contents: &str) -> ExtractedRecord {
     let supersedes = frontmatter_scalar(frontmatter.as_ref(), "supersedes");
     let superseded_by = frontmatter_scalar(frontmatter.as_ref(), "superseded_by");
     let tags = frontmatter_sequence(frontmatter.as_ref(), "tags");
+    let status = frontmatter_scalar(frontmatter.as_ref(), "status");
     let frontmatter_tail = extract_frontmatter_tail(frontmatter.as_ref());
 
     ExtractedRecord {
@@ -123,6 +128,7 @@ pub fn extract_record(path: &Path, contents: &str) -> ExtractedRecord {
         supersedes,
         superseded_by,
         tags,
+        status,
         frontmatter_tail,
     }
 }
@@ -410,11 +416,27 @@ mod tests {
         assert_eq!(
             extracted.frontmatter_tail,
             vec![
-                ("status".to_owned(), "Accepted".to_owned()),
                 ("tracker".to_owned(), "JIRA-1".to_owned()),
                 ("timestamp".to_owned(), "2026-07-17T00:00:00Z".to_owned()),
             ]
         );
+        assert_eq!(extracted.status, Some("Accepted".to_owned()));
+    }
+
+    #[test]
+    fn extract_record_reads_status_when_present() {
+        let contents = "---\ntype: ADR\nstatus: Accepted\n---\nBody.\n";
+        let extracted = extract_record(Path::new("/bundle/adr/0001-status.md"), contents);
+
+        assert_eq!(extracted.status, Some("Accepted".to_owned()));
+    }
+
+    #[test]
+    fn extract_record_defaults_missing_status_to_none() {
+        let contents = "---\ntype: ADR\ntitle: No Status\n---\nBody.\n";
+        let extracted = extract_record(Path::new("/bundle/adr/0002-no-status.md"), contents);
+
+        assert_eq!(extracted.status, None);
     }
 
     #[test]

--- a/db-store/src/serialize.rs
+++ b/db-store/src/serialize.rs
@@ -15,7 +15,7 @@ const TIMESTAMP_KEY: &str = "timestamp";
 
 /// Reconstructs `record` as canonical markdown: a `---`-fenced frontmatter
 /// block in the fixed field order — `type`, `title`, `description`,
-/// `status` (if present in the tail), `supersedes`, `superseded_by`, `tags`,
+/// `status` (if present), `supersedes`, `superseded_by`, `tags`,
 /// the remaining frontmatter tail by ascending ordinal, `tracker` (if
 /// present), then `timestamp` (if present) — followed by a blank line and
 /// the body. The typed identity (`number`/`concept_id`) is never emitted:
@@ -32,7 +32,7 @@ pub fn to_canonical_markdown(record: &ExtractedRecord) -> String {
         "description: {}",
         format_scalar(&record.description)
     ));
-    push_tail_key(&mut lines, record, STATUS_KEY);
+    push_optional(&mut lines, STATUS_KEY, record.status.as_deref());
     push_optional(&mut lines, "supersedes", record.supersedes.as_deref());
     push_optional(&mut lines, "superseded_by", record.superseded_by.as_deref());
     push_tags(&mut lines, &record.tags);
@@ -89,7 +89,7 @@ fn tail_value<'a>(record: &'a ExtractedRecord, key: &str) -> Option<&'a str> {
 }
 
 fn is_special_tail_key(key: &str) -> bool {
-    key == STATUS_KEY || key == TRACKER_KEY || key == TIMESTAMP_KEY
+    key == TRACKER_KEY || key == TIMESTAMP_KEY
 }
 
 const YAML_INDICATOR_PREFIXES: &str = "!&*-?|>%@`\"'#,[]{}";
@@ -132,8 +132,8 @@ mod tests {
             supersedes: Some("0001".to_owned()),
             superseded_by: None,
             tags: vec!["caching".to_owned(), "performance".to_owned()],
+            status: Some("Accepted".to_owned()),
             frontmatter_tail: vec![
-                ("status".to_owned(), "Accepted".to_owned()),
                 ("labels".to_owned(), "important".to_owned()),
                 ("blocked_by".to_owned(), "0002".to_owned()),
                 ("tracker".to_owned(), "JIRA-42".to_owned()),
@@ -186,6 +186,7 @@ mod tests {
         assert_eq!(reparsed.supersedes, original.supersedes);
         assert_eq!(reparsed.superseded_by, original.superseded_by);
         assert_eq!(reparsed.tags, original.tags);
+        assert_eq!(reparsed.status, original.status);
         assert_eq!(reparsed.frontmatter_tail, original.frontmatter_tail);
     }
 
@@ -212,7 +213,8 @@ mod tests {
             supersedes: None,
             superseded_by: None,
             tags: vec!["glossary".to_owned()],
-            frontmatter_tail: vec![("status".to_owned(), "Active".to_owned())],
+            status: Some("Active".to_owned()),
+            frontmatter_tail: Vec::new(),
         };
 
         let markdown = to_canonical_markdown(&record);
@@ -234,6 +236,7 @@ mod tests {
             supersedes: None,
             superseded_by: None,
             tags: Vec::new(),
+            status: None,
             frontmatter_tail: Vec::new(),
         };
 
@@ -261,6 +264,7 @@ mod tests {
             supersedes: None,
             superseded_by: None,
             tags: Vec::new(),
+            status: None,
             frontmatter_tail: Vec::new(),
         };
 
@@ -269,5 +273,33 @@ mod tests {
         assert!(markdown.contains("title: \"Caching: A Deep Dive\""));
         let reparsed = extract_record(Path::new("adr/0002-caching.md"), &markdown);
         assert_eq!(reparsed.title, "Caching: A Deep Dive");
+    }
+
+    /// Asserts `status` is read from [`ExtractedRecord::status`] rather than
+    /// the frontmatter tail (issue 0008, ADR 0015, S1 round 2): the typed
+    /// field must still round-trip to a `status:` frontmatter line even
+    /// though `frontmatter_tail` never carries a `status` entry.
+    #[test]
+    fn to_canonical_markdown_emits_status_from_the_typed_field() {
+        let record = ExtractedRecord {
+            doc_type: "ADR".to_owned(),
+            number: Some(3),
+            concept_id: None,
+            identity_kind: NUMBER_IDENTITY_KIND.to_owned(),
+            title: "Typed Status".to_owned(),
+            description: "d.".to_owned(),
+            body: "Body.\n".to_owned(),
+            supersedes: None,
+            superseded_by: None,
+            tags: Vec::new(),
+            status: Some("Accepted".to_owned()),
+            frontmatter_tail: Vec::new(),
+        };
+
+        let markdown = to_canonical_markdown(&record);
+
+        assert!(markdown.contains("status: Accepted"));
+        let reparsed = extract_record(Path::new("adr/0003-typed-status.md"), &markdown);
+        assert_eq!(reparsed.status, Some("Accepted".to_owned()));
     }
 }

--- a/db-store/src/sync.rs
+++ b/db-store/src/sync.rs
@@ -168,6 +168,7 @@ async fn insert_record<C: ConnectionTrait>(
         title: ActiveValue::Set(extracted.title),
         description: ActiveValue::Set(extracted.description),
         body: ActiveValue::Set(extracted.body),
+        status: ActiveValue::Set(extracted.status),
         ..Default::default()
     }
     .insert(conn)
@@ -432,6 +433,7 @@ async fn insert_record_row<C: ConnectionTrait>(
         title: ActiveValue::Set(extracted.title.clone()),
         description: ActiveValue::Set(extracted.description.clone()),
         body: ActiveValue::Set(extracted.body.clone()),
+        status: ActiveValue::Set(extracted.status.clone()),
         ..Default::default()
     }
     .insert(conn)
@@ -453,6 +455,7 @@ async fn update_record_row<C: ConnectionTrait>(
         title: ActiveValue::Set(extracted.title.clone()),
         description: ActiveValue::Set(extracted.description.clone()),
         body: ActiveValue::Set(extracted.body.clone()),
+        status: ActiveValue::Set(extracted.status.clone()),
         ..Default::default()
     };
     let updated = model.update(conn).await?;
@@ -706,6 +709,67 @@ pub(crate) mod test_support {
         files.insert(bundle.join("adr").join("0001-quokka-caching.md"), doc);
         (MemoryStore { files }, bundle)
     }
+
+    /// Two ADR records: one with a `status:` frontmatter key, one without,
+    /// so a sync test can assert the read-model's `status` column is
+    /// populated for the first and `NULL`/`None` for the second (issue
+    /// 0008, ADR 0015, S1).
+    pub(crate) fn corpus_with_and_without_status() -> (MemoryStore, PathBuf) {
+        let bundle = PathBuf::from("/bundle-status");
+        let mut files = BTreeMap::new();
+        files.insert(
+            bundle.join("adr").join("0001-with-status.md"),
+            "---\ntype: ADR\ntitle: With Status\ndescription: d.\nstatus: Accepted\n---\nBody.\n"
+                .to_owned(),
+        );
+        files.insert(
+            bundle.join("adr").join("0002-without-status.md"),
+            "---\ntype: ADR\ntitle: Without Status\ndescription: d.\n---\nBody.\n".to_owned(),
+        );
+        (MemoryStore { files }, bundle)
+    }
+
+    /// Three records spanning two doc types and non-sequential filesystem
+    /// insertion order, so a nav-listing test can assert the query itself
+    /// orders by doc type, then number, then path, rather than relying on
+    /// insertion order (issue 0008, ADR 0015, S1).
+    pub(crate) fn mixed_type_corpus() -> (MemoryStore, PathBuf) {
+        let bundle = PathBuf::from("/bundle-mixed");
+        let mut files = BTreeMap::new();
+        files.insert(
+            bundle.join("bdr").join("0001-first-bdr.md"),
+            "---\ntype: BDR\ntitle: First BDR\ndescription: d.\n---\nBody.\n".to_owned(),
+        );
+        files.insert(
+            bundle.join("adr").join("0002-second-adr.md"),
+            "---\ntype: ADR\ntitle: Second ADR\ndescription: d.\n---\nBody.\n".to_owned(),
+        );
+        files.insert(
+            bundle.join("adr").join("0001-first-adr.md"),
+            "---\ntype: ADR\ntitle: First ADR\ndescription: d.\n---\nBody.\n".to_owned(),
+        );
+        (MemoryStore { files }, bundle)
+    }
+
+    /// A superseded/superseding ADR pair, each carrying tags, so a
+    /// `record_meta` test can assert both supersede directions resolve to
+    /// the related record's path+title and that tags are attached (issue
+    /// 0008, ADR 0015, S1).
+    pub(crate) fn superseding_corpus() -> (MemoryStore, PathBuf) {
+        let bundle = PathBuf::from("/bundle-supersede");
+        let mut files = BTreeMap::new();
+        files.insert(
+            bundle.join("adr").join("0001-quokka-caching.md"),
+            "---\ntype: ADR\ntitle: Quokka Caching\ndescription: d.\nsuperseded_by: 0002\ntags: [caching]\n---\nBody.\n"
+                .to_owned(),
+        );
+        files.insert(
+            bundle.join("adr").join("0002-quokka-caching-v2.md"),
+            "---\ntype: ADR\ntitle: Quokka Caching V2\ndescription: d.\nstatus: Accepted\nsupersedes: 0001\ntags: [caching, performance]\n---\nBody.\n"
+                .to_owned(),
+        );
+        (MemoryStore { files }, bundle)
+    }
 }
 
 #[cfg(test)]
@@ -833,5 +897,30 @@ mod tests {
             .await
             .expect("query records for project");
         assert_eq!(stored.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn sync_persists_status_from_frontmatter_and_none_when_absent() {
+        let conn = connect_in_memory().await.expect("connect");
+        migrate(&conn).await.expect("migrate");
+        let (store, bundle) = super::test_support::corpus_with_and_without_status();
+
+        sync(&conn, &store, &bundle).await.expect("sync");
+
+        let with_status = Records::find()
+            .filter(Column::Path.eq("adr/0001-with-status.md"))
+            .one(&conn)
+            .await
+            .expect("query with-status record")
+            .expect("with-status record exists");
+        assert_eq!(with_status.status, Some("Accepted".to_owned()));
+
+        let without_status = Records::find()
+            .filter(Column::Path.eq("adr/0002-without-status.md"))
+            .one(&conn)
+            .await
+            .expect("query without-status record")
+            .expect("without-status record exists");
+        assert_eq!(without_status.status, None);
     }
 }

--- a/db-store/tests/ingestion.rs
+++ b/db-store/tests/ingestion.rs
@@ -361,7 +361,6 @@ async fn frontmatter_tail_excludes_typed_and_relation_keys_and_preserves_ordinal
     assert_eq!(
         ordered,
         vec![
-            ("status", "Accepted"),
             ("labels", "important"),
             ("blocked_by", "0002"),
             ("tracker", "JIRA-42"),
@@ -370,9 +369,11 @@ async fn frontmatter_tail_excludes_typed_and_relation_keys_and_preserves_ordinal
         "the tail must reconstruct in source encounter order by ascending ordinal"
     );
     assert!(
-        tail.iter()
-            .all(|field| field.key != "type" && field.key != "title" && field.key != "description"),
-        "type/title/description are typed columns and must not appear in the tail"
+        tail.iter().all(|field| field.key != "type"
+            && field.key != "title"
+            && field.key != "description"
+            && field.key != "status"),
+        "type/title/description/status are typed columns and must not appear in the tail"
     );
 }
 

--- a/db-store/tests/parity.rs
+++ b/db-store/tests/parity.rs
@@ -332,12 +332,13 @@ fn reconstructed_tail_preserves_both_field_order_and_the_concrete_ordinal_sequen
 
     assert_eq!(
         ordinals,
-        vec![0, 1, 2, 3, 4],
+        vec![0, 1, 2, 3],
         "ordinals must be the sequential 0..N encounter positions, not a constant"
     );
     assert_eq!(
         keys,
-        vec!["status", "labels", "blocked_by", "tracker", "timestamp"]
+        vec!["labels", "blocked_by", "tracker", "timestamp"],
+        "status has a typed column and never lands in the EAV tail (issue 0008, ADR 0015, S1)"
     );
 
     let db_store =

--- a/docs/adr/0015-web-ux-follows-the-three-pane-doc-site-archetype-with-search-first-cmd-k-palette.md
+++ b/docs/adr/0015-web-ux-follows-the-three-pane-doc-site-archetype-with-search-first-cmd-k-palette.md
@@ -1,0 +1,78 @@
+---
+type: ADR
+title: Web UX follows the three-pane doc-site archetype with a search-first Cmd+K palette
+description: The web front adopts the doc-site three-pane layout (type-grouped nav tree, rendered record, metadata/relations panel) with FTS5-backed search-first navigation via a Cmd+K palette — not a Notion-style block editor UX.
+status: Accepted
+supersedes:
+superseded_by:
+tags: [web, ux, frontend]
+timestamp: 2026-07-19T02:16:09Z
+---
+
+# 0015. Web UX follows the three-pane doc-site archetype with a search-first Cmd+K palette
+
+## Context
+
+Issue [0003](/issues/0003-web-read-only.md) delivers a
+read-only, server-rendered axum + maud view over the SQLite/FTS5 read-model (ADR 0006:
+no in-browser editing — authoring stays in the CLI + model). With the minimal
+search-page + record-page slices defined, the open fork was which UX archetype the web
+front grows into.
+
+Candidates considered:
+
+- **Notion-style database views.** Notion's core value is its block *editor*, which
+  ADR 0006 forbids here; what remains (filterable tables, clean typography) does not
+  justify the heavier client-side surface it implies.
+- **Decision-timeline home (log4brains).** Strong for the ADR supersede trail, weak for
+  general browsing of PRDs, BDRs, issues, and research notes.
+- **Doc-site three-pane (mkdocs-material / GitBook)** with **search-first navigation
+  (Linear-style Cmd+K palette)**. Matches a read-only corpus grouped by type, keeps the
+  FTS5 read-model — the system's findability core — as the primary entry point, and is
+  achievable server-rendered.
+
+The determinism boundary and the maud/server-rendered stack (plan for issue 0003) bound
+the choice: the archetype must not require a heavy client framework.
+
+## Decision
+
+We will build the web UX as a **three-pane doc-site**: a left navigation tree grouped by
+record type (ADR, BDR, PRD, issue, research), a center pane rendering the record body,
+and a right metadata panel showing status, supersede chain, and cross-links
+(log4brains-style lifecycle presentation). Primary navigation is **search-first**: a
+Cmd+K palette querying the FTS5 read-model with ranked results. Rendering stays
+server-side (axum + maud); client-side JavaScript is limited to progressive enhancement
+of the palette (vanilla JS or htmx), never a client framework.
+
+## Consequences
+
+**Easier / gained:**
+- The FTS5 read-model is the front door — search quality directly shapes UX value.
+- The supersede/status lifecycle (the corpus's distinguishing trait) gets a first-class
+  visual surface in the metadata panel.
+- Newcomers get browsable orientation (nav tree by type) without knowing what to search.
+- Stays within the locked stack: no client framework, no build-tooling for the front end.
+
+**Harder / accepted trade-offs:**
+- No Notion-style database/board views; filtering is limited to the nav tree and search.
+- The Cmd+K palette needs a small JS surface, which must stay progressive-enhancement
+  (the plain GET /?q= form remains the no-JS fallback).
+- Three panes require layout/CSS work beyond the minimal slices of issue 0003.
+
+**Follow-ups:**
+- A post-0003 issue for the three-pane shell: nav tree, metadata panel, palette
+  (issue 0003's search + record pages ship first as the walking surface).
+- The metadata panel needs supersede/status/links exposed by the read-model; extend the
+  db-store projection if the current schema does not carry them.
+
+## Verification
+
+**Implementation impact:** `web/src/main.rs`, `web/src/views.rs`, `db-store` (relation
+metadata in the projection), `tests/browser/`.
+
+**Verification criteria:**
+- The record page renders nav tree, body, and metadata panel; the metadata panel shows
+  status and the supersede chain for a superseded record (browser spec).
+- Disabling JavaScript still yields working search via the GET /?q= form (browser spec
+  with JS disabled).
+- The router remains GET-only (ADR 0006 fitness function stays green).

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -24,3 +24,4 @@ repo teaches. The decision *log* is this listing plus each record's `status` /
 * [0012 — Worldwide PII detection is checksum-tiered, two-stage, and deterministic](0012-worldwide-pii-detection-is-checksum-tiered-two-stage-and-deterministic.md) - Accepted
 * [0013 — Mermaid validation runs in-process via merman-core, not a Docker mermaid-cli shell-out](0013-mermaid-validation-runs-in-process-via-merman-core-not-a-docker-mermaid-cli-shell-out.md) - Accepted
 * [0014 — The CLI serves skill content from an embedded corpus; harness SKILL.md files are slim stubs](0014-the-cli-serves-skill-content-from-an-embedded-corpus-harness-skill-md-files-are-slim-stubs.md) - Accepted
+* [0015 — Web UX follows the three-pane doc-site archetype with a search-first Cmd+K palette](0015-web-ux-follows-the-three-pane-doc-site-archetype-with-search-first-cmd-k-palette.md) - Accepted

--- a/docs/bdr/index.md
+++ b/docs/bdr/index.md
@@ -1,0 +1,3 @@
+# BDRs
+
+## Active

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,5 +11,7 @@ and its tooling live here, under the same trail the skill teaches.
 
 * [Constitution](constitution.md) - the north star, scope boundaries, data model, non-negotiables
 * [ADRs](adr/) - how the skill and its tooling are structured, and why
+* [BDRs](bdr/) - behavior decision records: expected observable behavior at the edges
+* [PRDs](prd/) - product requirement docs for larger feature surfaces
 * [Issues](issues/) - the vertical, demoable slices that build the living-docs system
 * [Research](research/) - external, sourced evidence backing the decisions (e.g. the worldwide PII catalog)

--- a/docs/issues/0008-three-pane-web-shell-with-metadata-panel-and-cmd-k-palette.md
+++ b/docs/issues/0008-three-pane-web-shell-with-metadata-panel-and-cmd-k-palette.md
@@ -1,0 +1,54 @@
+---
+type: Issue
+title: Three-pane web shell with metadata panel and Cmd+K palette
+description: Implement the ADR 0015 web UX — type-grouped nav tree, record body pane, status/supersede metadata panel, and a progressive-enhancement Cmd+K search palette.
+status: open
+labels: [web, ux]
+blocked_by: []
+tracker:
+timestamp: 2026-07-19T02:22:09Z
+---
+
+## Three-pane web shell with metadata panel and Cmd+K palette
+
+Implements [ADR 0015](/adr/0015-web-ux-follows-the-three-pane-doc-site-archetype-with-search-first-cmd-k-palette.md)
+on top of the read-only web front delivered by
+[issue 0003](/issues/0003-web-read-only.md). The web view grows from two bare pages
+(search, record) into the three-pane doc-site archetype: left nav tree grouped by record
+type, center record body, right metadata panel (status badge, supersede chain,
+cross-links), with a search-first Cmd+K palette over the FTS5 read-model.
+
+### Scope
+
+- db-store read-model extensions: `status` column extracted from frontmatter, a
+  listing-by-type query for the nav tree, and a record-metadata getter (status,
+  supersedes/superseded_by via the existing relations table, tags).
+- Three-pane server-rendered layout (axum + maud + one static CSS route) applied to the
+  search and record pages.
+- Metadata panel on the record page: status badge, navigable supersede chain, tags.
+- Cmd+K palette as progressive enhancement (small vanilla JS asset + an HTML-fragment
+  results endpoint); the plain `GET /?q=` form remains the no-JS fallback.
+- KEPT: read-only GET-only router (ADR 0006 fitness), maud auto-escaping, async
+  db-store calls in handlers (never the sync port — lesson 3671).
+
+### Acceptance
+
+- The record page renders nav tree, body, and metadata panel; a superseded record shows
+  its status and a navigable supersede chain (browser spec).
+- The nav tree groups records by type and marks the current record (browser spec).
+- With JavaScript disabled, search via `GET /?q=` still works end-to-end (browser spec).
+- The Cmd+K palette opens, queries FTS5, and navigates to a picked record (browser spec).
+- A mutating HTTP method still returns 405 (read-only fitness stays green).
+- `living-docs check` passes; `cargo test --workspace` green.
+
+### Plan
+
+Four vertical slices, each demoable:
+
+1. **S1 — read-model:** `status` column + extraction in sync, `records_by_type` listing,
+   `record_meta` getter (status, supersede chain, tags). Unit-tested in db-store.
+2. **S2 — shell:** three-pane layout + CSS route; nav tree from `records_by_type` on
+   search and record pages.
+3. **S3 — metadata panel:** status badge, supersede chain, tags on the record page.
+4. **S4 — palette:** Cmd+K overlay (vanilla JS, `defer`), HTML-fragment endpoint
+   `GET /palette?q=`, JS-disabled fallback spec.

--- a/docs/issues/index.md
+++ b/docs/issues/index.md
@@ -7,6 +7,8 @@ one slice per fresh context, starting from the skeleton.
 
 ## Open
 
+* [0008 — Three-pane web shell with metadata panel and Cmd+K palette](0008-three-pane-web-shell-with-metadata-panel-and-cmd-k-palette.md) - open
+
 ## Closed
 
 * [0001 — Walking skeleton — Cargo workspace + living-docs-core + fs-store + thin cli](0001-workspace-core-skeleton.md) - done

--- a/docs/prd/index.md
+++ b/docs/prd/index.md
@@ -1,0 +1,3 @@
+# PRDs
+
+## Active

--- a/tests/browser/metadata-panel.spec.ts
+++ b/tests/browser/metadata-panel.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * Browser-observable gate for the record page's metadata panel (ADR 0015,
+ * issue 0008 slice S3). Drives a live server seeded from the repo's own
+ * docs/: ADR 0015 itself is Accepted and tagged [web, ux, frontend], so its
+ * own record page is used to assert the aside renders the doc type, a
+ * status badge, and a tag chip — without depending on the live corpus
+ * containing a supersede pair (that chain is covered by the seeded HTTP
+ * tests in web/tests/http.rs).
+ */
+import { test, expect } from "@playwright/test";
+
+const ADR_0015_PATH =
+  "/record/adr/0015-web-ux-follows-the-three-pane-doc-site-archetype-with-search-first-cmd-k-palette.md";
+
+test("the metadata panel shows the doc type, status badge, and tags for a live record", async ({
+  page,
+}) => {
+  await page.goto(ADR_0015_PATH);
+
+  const aside = page.locator("aside");
+  await expect(aside).toBeVisible();
+  await expect(aside).toContainText("ADR");
+
+  const statusBadge = aside.locator("span.status-badge");
+  await expect(statusBadge).toBeVisible();
+  await expect(statusBadge).toHaveText("Accepted");
+
+  const tagChip = aside.locator("span.tag", { hasText: "web" });
+  await expect(tagChip).toBeVisible();
+
+  await expect(page.locator("nav")).toBeVisible();
+  await expect(page.locator("main")).toBeVisible();
+});

--- a/tests/browser/palette.spec.ts
+++ b/tests/browser/palette.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * Browser-observable gate for the Cmd+K search palette (ADR 0015, issue
+ * 0008 slice S4). Drives a live server seeded from the repo's own docs/:
+ * with JavaScript enabled, Control+K opens the overlay, typing a live-corpus
+ * term renders ranked result links, activating one navigates to its record
+ * page, and Escape closes the overlay again. With JavaScript disabled, the
+ * palette never appears — the plain GET /?q= search form stays the fully
+ * functional fallback (ADR 0015's progressive-enhancement decision).
+ */
+import { test, expect, type Locator, type Page } from "@playwright/test";
+
+function paletteOverlay(page: Page): Locator {
+  return page.locator("#palette-overlay");
+}
+
+function paletteInput(page: Page): Locator {
+  return page.locator("#palette-input");
+}
+
+function paletteResultLinks(page: Page): Locator {
+  return page.locator("#palette-results ul.results li a[href^='/record/']");
+}
+
+function paletteAdrResultLink(page: Page): Locator {
+  return page.locator("#palette-results ul.results li a[href^='/record/adr/']");
+}
+
+test("Control+K opens the palette, a matching term renders a result, activating it navigates, and Escape closes it", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(paletteOverlay(page)).toBeHidden();
+
+  await page.keyboard.press("Control+K");
+  await expect(paletteOverlay(page)).toBeVisible();
+  await expect(paletteInput(page)).toBeFocused();
+
+  await paletteInput(page).fill("palette");
+
+  await expect(paletteResultLinks(page).first()).toBeVisible();
+  const adrResult = paletteAdrResultLink(page).first();
+  await expect(adrResult).toBeVisible();
+
+  await adrResult.click();
+  await expect(page).toHaveURL(/\/record\/adr\//);
+
+  await page.keyboard.press("Control+K");
+  await expect(paletteOverlay(page)).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(paletteOverlay(page)).toBeHidden();
+});
+
+test.describe("with JavaScript disabled", () => {
+  test.use({ javaScriptEnabled: false });
+
+  test("the plain search form remains the fully functional fallback", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator("#palette-overlay")).toBeHidden();
+
+    await page.locator('input[name="q"]').fill("palette");
+    await page.getByRole("button", { name: "Search" }).click();
+
+    const adrResult = page.locator('ul.results li a[href^="/record/adr/"]').first();
+    await expect(adrResult).toBeVisible();
+
+    await adrResult.click();
+
+    await expect(page).toHaveURL(/\/record\/adr\//);
+    await expect(page.locator("main")).toBeVisible();
+  });
+});

--- a/tests/browser/shell.spec.ts
+++ b/tests/browser/shell.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * Browser-observable gate for the three-pane doc-site shell (ADR 0015,
+ * issue 0008 slice S2). Drives a live server seeded from the repo's own
+ * docs/: the nav tree is visible on the search page, and clicking a nav
+ * entry navigates to the record page where the body renders, the nav
+ * persists, and the clicked entry carries aria-current="page".
+ */
+import { test, expect, type Locator, type Page } from "@playwright/test";
+
+function navGroupHeadings(page: Page): Locator {
+  return page.locator("nav h2");
+}
+
+function navLinks(page: Page): Locator {
+  return page.locator('nav a[href^="/record/"]');
+}
+
+test("the nav tree is visible and navigating a record entry keeps it present with the active entry marked", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await expect(page.locator("nav")).toBeVisible();
+  await expect(navGroupHeadings(page).first()).toBeVisible();
+
+  const firstLink = navLinks(page).first();
+  await expect(firstLink).toBeVisible();
+  const targetHref = await firstLink.getAttribute("href");
+  expect(targetHref).toBeTruthy();
+
+  await firstLink.click();
+
+  await expect(page).toHaveURL(/\/record\//);
+  await expect(page.locator("main h1").first()).toBeVisible();
+  await expect(page.locator("nav")).toBeVisible();
+
+  const activeLink = page.locator(`nav a[href="${targetHref}"]`);
+  await expect(activeLink).toHaveAttribute("aria-current", "page");
+});

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -1,19 +1,26 @@
 //! Library surface shared between the `living-docs-web` binary and its
-//! integration tests (ADR 0006, issue 0003 slices S3a-S3b): the read-only
-//! axum router, its `GET /` search handler, and its `GET /record/{*path}`
-//! record handler.
+//! integration tests (ADR 0006, issue 0003 slices S3a-S3b; three-pane shell
+//! ADR 0015, issue 0008 slices S2-S4): the read-only axum router, its
+//! `GET /` search handler, its `GET /record/{*path}` record handler
+//! (metadata panel fed by `db_store::record_meta`, S3), its
+//! `GET /style.css` stylesheet route, and the Cmd+K palette's
+//! `GET /palette.js` static script plus its `GET /palette` fragment
+//! endpoint (S4) reusing the same async `db_store` search path as `GET /`.
 
 pub mod views;
 
 use axum::extract::{Path, Query, State};
-use axum::http::StatusCode;
+use axum::http::{header, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::Router;
-use db_store::{ProjectView, RecordView, SearchHit};
+use db_store::{NavEntry, ProjectView, RecordMeta, RecordView, SearchHit};
 use maud::Markup;
 use sea_orm::DatabaseConnection;
 use serde::Deserialize;
+
+const STYLESHEET: &str = include_str!("style.css");
+const PALETTE_SCRIPT: &str = include_str!("palette.js");
 
 /// Query-string parameters accepted by the search page. `project`, when
 /// present and non-empty, narrows the search to one project's slug (ADR
@@ -24,13 +31,40 @@ pub struct SearchParams {
     project: Option<String>,
 }
 
-/// Builds the read-only router backed by `conn`. Exposes `GET /` and
-/// `GET /record/{*path}` only — no route here mutates the read-model.
+/// Builds the read-only router backed by `conn`. Exposes `GET /`,
+/// `GET /record/{*path}`, `GET /style.css`, `GET /palette.js`, and
+/// `GET /palette` only — no route here mutates the read-model.
 pub fn build_router(conn: DatabaseConnection) -> Router {
     Router::new()
         .route("/", get(search_handler))
         .route("/record/{*path}", get(record_handler))
+        .route("/style.css", get(style_handler))
+        .route("/palette.js", get(palette_script_handler))
+        .route("/palette", get(palette_handler))
         .with_state(conn)
+}
+
+async fn style_handler() -> impl IntoResponse {
+    ([(header::CONTENT_TYPE, "text/css")], STYLESHEET)
+}
+
+async fn palette_script_handler() -> impl IntoResponse {
+    (
+        [(header::CONTENT_TYPE, "application/javascript")],
+        PALETTE_SCRIPT,
+    )
+}
+
+async fn palette_handler(
+    State(conn): State<DatabaseConnection>,
+    Query(params): Query<SearchParams>,
+) -> Markup {
+    let query = params.q.filter(|value| !value.trim().is_empty());
+    let hits = match &query {
+        Some(term) => search_or_log(&conn, term, None).await,
+        None => Vec::new(),
+    };
+    views::palette_fragment(&hits)
 }
 
 async fn search_handler(
@@ -44,7 +78,9 @@ async fn search_handler(
         None => Vec::new(),
     };
     let projects = list_projects_or_log(&conn).await;
-    views::search_page(query.as_deref(), project.as_deref(), &projects, &hits)
+    let nav = nav_entries_or_log(&conn).await;
+    let main = views::search_page(query.as_deref(), project.as_deref(), &projects, &hits);
+    views::shell("living-docs search", &nav, None, main, None)
 }
 
 async fn search_or_log(
@@ -75,20 +111,42 @@ async fn list_projects_or_log(conn: &DatabaseConnection) -> Vec<ProjectView> {
     }
 }
 
+async fn nav_entries_or_log(conn: &DatabaseConnection) -> Vec<NavEntry> {
+    match db_store::records_by_type(conn).await {
+        Ok(entries) => entries,
+        Err(err) => {
+            eprintln!("listing nav entries failed: {err}");
+            Vec::new()
+        }
+    }
+}
+
 async fn record_handler(
     State(conn): State<DatabaseConnection>,
     Path(path): Path<String>,
 ) -> Response {
+    let nav = nav_entries_or_log(&conn).await;
     match record_or_log(&conn, &path).await {
         Some(record) => {
             let body_html = render_markdown(&record.body);
-            (
-                StatusCode::OK,
-                views::record_page(&record.title, &body_html),
-            )
-                .into_response()
+            let title = format!("{} — living-docs", record.title);
+            let main = views::record_page(&body_html);
+            let aside = record_meta_or_log(&conn, &path)
+                .await
+                .map(|meta| views::metadata_panel(&meta));
+            let shell = views::shell(&title, &nav, Some(path.as_str()), main, aside);
+            (StatusCode::OK, shell).into_response()
         }
-        None => (StatusCode::NOT_FOUND, views::not_found()).into_response(),
+        None => {
+            let shell = views::shell(
+                "Not found — living-docs",
+                &nav,
+                None,
+                views::not_found(),
+                None,
+            );
+            (StatusCode::NOT_FOUND, shell).into_response()
+        }
     }
 }
 
@@ -97,6 +155,16 @@ async fn record_or_log(conn: &DatabaseConnection, path: &str) -> Option<RecordVi
         Ok(record) => record,
         Err(err) => {
             eprintln!("record lookup {path:?} failed: {err}");
+            None
+        }
+    }
+}
+
+async fn record_meta_or_log(conn: &DatabaseConnection, path: &str) -> Option<RecordMeta> {
+    match db_store::record_meta(conn, path).await {
+        Ok(meta) => meta,
+        Err(err) => {
+            eprintln!("record_meta lookup {path:?} failed: {err}");
             None
         }
     }

--- a/web/src/palette.js
+++ b/web/src/palette.js
@@ -1,0 +1,103 @@
+/**
+ * Cmd+K search palette, a progressive enhancement over the plain
+ * `GET /?q=` search form (ADR 0015, issue 0008 slice S4). Vanilla JS, no
+ * dependencies: Control+K or Meta+K toggles a hidden overlay, typing
+ * debounces a fetch to `GET /palette?q=<term>` and injects the returned,
+ * server-escaped HTML fragment into the results container. With this
+ * script absent, the overlay stays hidden and the plain search form
+ * remains the fully functional fallback.
+ */
+(function paletteEnhancement() {
+  "use strict";
+
+  var DEBOUNCE_MS = 150;
+
+  /**
+   * @param {Function} fn Function to defer until calls settle.
+   * @param {number} waitMs Idle time required before `fn` runs.
+   * @returns {Function} Debounced wrapper around `fn`.
+   */
+  function debounce(fn, waitMs) {
+    var timerId = null;
+    return function debounced() {
+      var callArgs = arguments;
+      var callContext = this;
+      window.clearTimeout(timerId);
+      timerId = window.setTimeout(function runDebounced() {
+        fn.apply(callContext, callArgs);
+      }, waitMs);
+    };
+  }
+
+  function isToggleShortcut(event) {
+    return (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k";
+  }
+
+  function openPalette(overlay, input) {
+    overlay.hidden = false;
+    input.focus();
+  }
+
+  function closePalette(overlay, input, resultsEl) {
+    overlay.hidden = true;
+    input.value = "";
+    resultsEl.innerHTML = "";
+  }
+
+  function togglePalette(overlay, input, resultsEl) {
+    if (overlay.hidden) {
+      openPalette(overlay, input);
+    } else {
+      closePalette(overlay, input, resultsEl);
+    }
+  }
+
+  function fetchResultsFragment(query) {
+    return window
+      .fetch("/palette?q=" + encodeURIComponent(query))
+      .then(function readFragmentText(response) {
+        return response.text();
+      });
+  }
+
+  function renderResults(resultsEl, query) {
+    if (query.trim() === "") {
+      resultsEl.innerHTML = "";
+      return;
+    }
+    fetchResultsFragment(query).then(function injectFragment(html) {
+      resultsEl.innerHTML = html;
+    });
+  }
+
+  function wireKeyboardShortcuts(overlay, input, resultsEl) {
+    document.addEventListener("keydown", function handleKeydown(event) {
+      if (isToggleShortcut(event)) {
+        event.preventDefault();
+        togglePalette(overlay, input, resultsEl);
+        return;
+      }
+      if (event.key === "Escape" && !overlay.hidden) {
+        closePalette(overlay, input, resultsEl);
+      }
+    });
+  }
+
+  function wirePaletteInput(input, resultsEl) {
+    var onInput = debounce(function handleInput() {
+      renderResults(resultsEl, input.value);
+    }, DEBOUNCE_MS);
+    input.addEventListener("input", onInput);
+  }
+
+  document.addEventListener("DOMContentLoaded", function initPalette() {
+    var overlay = document.getElementById("palette-overlay");
+    var input = document.getElementById("palette-input");
+    var resultsEl = document.getElementById("palette-results");
+    if (!overlay || !input || !resultsEl) {
+      return;
+    }
+    wireKeyboardShortcuts(overlay, input, resultsEl);
+    wirePaletteInput(input, resultsEl);
+  });
+})();

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1,0 +1,215 @@
+/* living-docs three-pane doc-site shell (ADR 0015, issue 0008, S2). */
+
+:root {
+  color-scheme: light dark;
+  font-family: system-ui, sans-serif;
+}
+
+body {
+  display: grid;
+  grid-template-columns: 240px 1fr 280px;
+  gap: 1.5rem;
+  margin: 0;
+  padding: 1.5rem;
+  min-height: 100vh;
+  line-height: 1.5;
+}
+
+nav {
+  border-right: 1px solid #d0d0d0;
+  padding-right: 1rem;
+}
+
+nav h2 {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #666;
+  margin: 1.5rem 0 0.5rem;
+}
+
+nav h2:first-child {
+  margin-top: 0;
+}
+
+nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+nav li {
+  margin: 0.25rem 0;
+}
+
+nav a {
+  text-decoration: none;
+  color: #1a56c4;
+}
+
+nav a[aria-current="page"] {
+  font-weight: 700;
+  color: #111;
+  background: #eef2ff;
+  border-radius: 0.25rem;
+  padding: 0.1rem 0.4rem;
+}
+
+main {
+  min-width: 0;
+  max-width: 70ch;
+}
+
+main h1 {
+  margin-top: 0;
+}
+
+aside {
+  border-left: 1px solid #d0d0d0;
+  padding-left: 1rem;
+}
+
+form {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+ul.results {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+ul.results li {
+  padding: 0.75rem 0;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+ul.results li a {
+  font-weight: 600;
+}
+
+span.project-label {
+  display: inline-block;
+  margin-left: 0.5rem;
+  padding: 0.05rem 0.4rem;
+  font-size: 0.75rem;
+  color: #555;
+  background: #f0f0f0;
+  border-radius: 0.25rem;
+}
+
+p.empty-state {
+  color: #666;
+}
+
+.meta-panel .meta-row,
+.meta-panel section {
+  margin-bottom: 1.5rem;
+}
+
+.meta-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 0.9rem;
+}
+
+.meta-label {
+  color: #666;
+}
+
+.meta-related h2,
+.meta-tags h2 {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #666;
+  margin: 0 0 0.5rem;
+}
+
+.meta-related ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.meta-related li {
+  margin: 0.25rem 0;
+}
+
+span.status-badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  border-radius: 0.25rem;
+  background: #e0e0e0;
+  color: #333;
+}
+
+span.status-badge.status-accepted {
+  background: #dcfce7;
+  color: #14532d;
+}
+
+span.status-badge.status-superseded,
+span.status-badge.status-deprecated {
+  background: #fef3c7;
+  color: #7c2d12;
+}
+
+span.tag {
+  display: inline-block;
+  margin: 0 0.35rem 0.35rem 0;
+  padding: 0.05rem 0.4rem;
+  font-size: 0.75rem;
+  color: #555;
+  background: #f0f0f0;
+  border-radius: 0.25rem;
+}
+
+#palette-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding-top: 10vh;
+  background: rgba(0, 0, 0, 0.4);
+}
+
+#palette-overlay[hidden] {
+  display: none;
+}
+
+.palette-dialog {
+  width: min(560px, 90vw);
+  max-height: 70vh;
+  overflow-y: auto;
+  padding: 1rem;
+  background: #fff;
+  border-radius: 0.5rem;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25);
+}
+
+#palette-input {
+  box-sizing: border-box;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  font-size: 1rem;
+  border: 1px solid #d0d0d0;
+  border-radius: 0.25rem;
+}
+
+#palette-results {
+  margin-top: 0.75rem;
+}
+
+#palette-results ul.results {
+  margin: 0;
+}

--- a/web/src/views.rs
+++ b/web/src/views.rs
@@ -1,18 +1,102 @@
 //! maud rendering for the read-only search and record pages (ADR 0006, issue
-//! 0003 slices S3a-S3b; project filter ADR 0005 issue 0005 slice 0005-C2).
-//! Every value reflected from user input is rendered through maud's
-//! auto-escaping `Markup`, never string-concatenated into HTML. The record
-//! body is the sole exception: it is pre-rendered from the local corpus's
-//! markdown source (not user input) via pulldown-cmark, then injected as-is
-//! through `PreEscaped`.
+//! 0003 slices S3a-S3b; project filter ADR 0005 issue 0005 slice 0005-C2),
+//! wrapped in the three-pane doc-site shell (ADR 0015, issue 0008, S2) with
+//! its right-pane metadata panel (ADR 0015, issue 0008, S3) and the Cmd+K
+//! palette's hidden overlay container and result fragment (ADR 0015, issue
+//! 0008, S4). Every value reflected from user input is rendered through
+//! maud's auto-escaping `Markup`, never string-concatenated into HTML. The
+//! record body is the sole exception: it is pre-rendered from the local
+//! corpus's markdown source (not user input) via pulldown-cmark, then
+//! injected as-is through `PreEscaped`.
 
-use db_store::{ProjectView, SearchHit};
+use db_store::{NavEntry, ProjectView, RecordMeta, RelatedRef, SearchHit};
 use maud::{html, Markup, PreEscaped};
 
-/// Renders the full search page: the search form (with its project filter)
-/// plus, when a query was submitted, either the ranked results or an
-/// explicit empty-state message. `selected_project` is the slug currently
-/// narrowing the search, preserved in the form on re-render.
+/// Renders the full three-pane document: `<head>` with the served
+/// stylesheet and the deferred palette script, the left nav tree grouped by
+/// `doc_type` (built from `nav`), `main` as the center pane, `aside` as the
+/// right pane — an empty placeholder when `None`, filled by slice S3 — and
+/// the hidden Cmd+K palette overlay (slice S4). The nav entry whose `path`
+/// equals `active_path` carries `aria-current="page"`.
+pub fn shell(
+    page_title: &str,
+    nav: &[NavEntry],
+    active_path: Option<&str>,
+    main: Markup,
+    aside: Option<Markup>,
+) -> Markup {
+    html! {
+        html {
+            head {
+                meta charset="utf-8";
+                title { (page_title) }
+                link rel="stylesheet" href="/style.css";
+                script src="/palette.js" defer {}
+            }
+            body {
+                nav { (nav_tree(nav, active_path)) }
+                main { (main) }
+                aside { @if let Some(aside) = aside { (aside) } }
+                (palette_overlay())
+            }
+        }
+    }
+}
+
+fn palette_overlay() -> Markup {
+    html! {
+        div id="palette-overlay" hidden {
+            div class="palette-dialog" {
+                input
+                    id="palette-input"
+                    type="search"
+                    placeholder="Search docs…"
+                    aria-label="Search docs";
+                div id="palette-results" {}
+            }
+        }
+    }
+}
+
+fn nav_tree(nav: &[NavEntry], active_path: Option<&str>) -> Markup {
+    html! {
+        @for (doc_type, entries) in nav_groups(nav) {
+            section class="nav-group" {
+                h2 { (doc_type) }
+                ul {
+                    @for entry in entries {
+                        li { (nav_link(entry, active_path)) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn nav_groups(nav: &[NavEntry]) -> Vec<(&str, Vec<&NavEntry>)> {
+    let mut groups: Vec<(&str, Vec<&NavEntry>)> = Vec::new();
+    for entry in nav {
+        match groups.last_mut() {
+            Some((doc_type, entries)) if *doc_type == entry.doc_type => entries.push(entry),
+            _ => groups.push((entry.doc_type.as_str(), vec![entry])),
+        }
+    }
+    groups
+}
+
+fn nav_link(entry: &NavEntry, active_path: Option<&str>) -> Markup {
+    let is_active = active_path == Some(entry.path.as_str());
+    html! {
+        a href=(record_href(&entry.path)) aria-current=[is_active.then_some("page")] {
+            (entry.title)
+        }
+    }
+}
+
+/// Renders the search page's center-pane content: the search form (with its
+/// project filter) plus, when a query was submitted, either the ranked
+/// results or an explicit empty-state message. `selected_project` is the
+/// slug currently narrowing the search, preserved in the form on re-render.
 pub fn search_page(
     query: Option<&str>,
     selected_project: Option<&str>,
@@ -20,17 +104,10 @@ pub fn search_page(
     hits: &[SearchHit],
 ) -> Markup {
     html! {
-        html {
-            head {
-                title { "living-docs search" }
-            }
-            body {
-                h1 { "living-docs search" }
-                (search_form(query, selected_project, projects))
-                @if let Some(query) = query {
-                    (search_results(hits, query))
-                }
-            }
+        h1 { "living-docs search" }
+        (search_form(query, selected_project, projects))
+        @if let Some(query) = query {
+            (search_results(hits, query))
         }
     }
 }
@@ -69,15 +146,42 @@ fn search_results(hits: &[SearchHit], query: &str) -> Markup {
         @if hits.is_empty() {
             p class="empty-state" { "No results for \"" (query) "\"." }
         } @else {
-            ul class="results" {
-                @for hit in hits {
-                    li {
-                        a href=(record_href(&hit.path)) { (hit.title) }
-                        span class="project-label" { (hit.project) }
-                        p { (hit.snippet) }
-                    }
-                }
+            (result_list(hits))
+        }
+    }
+}
+
+/// Renders the Cmd+K palette's result fragment (issue 0008, ADR 0015, S4):
+/// a bare `<ul class="results">` of the same result items the search page
+/// renders — reused via `result_list` so the two views share one item
+/// renderer — or an empty-state `<p>` when `hits` is empty. Returned as-is
+/// by `GET /palette`, with no surrounding shell.
+pub fn palette_fragment(hits: &[SearchHit]) -> Markup {
+    html! {
+        @if hits.is_empty() {
+            p class="empty-state" { "No results." }
+        } @else {
+            (result_list(hits))
+        }
+    }
+}
+
+fn result_list(hits: &[SearchHit]) -> Markup {
+    html! {
+        ul class="results" {
+            @for hit in hits {
+                (result_item(hit))
             }
+        }
+    }
+}
+
+fn result_item(hit: &SearchHit) -> Markup {
+    html! {
+        li {
+            a href=(record_href(&hit.path)) { (hit.title) }
+            span class="project-label" { (hit.project) }
+            p { (hit.snippet) }
         }
     }
 }
@@ -86,37 +190,87 @@ fn record_href(path: &str) -> String {
     format!("/record/{path}")
 }
 
-/// Renders a single record's page: its escaped title plus its `body_html`,
-/// already rendered from markdown by the caller and injected verbatim.
-pub fn record_page(title: &str, body_html: &str) -> Markup {
+/// Renders a single record's center-pane content: the back link plus
+/// `body_html`, already rendered from markdown by the caller and injected
+/// verbatim. The body's own leading `# Title` markdown heading is the
+/// page's sole `h1` (issue 0008, ADR 0015, S3) — this view renders no h1 of
+/// its own, so a record page never carries two.
+pub fn record_page(body_html: &str) -> Markup {
     html! {
-        html {
-            head {
-                title { (title) " — living-docs" }
+        a href="/" { "← Back to search" }
+        (PreEscaped(body_html))
+    }
+}
+
+/// Renders the right-pane metadata panel for a record (issue 0008, ADR
+/// 0015, S3): its doc type, an optional status badge, its supersede chain
+/// in both directions as links to `/record/<path>` (each section omitted
+/// when its list is empty), and its tags as chips (omitted when empty).
+pub fn metadata_panel(meta: &RecordMeta) -> Markup {
+    html! {
+        section class="meta-panel" {
+            div class="meta-row" {
+                span class="meta-label" { "Type" }
+                span class="meta-value" { (meta.doc_type) }
             }
-            body {
-                a href="/" { "← Back to search" }
-                h1 { (title) }
-                (PreEscaped(body_html))
+            @if let Some(status) = &meta.status {
+                (status_badge(status))
+            }
+            @if !meta.supersedes.is_empty() {
+                (related_section("Supersedes", &meta.supersedes))
+            }
+            @if !meta.superseded_by.is_empty() {
+                (related_section("Superseded by", &meta.superseded_by))
+            }
+            @if !meta.tags.is_empty() {
+                (tags_section(&meta.tags))
             }
         }
     }
 }
 
-/// Renders the page shown when `GET /record/{*path}` finds no matching
-/// record.
-pub fn not_found() -> Markup {
+fn status_badge(status: &str) -> Markup {
+    let modifier = status_modifier(status);
     html! {
-        html {
-            head {
-                title { "Not found — living-docs" }
-            }
-            body {
-                h1 { "Record not found" }
-                p { "No record exists at this path." }
-                a href="/" { "← Back to search" }
+        span class=(format!("status-badge status-{modifier}")) { (status) }
+    }
+}
+
+fn status_modifier(status: &str) -> String {
+    status.to_lowercase().replace(' ', "-")
+}
+
+fn related_section(heading: &str, refs: &[RelatedRef]) -> Markup {
+    html! {
+        section class="meta-related" {
+            h2 { (heading) }
+            ul {
+                @for related in refs {
+                    li { a href=(record_href(&related.path)) { (related.title) } }
+                }
             }
         }
+    }
+}
+
+fn tags_section(tags: &[String]) -> Markup {
+    html! {
+        section class="meta-tags" {
+            h2 { "Tags" }
+            @for tag in tags {
+                span class="tag" { (tag) }
+            }
+        }
+    }
+}
+
+/// Renders the center-pane content shown when `GET /record/{*path}` finds
+/// no matching record.
+pub fn not_found() -> Markup {
+    html! {
+        h1 { "Record not found" }
+        p { "No record exists at this path." }
+        a href="/" { "← Back to search" }
     }
 }
 
@@ -224,16 +378,115 @@ mod tests {
     }
 
     #[test]
-    fn record_page_renders_the_escaped_title_and_injects_the_preescaped_body() {
-        let rendered = record_page(
-            "Quokka Caching Strategy",
-            "<h1>Quokka Caching Strategy</h1>\n<p>Body.</p>\n",
-        )
-        .into_string();
+    fn record_page_injects_the_preescaped_body_and_carries_no_view_level_h1() {
+        let rendered =
+            record_page("<h1>Quokka Caching Strategy</h1>\n<p>Body.</p>\n").into_string();
 
-        assert!(rendered.contains("Quokka Caching Strategy"));
         assert!(rendered.contains("<h1>Quokka Caching Strategy</h1>"));
         assert!(rendered.contains("<p>Body.</p>"));
+        assert_eq!(rendered.matches("<h1").count(), 1);
+        assert!(rendered.contains("← Back to search"));
+    }
+
+    fn related_ref(path: &str, title: &str) -> RelatedRef {
+        RelatedRef {
+            path: path.to_owned(),
+            title: title.to_owned(),
+        }
+    }
+
+    fn record_meta(
+        doc_type: &str,
+        status: Option<&str>,
+        supersedes: Vec<RelatedRef>,
+        superseded_by: Vec<RelatedRef>,
+        tags: Vec<&str>,
+    ) -> RecordMeta {
+        RecordMeta {
+            doc_type: doc_type.to_owned(),
+            status: status.map(str::to_owned),
+            supersedes,
+            superseded_by,
+            tags: tags.into_iter().map(str::to_owned).collect(),
+        }
+    }
+
+    #[test]
+    fn metadata_panel_renders_the_doc_type_row() {
+        let meta = record_meta("ADR", None, vec![], vec![], vec![]);
+
+        let rendered = metadata_panel(&meta).into_string();
+
+        assert!(rendered.contains("Type"));
+        assert!(rendered.contains("ADR"));
+    }
+
+    #[test]
+    fn metadata_panel_renders_a_lowercased_status_badge_modifier_class() {
+        let meta = record_meta("ADR", Some("Accepted"), vec![], vec![], vec![]);
+
+        let rendered = metadata_panel(&meta).into_string();
+
+        assert!(rendered.contains("class=\"status-badge status-accepted\""));
+        assert!(rendered.contains(">Accepted<"));
+    }
+
+    #[test]
+    fn metadata_panel_omits_the_status_badge_when_status_is_none() {
+        let meta = record_meta("ADR", None, vec![], vec![], vec![]);
+
+        let rendered = metadata_panel(&meta).into_string();
+
+        assert!(!rendered.contains("status-badge"));
+    }
+
+    #[test]
+    fn metadata_panel_links_each_supersede_direction_to_its_record_path() {
+        let meta = record_meta(
+            "ADR",
+            None,
+            vec![related_ref("adr/0001-a.md", "Decision A")],
+            vec![related_ref("adr/0003-c.md", "Decision C")],
+            vec![],
+        );
+
+        let rendered = metadata_panel(&meta).into_string();
+
+        assert!(rendered.contains("Supersedes"));
+        assert!(rendered.contains("href=\"/record/adr/0001-a.md\""));
+        assert!(rendered.contains("Decision A"));
+        assert!(rendered.contains("Superseded by"));
+        assert!(rendered.contains("href=\"/record/adr/0003-c.md\""));
+        assert!(rendered.contains("Decision C"));
+    }
+
+    #[test]
+    fn metadata_panel_omits_supersede_sections_when_their_lists_are_empty() {
+        let meta = record_meta("ADR", None, vec![], vec![], vec![]);
+
+        let rendered = metadata_panel(&meta).into_string();
+
+        assert!(!rendered.contains("Supersedes"));
+        assert!(!rendered.contains("Superseded by"));
+    }
+
+    #[test]
+    fn metadata_panel_renders_a_tag_chip_per_tag() {
+        let meta = record_meta("ADR", None, vec![], vec![], vec!["web", "ux"]);
+
+        let rendered = metadata_panel(&meta).into_string();
+
+        assert!(rendered.contains("<span class=\"tag\">web</span>"));
+        assert!(rendered.contains("<span class=\"tag\">ux</span>"));
+    }
+
+    #[test]
+    fn metadata_panel_omits_the_tags_section_when_tags_are_empty() {
+        let meta = record_meta("ADR", None, vec![], vec![], vec![]);
+
+        let rendered = metadata_panel(&meta).into_string();
+
+        assert!(!rendered.contains("class=\"tag\""));
     }
 
     #[test]
@@ -241,5 +494,118 @@ mod tests {
         let rendered = not_found().into_string();
 
         assert!(rendered.to_lowercase().contains("not found"));
+    }
+
+    fn nav_entry(doc_type: &str, path: &str, title: &str) -> NavEntry {
+        NavEntry {
+            doc_type: doc_type.to_owned(),
+            number: None,
+            title: title.to_owned(),
+            path: path.to_owned(),
+        }
+    }
+
+    #[test]
+    fn shell_groups_nav_entries_by_doc_type_and_links_to_each_record() {
+        let nav = vec![
+            nav_entry("ADR", "adr/0001-a.md", "Decision A"),
+            nav_entry("ADR", "adr/0002-b.md", "Decision B"),
+            nav_entry("Runbook", "runbook/0001-r.md", "Runbook R"),
+        ];
+
+        let rendered =
+            shell("living-docs", &nav, None, html! { p { "content" } }, None).into_string();
+
+        assert!(rendered.contains("<nav"));
+        assert_eq!(rendered.matches("<h2>ADR</h2>").count(), 1);
+        assert!(rendered.contains("<h2>Runbook</h2>"));
+        assert!(rendered.contains("href=\"/record/adr/0001-a.md\""));
+        assert!(rendered.contains("Decision A"));
+        assert!(rendered.contains("href=\"/record/runbook/0001-r.md\""));
+    }
+
+    #[test]
+    fn shell_marks_the_active_path_entry_with_aria_current_page() {
+        let nav = vec![
+            nav_entry("ADR", "adr/0001-a.md", "Decision A"),
+            nav_entry("ADR", "adr/0002-b.md", "Decision B"),
+        ];
+
+        let rendered = shell(
+            "living-docs",
+            &nav,
+            Some("adr/0002-b.md"),
+            html! { p { "content" } },
+            None,
+        )
+        .into_string();
+
+        assert!(rendered.contains("href=\"/record/adr/0002-b.md\" aria-current=\"page\""));
+        assert!(!rendered.contains("href=\"/record/adr/0001-a.md\" aria-current=\"page\""));
+    }
+
+    #[test]
+    fn shell_renders_an_empty_aside_placeholder_when_none() {
+        let rendered =
+            shell("living-docs", &[], None, html! { p { "content" } }, None).into_string();
+
+        assert!(rendered.contains("<aside></aside>"));
+    }
+
+    #[test]
+    fn shell_renders_the_provided_aside_content_when_present() {
+        let rendered = shell(
+            "living-docs",
+            &[],
+            None,
+            html! { p { "content" } },
+            Some(html! { p { "meta" } }),
+        )
+        .into_string();
+
+        assert!(rendered.contains("<aside><p>meta</p></aside>"));
+    }
+
+    #[test]
+    fn shell_links_the_stylesheet_and_sets_the_page_title() {
+        let rendered = shell("living-docs search", &[], None, html! { p {} }, None).into_string();
+
+        assert!(rendered.contains("<link rel=\"stylesheet\" href=\"/style.css\">"));
+        assert!(rendered.contains("<title>living-docs search</title>"));
+    }
+
+    #[test]
+    fn shell_loads_the_deferred_palette_script_and_renders_the_hidden_overlay() {
+        let rendered = shell("living-docs search", &[], None, html! { p {} }, None).into_string();
+
+        assert!(rendered.contains("<script src=\"/palette.js\" defer></script>"));
+        assert!(rendered.contains("id=\"palette-overlay\" hidden"));
+        assert!(rendered.contains("id=\"palette-input\""));
+        assert!(rendered.contains("id=\"palette-results\""));
+    }
+
+    #[test]
+    fn palette_fragment_with_hits_links_to_the_record_path_and_carries_no_shell_nav() {
+        let hits = vec![hit(
+            "adr/0001-quokka-caching.md",
+            "Quokka Caching Strategy",
+            "an aggressive [quokka] caching strategy",
+            "docs",
+        )];
+
+        let rendered = palette_fragment(&hits).into_string();
+
+        assert!(rendered.contains("href=\"/record/adr/0001-quokka-caching.md\""));
+        assert!(rendered.contains("Quokka Caching Strategy"));
+        assert!(!rendered.contains("<nav"));
+        assert!(!rendered.contains("<html"));
+    }
+
+    #[test]
+    fn palette_fragment_with_no_hits_renders_the_empty_state() {
+        let rendered = palette_fragment(&[]).into_string();
+
+        assert!(rendered.contains("empty-state"));
+        assert!(rendered.contains("No results."));
     }
 }

--- a/web/tests/http.rs
+++ b/web/tests/http.rs
@@ -1,6 +1,8 @@
 //! In-process HTTP assertions for the read-only search and record pages
-//! (ADR 0006, issue 0003 slices S3a-S3b): a real request/response round trip
-//! via `tower::ServiceExt::oneshot`, with no bound TCP port.
+//! (ADR 0006, issue 0003 slices S3a-S3b) and the Cmd+K palette's
+//! `GET /palette.js` script and `GET /palette` fragment endpoint (ADR 0015,
+//! issue 0008 slice S4): a real request/response round trip via
+//! `tower::ServiceExt::oneshot`, with no bound TCP port.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -24,12 +26,46 @@ fn temp_dir(label: &str) -> PathBuf {
 }
 
 fn write_record(docs: &Path, dir: &str, filename: &str, title: &str, body: &str) {
+    write_record_with_frontmatter(docs, dir, filename, "status: Accepted\n", title, body);
+}
+
+fn write_record_with_frontmatter(
+    docs: &Path,
+    dir: &str,
+    filename: &str,
+    extra_frontmatter: &str,
+    title: &str,
+    body: &str,
+) {
     let type_dir = docs.join(dir);
     fs::create_dir_all(&type_dir).expect("create record type dir");
     let contents = format!(
-        "---\ntype: ADR\ntitle: {title}\ndescription: seeded for web http test\nstatus: Accepted\n---\n\n# {title}\n\n{body}\n"
+        "---\ntype: ADR\ntitle: {title}\ndescription: seeded for web http test\n{extra_frontmatter}---\n\n# {title}\n\n{body}\n"
     );
     fs::write(type_dir.join(filename), contents).expect("write seeded record");
+}
+
+async fn request(router: Router, method: Method, uri: &str) -> Response {
+    router
+        .oneshot(
+            Request::builder()
+                .method(method)
+                .uri(uri)
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("router responds")
+}
+
+async fn get(router: Router, uri: &str) -> Response {
+    request(router, Method::GET, uri).await
+}
+
+async fn get_ok_body(router: Router, uri: &str) -> String {
+    let response = get(router, uri).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    body_text(response).await
 }
 
 async fn seeded_router() -> Router {
@@ -47,6 +83,22 @@ async fn seeded_router() -> Router {
         "0002-unrelated.md",
         "Unrelated Decision",
         "This document discusses logging conventions.",
+    );
+    write_record_with_frontmatter(
+        &docs,
+        "adr",
+        "0003-superseded-record.md",
+        "status: Deprecated\nsuperseded_by: 0004\ntags: [caching]\n",
+        "Superseded Record",
+        "This document was superseded by a later decision.",
+    );
+    write_record_with_frontmatter(
+        &docs,
+        "adr",
+        "0004-superseding-record.md",
+        "status: Accepted\nsupersedes: 0003\ntags: [caching, performance]\n",
+        "Superseding Record",
+        "This document supersedes the prior decision.",
     );
 
     let db_path = temp_dir("db-parent").join("index.db");
@@ -70,82 +122,52 @@ async fn body_text(response: Response) -> String {
     String::from_utf8(bytes.to_vec()).expect("response body is valid utf-8")
 }
 
+fn main_pane(body: &str) -> &str {
+    let start = body.find("<main>").expect("body has a main pane") + "<main>".len();
+    let end = body.find("</main>").expect("body has a main pane");
+    &body[start..end]
+}
+
+fn aside_pane(body: &str) -> &str {
+    let start = body.find("<aside>").expect("body has an aside pane") + "<aside>".len();
+    let end = body.find("</aside>").expect("body has an aside pane");
+    &body[start..end]
+}
+
 #[tokio::test]
 async fn search_with_a_matching_term_returns_the_record_title_and_path() {
     let router = seeded_router().await;
+    let body = get_ok_body(router, "/?q=quokka").await;
 
-    let response = router
-        .oneshot(
-            Request::builder()
-                .uri("/?q=quokka")
-                .body(Body::empty())
-                .expect("build request"),
-        )
-        .await
-        .expect("router responds");
-
-    assert_eq!(response.status(), StatusCode::OK);
-    let body = body_text(response).await;
-    assert!(body.contains("Quokka Caching Strategy"), "got: {body}");
-    assert!(body.contains("adr/0001-quokka-caching.md"), "got: {body}");
-    assert!(!body.contains("Unrelated Decision"), "got: {body}");
+    let main = main_pane(&body);
+    assert!(main.contains("Quokka Caching Strategy"), "got: {body}");
+    assert!(main.contains("adr/0001-quokka-caching.md"), "got: {body}");
+    assert!(!main.contains("Unrelated Decision"), "got: {body}");
 }
 
 #[tokio::test]
 async fn search_with_no_matches_renders_an_empty_state_not_an_error() {
     let router = seeded_router().await;
+    let body = get_ok_body(router, "/?q=zzzznomatch").await;
 
-    let response = router
-        .oneshot(
-            Request::builder()
-                .uri("/?q=zzzznomatch")
-                .body(Body::empty())
-                .expect("build request"),
-        )
-        .await
-        .expect("router responds");
-
-    assert_eq!(response.status(), StatusCode::OK);
-    let body = body_text(response).await;
     assert!(body.to_lowercase().contains("no results"), "got: {body}");
 }
 
 #[tokio::test]
 async fn search_with_no_query_renders_only_the_form() {
     let router = seeded_router().await;
+    let body = get_ok_body(router, "/").await;
 
-    let response = router
-        .oneshot(
-            Request::builder()
-                .uri("/")
-                .body(Body::empty())
-                .expect("build request"),
-        )
-        .await
-        .expect("router responds");
-
-    assert_eq!(response.status(), StatusCode::OK);
-    let body = body_text(response).await;
-    assert!(body.contains("<form"), "got: {body}");
-    assert!(!body.contains("Quokka Caching Strategy"), "got: {body}");
+    let main = main_pane(&body);
+    assert!(main.contains("<form"), "got: {body}");
+    assert!(!main.contains("Quokka Caching Strategy"), "got: {body}");
 }
 
 #[tokio::test]
 async fn record_route_with_a_seeded_path_returns_the_rendered_body() {
     let router = seeded_router().await;
+    let body = get_ok_body(router, "/record/adr/0001-quokka-caching.md").await;
 
-    let response = router
-        .oneshot(
-            Request::builder()
-                .uri("/record/adr/0001-quokka-caching.md")
-                .body(Body::empty())
-                .expect("build request"),
-        )
-        .await
-        .expect("router responds");
-
-    assert_eq!(response.status(), StatusCode::OK);
-    let body = body_text(response).await;
     assert!(body.contains("Quokka Caching Strategy"), "got: {body}");
     assert!(
         body.contains("<p>We adopt an aggressive quokka caching strategy for search results.</p>"),
@@ -156,16 +178,7 @@ async fn record_route_with_a_seeded_path_returns_the_rendered_body() {
 #[tokio::test]
 async fn record_route_with_a_missing_path_returns_404_not_500() {
     let router = seeded_router().await;
-
-    let response = router
-        .oneshot(
-            Request::builder()
-                .uri("/record/adr/9999-missing.md")
-                .body(Body::empty())
-                .expect("build request"),
-        )
-        .await
-        .expect("router responds");
+    let response = get(router, "/record/adr/9999-missing.md").await;
 
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     let body = body_text(response).await;
@@ -173,19 +186,183 @@ async fn record_route_with_a_missing_path_returns_404_not_500() {
 }
 
 #[tokio::test]
+async fn the_search_page_renders_a_nav_tree_grouped_by_doc_type() {
+    let router = seeded_router().await;
+    let body = get_ok_body(router, "/").await;
+
+    assert!(body.contains("<nav"), "got: {body}");
+    assert!(body.contains("<h2>ADR</h2>"), "got: {body}");
+    assert!(
+        body.contains("href=\"/record/adr/0001-quokka-caching.md\""),
+        "got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn the_record_page_marks_its_own_nav_entry_as_the_active_page() {
+    let router = seeded_router().await;
+    let body = get_ok_body(router, "/record/adr/0001-quokka-caching.md").await;
+
+    assert!(
+        body.contains("href=\"/record/adr/0001-quokka-caching.md\" aria-current=\"page\""),
+        "got: {body}"
+    );
+    assert!(
+        !body.contains("href=\"/record/adr/0002-unrelated.md\" aria-current=\"page\""),
+        "got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn style_css_is_served_with_the_css_content_type() {
+    let router = seeded_router().await;
+    let response = get(router, "/style.css").await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get("content-type")
+            .expect("content-type header present"),
+        "text/css"
+    );
+}
+
+#[tokio::test]
 async fn a_mutating_method_is_rejected_with_method_not_allowed() {
     let router = seeded_router().await;
-
-    let response = router
-        .oneshot(
-            Request::builder()
-                .method(Method::POST)
-                .uri("/")
-                .body(Body::empty())
-                .expect("build request"),
-        )
-        .await
-        .expect("router responds");
+    let response = request(router, Method::POST, "/").await;
 
     assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+}
+
+#[tokio::test]
+async fn the_superseded_records_page_shows_its_status_badge_and_links_to_the_superseding_record() {
+    let router = seeded_router().await;
+    let body = get_ok_body(router, "/record/adr/0003-superseded-record.md").await;
+
+    let aside = aside_pane(&body);
+    assert!(
+        aside.contains("class=\"status-badge status-deprecated\""),
+        "got: {body}"
+    );
+    assert!(aside.contains(">Deprecated<"), "got: {body}");
+    assert!(
+        aside.contains("href=\"/record/adr/0004-superseding-record.md\""),
+        "got: {body}"
+    );
+    assert!(aside.contains("Superseding Record"), "got: {body}");
+}
+
+#[tokio::test]
+async fn the_superseding_records_page_links_back_under_supersedes() {
+    let router = seeded_router().await;
+    let body = get_ok_body(router, "/record/adr/0004-superseding-record.md").await;
+
+    let aside = aside_pane(&body);
+    assert!(aside.contains("Supersedes"), "got: {body}");
+    assert!(
+        aside.contains("href=\"/record/adr/0003-superseded-record.md\""),
+        "got: {body}"
+    );
+    assert!(aside.contains("Superseded Record"), "got: {body}");
+}
+
+#[tokio::test]
+async fn a_record_with_tags_shows_its_tag_chips() {
+    let router = seeded_router().await;
+    let body = get_ok_body(router, "/record/adr/0004-superseding-record.md").await;
+
+    let aside = aside_pane(&body);
+    assert!(
+        aside.contains("<span class=\"tag\">caching</span>"),
+        "got: {body}"
+    );
+    assert!(
+        aside.contains("<span class=\"tag\">performance</span>"),
+        "got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn a_record_page_renders_exactly_one_h1_within_main() {
+    let router = seeded_router().await;
+    let body = get_ok_body(router, "/record/adr/0001-quokka-caching.md").await;
+
+    let main = main_pane(&body);
+    assert_eq!(main.matches("<h1").count(), 1, "got: {body}");
+}
+
+#[tokio::test]
+async fn sections_for_empty_relation_and_tag_lists_are_absent() {
+    let router = seeded_router().await;
+    let body = get_ok_body(router, "/record/adr/0002-unrelated.md").await;
+
+    let aside = aside_pane(&body);
+    assert!(!aside.contains("Supersedes"), "got: {body}");
+    assert!(!aside.contains("Superseded by"), "got: {body}");
+    assert!(!aside.contains("class=\"tag\""), "got: {body}");
+}
+
+#[tokio::test]
+async fn palette_js_is_served_with_a_javascript_content_type_and_a_non_empty_body() {
+    let router = seeded_router().await;
+    let response = get(router, "/palette.js").await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get("content-type")
+            .expect("content-type header present"),
+        "application/javascript"
+    );
+    let body = body_text(response).await;
+    assert!(!body.trim().is_empty(), "expected a non-empty script body");
+}
+
+#[tokio::test]
+async fn palette_with_a_matching_term_returns_a_bare_fragment_linking_to_the_record() {
+    let router = seeded_router().await;
+    let body = get_ok_body(router, "/palette?q=quokka").await;
+
+    assert!(
+        body.contains("href=\"/record/adr/0001-quokka-caching.md\""),
+        "got: {body}"
+    );
+    assert!(body.contains("Quokka Caching Strategy"), "got: {body}");
+    assert!(!body.contains("<nav"), "got: {body}");
+    assert!(!body.contains("<html"), "got: {body}");
+}
+
+#[tokio::test]
+async fn palette_with_a_blank_query_returns_the_empty_state_fragment() {
+    let router = seeded_router().await;
+    let body = get_ok_body(router, "/palette?q=").await;
+
+    assert!(body.contains("empty-state"), "got: {body}");
+    assert!(!body.contains("<nav"), "got: {body}");
+}
+
+#[tokio::test]
+async fn palette_with_no_query_returns_the_empty_state_fragment() {
+    let router = seeded_router().await;
+    let body = get_ok_body(router, "/palette").await;
+
+    assert!(body.contains("empty-state"), "got: {body}");
+}
+
+#[tokio::test]
+async fn the_home_page_loads_the_deferred_palette_script_and_the_hidden_overlay() {
+    let router = seeded_router().await;
+    let body = get_ok_body(router, "/").await;
+
+    assert!(
+        body.contains("<script src=\"/palette.js\" defer></script>"),
+        "got: {body}"
+    );
+    assert!(
+        body.contains("id=\"palette-overlay\" hidden"),
+        "got: {body}"
+    );
 }


### PR DESCRIPTION
## Summary

Implements **issue 0008** / **ADR 0015**: the web front's UX moves to the three-pane doc-site archetype with a search-first Cmd+K palette, delivered in four verticals slices.

- **S1 — read-model**: `records.status` promoted to a typed column (new migration, canonical serialization keeps emitting `status:`); new `db-store` queries `records_by_type` (nav tree, deduped across projects) and `record_meta` (status + supersede chain + tags).
- **S2 — shell**: full-document three-pane layout (nav tree by doc type / record body / aside), `aria-current` active marking, `GET /style.css` served via `include_str!`.
- **S3 — metadata panel**: doc type, status badge, navigable Supersedes/Superseded-by links, tag chips; record page now renders exactly one `h1` (the body's own).
- **S4 — Cmd+K palette**: dependency-free vanilla JS (`GET /palette.js`, `defer`) opening on Ctrl/Cmd+K, fetching the new `GET /palette?q=` maud fragment (shared result renderer with the search page). With JS disabled, the plain `GET /?q=` form remains fully functional — strictly progressive enhancement per ADR 0015.

Router stays GET-only (ADR 0006); no client framework, no external assets.

## Verification

- 626 workspace tests green (43 in `web`, incl. 9 new S4 tests); `cargo fmt --all --check` and clippy clean.
- Browser gate 6/6 playwright specs against a live two-project corpus: shell nav, search flow, project filter, metadata panel, palette open/navigate/close, and a **JavaScript-disabled** fallback spec.
- Quality gate: max cyclomatic 5 / cognitive 5 on changed files, duplication 0.33%, comment hygiene clean.
- Each slice went through independent code review; all acceptance criteria passed.

## Notes

- Known follow-up (out of scope): FTS5 parses a bare hyphen as its NOT operator, so hyphenated search terms (e.g. `three-pane`) silently return empty — candidate db-store issue for query sanitization.
- Docs ride the same train: ADR 0015 (Accepted) and issue 0008; `living-docs check` passes over `docs/`.

🤖 Co-authored with Claude Code

Evaldo Klock <neto.nemesis@gmail.com>