### PR TITLE
docs: issues 0008 (brief scaffold) + 0009 (doc size targets) — token-economy slices

### DIFF
--- a/docs/issues/0008-brief-scaffold.md
+++ b/docs/issues/0008-brief-scaffold.md
@@ -1,0 +1,69 @@
+---
+type: Issue
+title: living-docs brief — deterministic pre-filled scaffold that leaves only the judgment slots for the authoring model
+description: A `brief` subcommand that extends `new` by pre-filling everything derivable from the repo (frontmatter, next number, timestamp, cross-links, git-derived touched files) and emitting the template with explicitly marked empty judgment slots — so the authoring model fills gaps instead of generating whole files.
+status: open
+labels: [slice, cli, token-economy]
+blocked_by: []
+tracker:
+timestamp: 2026-07-19T00:00:00Z
+---
+
+## living-docs brief — pre-filled scaffold, judgment slots left empty
+
+Motivated by ai-configs research `0053` (living-docs token economy): the authoring
+model's cost is output tokens spent on prose; everything mechanically derivable should
+come from the tool at zero token cost. `brief` is the next step on the ADR 0001 line —
+it widens what the tool pre-fills without crossing the determinism boundary (the tool
+derives facts; it never writes rationale, never chooses an epistemic type).
+
+### Objective link
+
+Constitution (deterministic layer owns the mechanical) → [ADR 0001](/adr/0001-living-docs-cli.md)
+(CLI owns template-fillable steps) → this slice.
+
+### Context manifest
+
+- Read: `cli/src/main.rs` (`New`/`Next` commands), `living-docs-core` record templates,
+  the fs `DocStore`.
+- Seams touched: a `Brief` variant next to `New` in the CLI; a scaffold builder in
+  `living-docs-core` that composes the existing template + derivable fields; optional
+  git read (touched files for an issue/ADR context section) behind a flag so the core
+  stays I/O-free.
+- Pattern: strictly a superset of `new` — same template, more fields pre-filled, empty
+  slots explicitly marked (e.g. `<!-- judgment: rationale -->`) so an agent can locate
+  them without re-reading the whole file.
+
+### Scope
+
+`living-docs brief <doc-type> "<title>"` writes the same record `new` would, with:
+number/slug/frontmatter/timestamp filled (as today), cross-link stubs to the docs the
+type conventionally links (ADR → issue/research placeholders), an optional
+`--from-diff <range>` that lists git-touched files into the context section, and every
+judgment field emitted as a marked empty slot. Output passes `check`.
+
+### Vertical Demo
+
+- **Given** a docs bundle, **When** I run `living-docs brief adr "Choose X over Y"`,
+  **Then** a conformant ADR file exists with frontmatter and links pre-filled and the
+  Context/Decision/Consequences bodies as marked empty slots, and `living-docs check`
+  passes.
+- **Given** `--from-diff HEAD~3..HEAD`, **When** I run `brief issue "..."`, **Then**
+  the context section lists the files touched in that range (unhappy path: an invalid
+  range fails with a clear error, no file written).
+
+### Acceptance
+
+- `brief` output passes `check` for every doc type it supports. — verify_by: test
+- `brief` writes no prose into judgment slots — the slots are byte-identical markers,
+  asserted by test. — verify_by: test
+- `--from-diff` content is exactly derivable from `git diff --name-only` on the range
+  (deterministic; same input → same output). — verify_by: test
+- Complexity + no-comments + tests-with-the-change standing rules hold. — verify_by: command
+
+### Out of scope
+
+No LLM calls, no prose generation, no epistemic-type inference (determinism boundary,
+ADR 0001). No new ADR needed unless implementation surfaces a real fork; the scaffold
+is additive CLI surface under existing decisions. Size-target warnings are slice
+[0009](/issues/0009-doc-size-targets.md).

--- a/docs/issues/0009-doc-size-targets.md
+++ b/docs/issues/0009-doc-size-targets.md
@@ -1,7 +1,7 @@
 ---
 type: Issue
 title: Per-type doc size targets — authoring convention in the skill corpus + advisory warning in check, plus the same-change economic rationale
-description: State per-doc-type body size targets (ADR/BDR/issue/research) as an authoring convention in the embedded living-docs skill corpus, have `check` emit an advisory (non-failing) warning when a body exceeds its target, and record the economic rationale for the docs-in-the-same-change rule where that rule lives.
+description: State the doc body size target (aim ~100 lines, advisory warning at 120 — owner-set, uniform for decision/execution records; research exempt) as an authoring convention in the embedded living-docs skill corpus, have `check` emit an advisory (non-failing) warning when a body exceeds it, and record the economic rationale for the docs-in-the-same-change rule where that rule lives.
 status: open
 labels: [slice, cli, skill-corpus, token-economy]
 blocked_by: []
@@ -35,10 +35,11 @@ Constitution → [ADR 0001](/adr/0001-living-docs-cli.md) (`check` is the doc-ga
 
 ### Scope
 
-- Corpus: per-type body-line targets (proposed starting values, tune at implementation:
-  ADR ≤ ~60, BDR ≤ ~40, issue ≤ ~80, research unbounded-but-index-summarized) with the
-  one-line rationale (output-token cost + compaction survival) and the standing rule
-  that a target is never a reason to omit a load-bearing rationale.
+- Corpus: body-line targets set by the owner (2026-07-19): **aim ~100 lines, advisory
+  warning at 120**, uniform across decision/execution records (ADR, BDR, PRD, issue);
+  research stays unbounded-but-index-summarized (long-form evidence by nature). State
+  the one-line rationale (output-token cost + compaction survival) and the standing
+  rule that a target is never a reason to omit a load-bearing rationale.
 - Corpus: next to the docs-in-the-same-change rule, add the `0053` Finding-3 economic
   rationale — same-session hot-context writing is output-token-dominant; deferring docs
   re-pays the input context cold.

--- a/docs/issues/0009-doc-size-targets.md
+++ b/docs/issues/0009-doc-size-targets.md
@@ -1,0 +1,68 @@
+---
+type: Issue
+title: Per-type doc size targets — authoring convention in the skill corpus + advisory warning in check, plus the same-change economic rationale
+description: State per-doc-type body size targets (ADR/BDR/issue/research) as an authoring convention in the embedded living-docs skill corpus, have `check` emit an advisory (non-failing) warning when a body exceeds its target, and record the economic rationale for the docs-in-the-same-change rule where that rule lives.
+status: open
+labels: [slice, cli, skill-corpus, token-economy]
+blocked_by: []
+tracker:
+timestamp: 2026-07-19T00:00:00Z
+---
+
+## Per-type doc size targets + the same-change economic rationale
+
+Motivated by ai-configs research `0053`: output tokens scale with prose length, so
+"write less" is the largest authoring saving available — and terse docs independently
+read better and survive context compaction. The targets are a convention with an
+advisory instrument, not a hard gate: judgment prose must never be truncated to satisfy
+a number.
+
+### Objective link
+
+Constitution → [ADR 0001](/adr/0001-living-docs-cli.md) (`check` is the doc-gate) →
+[ADR 0014](/adr/0014-the-cli-serves-skill-content-from-an-embedded-corpus-harness-skill-md-files-are-slim-stubs.md)
+(skill content lives in the embedded corpus) → this slice.
+
+### Context manifest
+
+- Read: `skills/living-docs/` corpus (authoring conventions topics), `check`
+  implementation in `living-docs-core`.
+- Seams touched: one new/extended corpus topic stating the per-type targets and their
+  rationale; a `check` warning path (stdout note, exit 0) when a non-index doc body
+  exceeds its type's target.
+- Pattern: warning, never failure — mirrors how ai-configs states agent-file line
+  targets as review pressure, not a build break.
+
+### Scope
+
+- Corpus: per-type body-line targets (proposed starting values, tune at implementation:
+  ADR ≤ ~60, BDR ≤ ~40, issue ≤ ~80, research unbounded-but-index-summarized) with the
+  one-line rationale (output-token cost + compaction survival) and the standing rule
+  that a target is never a reason to omit a load-bearing rationale.
+- Corpus: next to the docs-in-the-same-change rule, add the `0053` Finding-3 economic
+  rationale — same-session hot-context writing is output-token-dominant; deferring docs
+  re-pays the input context cold.
+- `check`: advisory `SIZE` warning per over-target doc, listing doc, lines, target;
+  exit code unchanged.
+
+### Vertical Demo
+
+- **Given** a bundle with an ADR body over target, **When** I run `living-docs check`,
+  **Then** a `SIZE` advisory names the file and both numbers and the command still
+  exits 0 (and existing failures still fail).
+- **Given** `living-docs skill living-docs --topic <conventions-topic>`, **Then** the
+  targets and the same-change economic rationale print from the embedded corpus.
+
+### Acceptance
+
+- `check` emits the advisory for an over-target fixture and stays exit 0; a fixture
+  with a real invariant violation still exits non-zero. — verify_by: test
+- Targets and rationale live in exactly one corpus topic (one home per fact) and are
+  served via `living-docs skill`. — verify_by: command
+- Complexity + no-comments + tests-with-the-change standing rules hold. — verify_by: command
+
+### Out of scope
+
+No hard failure on size, no auto-truncation, no per-project target overrides until a
+real need appears. The `brief` scaffold is slice
+[0008](/issues/0008-brief-scaffold.md).

--- a/docs/issues/index.md
+++ b/docs/issues/index.md
@@ -7,6 +7,9 @@ one slice per fresh context, starting from the skeleton.
 
 ## Open
 
+* [0008 — living-docs brief — deterministic pre-filled scaffold, judgment slots left empty](0008-brief-scaffold.md) - open
+* [0009 — Per-type doc size targets (skill corpus + advisory check warning) + the same-change economic rationale](0009-doc-size-targets.md) - open
+
 ## Closed
 
 * [0001 — Walking skeleton — Cargo workspace + living-docs-core + fs-store + thin cli](0001-workspace-core-skeleton.md) - done


### PR DESCRIPTION
## What

Two docs-first slices motivated by ai-configs research 0053 (living-docs token economy — the authoring model's cost is output tokens spent on prose; everything mechanically derivable should come from the tool at zero token cost):

- **`docs/issues/0008-brief-scaffold.md`** — `living-docs brief <type> "<title>"`: a strict superset of `new` that pre-fills everything derivable (frontmatter, cross-link stubs, optional `--from-diff` git-touched files) and emits explicitly marked **empty judgment slots**, so the authoring model fills gaps instead of generating files. Stays inside the ADR 0001 determinism boundary — the tool derives facts, never writes rationale.
- **`docs/issues/0009-doc-size-targets.md`** — per-type body size targets as a skill-corpus convention plus an advisory (non-failing) `SIZE` warning in `check`, and the economic rationale for the docs-in-the-same-change rule recorded where that rule lives. Warning, never a gate: judgment prose is never truncated to satisfy a number.
- Issues `index.md` Open section updated.

Docs only — no code in this PR; both slices implement later, one per fresh context.

## Verification

- `cargo build -p living-docs` + `./target/debug/living-docs check docs` → `OK — 29 docs, no invariant violations.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YP4yM8e379fDSCL9Sdc2LM

---
_Generated by [Claude Code](https://claude.ai/code/session_01YP4yM8e379fDSCL9Sdc2LM)_