### PR TITLE
docs: Atlas vision + pure-router skill stubs (ADR 0016, 0017)

### DIFF
--- a/.research-runs/2026-07-20-ontology-codegraph-bridge/raw-angle-code-kg.md
+++ b/.research-runs/2026-07-20-ontology-codegraph-bridge/raw-angle-code-kg.md
@@ -1,0 +1,42 @@
+# Angle: Code knowledge graph standards (agent a5755, 10 tool_uses)
+
+## LSIF (Microsoft)
+- LSIF dumps language-server knowledge so LSP requests (defs/refs/hovers) answer without running the server; reuses LSP data types. Graph of vertices (documents, ranges, resultSets, hovers) + edges (LSP requests); cross-project via "monikers".
+- [T1] https://microsoft.github.io/language-server-protocol/specifications/lsif/0.4.0/specification/ — LSIF Spec 0.4.0
+- [T1] https://microsoft.github.io/language-server-protocol/overviews/lsif/overview/ — LSP/LSIF Overview
+
+## SCIP (Sourcegraph)
+- Protobuf schema centered on human-readable string symbol IDs (replaces LSIF monikers/resultSet). Transmission format, explicitly NOT a query/storage format; "does not aim to support efficient code navigation by itself". Influenced by Scala SemanticDB. Indexers: scip-java, scip-typescript, rust-analyzer, scip-clang, scip-python.
+- [T1] https://sourcegraph.com/blog/announcing-scip
+- [T1] https://github.com/scip-code/scip/blob/main/docs/DESIGN.md
+
+## Kythe (Google)
+- Language-agnostic graph: nodes, edges, facts. Facts = named bytestrings on nodes; edges = directed labelled; emitted as stream of entries; nodes id'd by 5-field VNames. Cross-refs via anchors: define/binding + ref edges. Schema extensible w/o central authority; reverse edges auto-generated. Has doc/uri fact but no NL-concept ontology.
+- [T1] https://kythe.io/docs/schema-overview.html
+- [T1] https://kythe.io/docs/kythe-storage.html
+- [T1] https://kythe.io/docs/schema/writing-an-indexer.html
+
+## Code Property Graph (Joern/ShiftLeft)
+- Merges AST+CFG+PDG at shared statement/predicate nodes; labeled property graph (Neo4j/JanusGraph-style), NOT RDF. Yamaguchi et al., IEEE S&P 2014. Joern = OSS ref impl; ShiftLeft/Qwiet = commercial; Plume merged into Joern 2021. Security/dataflow oriented; no ontology/NL layer.
+- [T1 paper] Yamaguchi et al., "Modeling and Discovering Vulnerabilities with Code Property Graphs", IEEE S&P 2014
+- [T2] https://en.wikipedia.org/wiki/Code_property_graph
+
+## CodeOntology (closest to the bridge)
+- OWL 2 ontology of OO structural entities + parser serializing Java source/bytecode to RDF triples, SPARQL-queryable. Designed in Protégé. Links code entities to NL concepts by disambiguating doc comments against DBpedia via TagMe. => closest existing code-symbol<->NL-concept RDF bridge.
+- MAINTENANCE: dormant. parser repo last updated Oct 2021; CodeOntologyPython Oct 2022; question-answering Jul 2022. Java-only.
+- [T1] https://link.springer.com/chapter/10.1007/978-3-319-68204-4_2 — "CodeOntology: RDF-ization of Source Code" (ISWC 2017)
+- [T1 repo] https://github.com/codeontology
+
+## SEON (two projects, same acronym)
+- (a) Software Evolution ONtologies: pyramid of OWL ontologies + Linked Data (se-on.org). Würsch et al., Computing 94(11):857-885 (2012). https://link.springer.com/article/10.1007/s00607-012-0204-1 [T1]
+- (b) Software Engineering Ontology Network (NEMO/UFES Brazil): network of SE reference ontologies (reqs/design/coding/testing). Ruy et al., EKAW 2016. https://link.springer.com/chapter/10.1007/978-3-319-49004-5_34 [T1]
+- Both are reference/domain ontologies, NOT per-repo symbol indexers.
+
+## Traceability KGs (code<->doc linking research frontier)
+- Traceability KGs = artifacts as typed nodes, trace links as typed directed edges (labeled property graph), each node has text + embedding, edges have confidence. [T2] arxiv 2606.17203
+- NL<->code trace-link recovery treated as learned similarity/GNN problem (HGNNLink) because code lacks functional-semantic descriptions + high spurious textual similarity. arxiv 2509.05585; Springer 10.1007/s10515-025-00528-2
+- Requirements traceability survey: connecting artifacts "requires a knowledge graph for domain concepts" + heuristics — must be built/supplied. [T1] https://arxiv.org/abs/2405.10845
+- LLM doc-to-code traceability viable w/o formal ontology (best LLM F1 ~79-80% vs TF-IDF/BM25/CodeBERT). [T2] https://arxiv.org/abs/2506.16440
+
+## VERDICT (angle)
+No mature, maintained off-the-shelf code-ontology standard both maps repo symbols into a queryable graph AND bridges to human doc concepts in RDF/SKOS. Industrial standards (LSIF/SCIP/Kythe) = protobuf/property-graph, code-boundary only, no doc-concept/SKOS layer; SCIP disclaims being queryable store. CPG = security-focused property graph. CodeOntology = the one true code->RDF/OWL + doc->DBpedia bridge, but Java-only + unmaintained since 2021-22. SEON = domain reference ontologies, not symbol indexers. Frontier treats code<->NL link as build-or-learn (GNN/embeddings/LLM). => For code-symbol layer a purpose-built graph (SCIP/Kythe/codegraph-style) wins; for the code<->doc bridge nothing standard exists, so a hand-rolled RDF/SKOS map is NOT made redundant.

--- a/.research-runs/2026-07-20-ontology-codegraph-bridge/raw-angle-ontology-bridge.md
+++ b/.research-runs/2026-07-20-ontology-codegraph-bridge/raw-angle-ontology-bridge.md
@@ -1,0 +1,41 @@
+# Angle: Ontology-driven docs bridging code<->human (agent af5b23, 12 tool_uses)
+
+## Ontology as intermediate representation (traceability)
+- Ontology bridges "semantic gap" between NL docs/requirements and syntactic code; serves as intermediate artefact connecting metamodel-based + NL artefacts; independent of historical trace data. [T1] Springer OntoTrace 10.1007/978-3-031-29786-1_10
+- Code-as-KG + graph+keyword+vector indexing + LLM/RAG improves requirement->code traceability over text-similarity alone. [T1] ER 2024 Requirements2Code (PDF fetch BLOCKED - FlateDecode; rests on search summary)
+- Ontology+KG+LLM generalizable extraction pattern -> "semantic querying, traceability, automated reasoning". [T1] arxiv 2510.01409 OntoLogX
+- Empirically validated ontology-based NLP tracing reqs->conceptual models. [T1] Requirements Eng journal 2025, 10.1007/s00766-025-00447-4
+
+## Developer KGs in practice
+- GraphGen4Code (MOST on-point): nodes = classes/functions/methods, edges include DOCUMENTATION links; "links library calls to documentation and forum discussions"; 79% linking accuracy (100% annotator agreement on 100 samples); 1.3M Python programs. [T1] arxiv 2002.09440
+- Sourcegraph "code as data" global reference graph via SCIP (Protobuf, human-readable string symbol IDs, inspired by SemanticDB); cross-repo defs/refs; SCIP 10-20% smaller than LSIF. [T1] sourcegraph.com/blog/announcing-scip
+- LinkedIn KG: trillions of edges; binary classifier per entity-relationship type; entity DISAMBIGUATION is the hard problem (the "uber" 96-member mismap). [T1] linkedin.com/blog/engineering
+- Code Digital Twin (NORTH-STAR match): unifies code symbol graph (structural) + tacit/domain knowledge from docs+devs via domain-glossary construction + concept linking code symbols<->domain concepts. [T1] arxiv 2503.07967 (Xin Peng, Chong Wang). Verified abstract quote: "models both the physical and conceptual layers... integrating hybrid knowledge representations". Sharp "symbol graph vs domain KG" phrasing = paraphrase, needs full-text.
+- Repo-level KG: FTS + vector + reverse-mapping from documentation nodes back to code nodes they describe. [T1] arxiv 2505.14394
+
+## DDD ubiquitous language -> code identifiers
+- Ubiquitous Language reaches "all the way into the product's source code"; class/method/var names mirror domain terms. [T1] Fowler; Evans DDD Reference: "a change in the language is a change to the model... refactor the code, renaming classes".
+- CRUCIAL CONSTRAINT: mapping is BOUNDED-CONTEXT-scoped; same term differs across contexts; DDD explicitly REJECTS a single global unified model. => ontology bridge mappings must be context-qualified, NOT global. [T3 wiki DDD]
+- Model-to-code tools (Context Mapper DSL, Actifsource, CubicWeb, OpenMDX) exist but are generation tools, not "glossary term<->existing code identifier" bridges.
+
+## Semantic search / RAG: graph vs vector
+- Pure vector better for topical "find content about X"; on simple semantic search vector RAG and GraphRAG comparable, graph adds overhead w/o benefit; graph wins often "cherry-picked worst case". [T2] tianpan.co
+- Graph earns keep for: (a) multi-hop reasoning, (b) entity disambiguation via explicit edges, (c) temporal/causal, (d) synthesis across scattered chunks. [T2] flur.ee
+- MS GraphRAG: entity/rel extraction -> Leiden community clustering -> community summaries -> global/local query. [T2]
+- Graph costs: ontology/schema maintenance, hard incremental updates, latency (graph traversal 200-300ms vs sub-50ms vector ANN), query expertise. MEASURE FIRST: build 50-100 query eval set; "recall@k < 70% => retrieval is bottleneck". [T2] tianpan.co => maps to repo's own evidence-gate discipline.
+- Hybrid = common prod answer: vector finds seeds, graph traversal enriches. [T2] memgraph HybridRAG
+
+## Standards for cross-artifact concept links
+- SKOS mapping properties (align concepts ACROSS schemes): exactMatch, closeMatch, broadMatch, narrowMatch, relatedMatch (sub-props of skos:mappingRelation). exactMatch transitive; closeMatch deliberately NON-transitive (prevents uncontrolled similarity propagation). Positioned as alternatives to overused owl:sameAs. Caveat: "no substitute for careful management of RDF graphs / provenance". [T1] W3C SKOS Reference https://www.w3.org/TR/skos-reference/ ; SKOS Primer https://www.w3.org/TR/skos-primer/
+  => exactMatch/closeMatch/relatedMatch is the precise vocabulary for "code symbol <-> human concept" links of varying tightness across schemes (code graph vs human ontology).
+- W3C Web Annotation Data Model: Annotation + Body(ies) + Target(s), JSON-LD; Target/Body may be a specific SEGMENT. "conveys that the body is related to the target". [T1] https://www.w3.org/TR/annotation-model/ ; Protocol on LDP https://www.w3.org/TR/annotation-protocol/
+  => natural mechanism to attach human concept (Body) to precise code location/symbol (Target segment), interoperably.
+- JSON-LD = shared serialization making SKOS + Web Annotation RDF-native yet dev-friendly (plain JSON that is also a graph).
+
+## Blocked/gaps
+- ER24-Requirements2Code.pdf: binary FlateDecode, no verbatim (rests on search summary).
+- Code Digital Twin 2503.07967: sharp phrasing = paraphrase, only "physical+conceptual layers, hybrid knowledge representations" verbatim.
+- Uber KG: no accessible tier-1 architecture writeup. LinkedIn = documented exemplar.
+
+## VERDICT (angle)
+Value of ontology bridge is CONDITIONAL and NARROW, not universal. Real+measured for: (1) entity disambiguation (explicit edges resolve term meaning where embeddings blur - LinkedIn "uber"; GraphGen4Code 79%); (2) multi-hop/relational + traceability queries (what req does this class satisfy / what breaks if I rename this concept) where FTS/vector degrade; (3) stable human-readable cross-artifact identity (SCIP string IDs, SKOS mapping relations - durable anchors vs per-model-drifting embeddings). For plain "find docs about X" the graph adds latency/schema-cost for no measurable gain -> measure query distribution first, expect hybrid (vector-seeded, graph-enriched). MINIMAL VIABLE SHAPE: code symbol graph w/ human-readable stable IDs (SCIP-style) on one side; lightweight human concept scheme (DDD glossary, bounded-context-scoped since global model rejected) on other; between them typed links via EXISTING standards - SKOS exactMatch/closeMatch/relatedMatch for concept-concept + W3C Web Annotation (Body=concept, Target=code segment) for concept-code-location, all JSON-LD so the bridge is itself a queryable graph. Build graph traversal only after eval corpus shows FTS+embeddings failing on relational/disambiguation queries you care about.

--- a/.research-runs/2026-07-20-ontology-codegraph-bridge/raw-angle-rdf-vs-pg.md
+++ b/.research-runs/2026-07-20-ontology-codegraph-bridge/raw-angle-rdf-vs-pg.md
@@ -1,0 +1,31 @@
+# Angle: RDF vs property graph tradeoffs (agent a9d44, 10 tool_uses) — REFUTE F3
+
+## Model differences
+- RDF = edge-centric triples (S-P-O) + global URIs + SPARQL (W3C std). LPG = node-centric, inline properties on nodes AND edges + Cypher/GQL (ISO GQL). [T2] DZone/Ontotext; Neo4j blog (pro-LPG bias)
+- LPG attaches properties directly to edges; RDF cannot natively -> reification (extra nodes/triples). "relationships in RDF don't really exist as first class citizens". RDF-star/RDF 1.2 = convergence giving RDF edge-properties.
+- RDF strengths: standards/interop, ontologies, inference/reasoning. LPG strengths: simplicity, edge properties, traversal ergonomics.
+- [T1 peer-reviewed] PLOS ONE "Property Graph vs RDF Triple Store: Glycan Substructure Search" https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0144578 : SPARQL-on-Neo4j-via-plugin ran 2.4-27x SLOWER than Jena Fuseki (itself slowest triple store) => paradigm-bridging is a perf tax.
+
+## Neo4j + neosemantics (n10s)
+- Imports/exports RDF into Neo4j LPG losslessly; maps OWL/RDFS/SKOS; SHACL. [T1] github.com/neo4j-labs/neosemantics (Labs = community-supported, not core)
+- Mechanics: dataType props -> node properties; object props -> relationships; rdf:type -> node labels; every node has uri property. Requires unique-URI constraint + GraphConfig.
+- LIMITATION: ontology loader only processes rdfs:domain/range + owl:Restriction; "All other elements will be ignored by this loader" => OWL semantics beyond subset dropped.
+- Java (81.8%), runs inside Neo4j server (JVM) = separate service, NOT in-process for Rust.
+
+## Embeddable/in-process stores
+- Oxigraph: Rust RDF/SPARQL, in-process, RocksDB on-disk + in-memory. Native Rust crate. [T1]
+- RDFLib: pure Python, in-process (not Rust). SQLite backends stale (rdflib-sqlite MOTHBALLED).
+- Apache Jena TDB2: Java, embedded but JVM-only. COW MVCC.
+- SQLite-as-triplestore: 3-col triples table; SPARQL = expensive self-joins; needs full SPO permutation indexes; NO off-the-shelf SQLite->SPARQL engine (hand-roll query logic). [T1/2 arxiv 1801.00036]
+- KuzuDB: embeddable LPG + Cypher, has Rust bindings (cargo add kuzu), historically RDF->PG mapping. BUT ARCHIVED Oct 10 2025 (read-only, on-disk format never stabilized). [T1] github.com/kuzudb/kuzu
+
+## JVM/separate-service cost
+- Jena/RDF4J/n10s pull in JVM; Neo4j+n10s adds out-of-process server + serialization per query. No tier-1 benchmark of JVM-vs-Rust overhead (architectural fact). Oxigraph + SQLite ext both link as native Rust crates (single binary, in-process, no socket).
+
+## codegraph-style (already SQLite): 3 options
+- Extend SQLite: in-process, zero new runtime; BUT inherit self-join perf problem + no SPARQL/reasoning free.
+- Add embedded RDF (Oxigraph): stays Rust in-process, real SPARQL 1.1 + RDF/SKOS/OWL ingestion; cost = 2nd store to sync + "not optimized yet" caveat.
+- Separate graph DB (Neo4j+n10s): mature Cypher + RDF bridge, but out-of-process JVM, lossy OWL, extra service. Kuzu = archived risk.
+
+## VERDICT (angle): F3 REFUTED for this use
+Embedded RDF holds up; property-graph service does NOT clearly win. Only credible in-process same-language options = Oxigraph or extend SQLite (single binary, zero new runtime). Kuzu (embeddable LPG) archived. Neo4j+n10s buys Cypher + lossless RDF round-trip but imposes JVM + separate server + lossy OWL; SPARQL-on-LPG 2.4-27x slower even before cross-process hop. A "documentation ontology" with SKOS/OWL semantics is RDF's home turf. Least-cost path w/ real ontology semantics = Oxigraph embedded alongside (or projected from) existing SQLite graph. Non-Rust service warranted only if you need heavy Cypher analytics / Neo4j ops tooling — not implied by ontology-linking.

--- a/.research-runs/2026-07-20-ontology-codegraph-bridge/raw-angle-rust-rdf.md
+++ b/.research-runs/2026-07-20-ontology-codegraph-bridge/raw-angle-rust-rdf.md
@@ -1,0 +1,41 @@
+# Angle: Rust RDF ecosystem maturity (agent a4a1, 24 tool_uses) — REFUTE F1
+
+## Oxigraph
+- Latest 0.5.9, published 2026-06-18; ~511,934 downloads. [T1] https://crates.io/api/v1/crates/oxigraph
+- Near-monthly cadence: 0.5.7 (2026-04-19) ... 0.5.0 (2025-09-13), etc. [T1] CHANGELOG raw
+- Most recent commit 2026-07-19 (day before report). [T1] https://api.github.com/repos/oxigraph/oxigraph/commits
+- Open 112 / closed 247 issues (~0.45 ratio, healthy). ~1.8k stars. Lead maintainer Tpt (Thomas Tanon), offers paid support. Bus-factor: single lead.
+- Features: SPARQL 1.1 Query+Update+Federated; XML/JSON/CSV/TSV results; RDF Dataset Canonicalization; preliminary SPARQL 1.2 behind sparql-12. RDF-star dropped for RDF 1.2 (0.5.0). JSON-LD 1.1 default (0.5.5). Formats: Turtle, TriG, N-Triples, N-Quads, RDF/XML, JSON-LD.
+- Embeddable in-process Rust lib; RocksDB on-disk + in-memory (WASM default). Python + JS/WASM bindings + CLI.
+- Users: Zazuko, RelationLabs, Data Treehouse, DeciSym.AI, ACE IoT.
+- CAVEAT (README): "Oxigraph is in heavy development and SPARQL query evaluation has not been optimized yet." (perf caveat, not "don't use in prod").
+- Sub-crates: oxrdf 0.3.3, oxttl 0.2.3, spargebra 0.4.6 (all 2026), oxrdfio/sparesults/spareval/sparopt.
+
+## sophia
+- Meta-crate 0.10.0 (2026-05-19); created 2018; ~458k downloads. Slow/irregular (~1 minor/yr) but current.
+- Recent commit 2026-05-20. Open 22 / closed 99. 324 stars. Lead: Pierre-Antoine Champin. Bus-factor: single lead.
+- Generic API for RDF 1.2. sophia_sparql = "(currently partial) implementation of SPARQL 1.2 Query" — INCOMPLETE, no Update. Formats: Turtle-family, JSON-LD 1.1, RDF/XML, N-Triples. In-memory only (sophia_inmem); NO native on-disk store. Has sophia_reasoner (Simple/RDF/RDFS entailment).
+- Dependents: manas (Solid), nanopub.
+
+## horned-owl
+- 2.1.0 published 2026-07-17 (major bump 3 days before report). ~58.7k downloads. Rust 2024, needs Rust >=1.88.
+- Recent commit 2026-07-20 (report date). Open 11 / closed 105. 98 stars. Lead: Phillip Lord (Newcastle Univ), academically backed.
+- Full OWL 2 DL implementation + SWRL. Syntaxes: RDF/XML, OWL/XML, Functional (Pest parser), Manchester. 928 unit tests.
+- Peer-reviewed: 20x-40x faster than Java OWL API; millions of terms. [T3 paper] Dagstuhl TGDK "Horned-OWL: Flying Further and Faster with Ontologies"
+- NOT a reasoner (reasoning = companion whelk-rs). Bindings: py-horned-owl.
+
+## Rust SKOS support — THE WEAK SPOT
+- rdftk_skos: dormant. Newest 0.2.0 published 2021-06-14. Self-described "not a complete API... extensibility with OWL is limited." [T1] https://crates.io/api/v1/crates/rdftk_skos
+- rdftk_core: more recent (~Nov 2024), added SKOS to PrefixMapping.
+- OxiRS oxirs-rule ships skos_validation module (broader/broaderTransitive/top-concept checks). OxiRS = separate newer project. [T2] docs.rs/oxirs-rule
+- NET: no actively-maintained dedicated SKOS crate. SKOS in Rust = build on Oxigraph/sophia w/ rdf_vocabularies, or dormant rdftk_skos, or emerging oxirs-rule.
+
+## OxiRS (cool-japan/oxirs): SPARQL 1.2 + GraphQL + "AI reasoning", early-stage, not deep-verified. [T3]
+
+## Blocked/partial fetches
+- crates.io HTML for horned-owl (title only) -> worked around via JSON API.
+- GitHub contributor graphs failed to render for sophia/horned-owl -> relied on commits/issues/stars.
+- Some download counts / timestamps via WebFetch summarizer (accurate-to-source, not re-parsed).
+
+## VERDICT (angle): F1 REFUTED (qualified yes)
+Rust RDF ecosystem IS production-viable as embedded in-process lib. Oxigraph clearly strongest (embeddable, RocksDB persistent + in-memory, full SPARQL 1.1, JSON-LD/Turtle/etc, monthly cadence, active). Qualifications: query eval "not optimized yet"; single-maintainer bus-factor across all three. sophia = toolkit/library (partial SPARQL, no store). horned-owl = OWL modeling/parsing (active, fast), not a store/reasoner. SKOS weak spot: no maintained dedicated crate -> build SKOS on Oxigraph/sophia. Bottom line: embedded RDF/SPARQL store -> Oxigraph; add horned-owl if OWL in scope; don't rely on off-the-shelf SKOS crate.

--- a/.research-runs/2026-07-20-ontology-codegraph-bridge/raw-angle-skos-vs-owl.md
+++ b/.research-runs/2026-07-20-ontology-codegraph-bridge/raw-angle-skos-vs-owl.md
@@ -1,0 +1,29 @@
+# Angle: SKOS vs OWL sufficiency (agent aecf74, 9 tool_uses) — REFUTE F2
+
+## SKOS data model [T1 W3C]
+- skos:Concept = "an idea or notion; a unit of thought". ConceptScheme = aggregation of concepts. [T1] https://www.w3.org/TR/skos-reference/
+- Labels: prefLabel/altLabel/hiddenLabel + notation ("string like 'T58.5' to uniquely identify a concept within a scheme"). hiddenLabel = accessible to text indexing/search. [T1] SKOS Primer https://www.w3.org/TR/skos-primer/
+- Cross-scheme mapping relations native: exactMatch (transitive, "used interchangeably across wide range of IR apps"), closeMatch ("sufficiently similar, interchangeable in some IR apps"), broadMatch/narrowMatch (hierarchical), relatedMatch (associative). [T1] SKOS Reference
+
+## The deliberate boundary [T1] — LOAD-BEARING
+- "SKOS is not a formal knowledge representation language." Thesaurus/classification "does not assert any axioms or facts... do not have any formal semantics, cannot be reliably interpreted as either formal axioms or facts about the world." [T1] SKOS Reference
+- Gap = class axioms, disjointness, cardinality/property restrictions, property characteristics (functional/inverse/transitive/symmetric), reasoner-based contradiction detection + auto-classification. [T1 academic] EMMeT-to-OWL OWLED 2015 https://cgi.csc.liv.ac.uk/~valli/OWLED2015/OWLED_2015_paper_9.pdf ; "SKOS with OWL: Don't be Full-ish!" https://ceur-ws.org/Vol-432/owled2008eu_submission_22.pdf
+- EMMeT: partial lift to OWL driven by "an application (generating multiple choice questions) that requires more precision"; BUT "many controlled vocabularies do not need any such precision."
+
+## SKOS/OWL tension [T1] — LOAD-BEARING
+- skos:broader is NOT transitive by design; broaderTransitive = opt-in inference super-property for transitive closure. "Note that skos:broader is not a transitive property." [T1] SKOS Reference + Primer worked example (animals>mammals>cats)
+- SKOS deliberately does NOT equate skos:Concept with owl:Class: "This specification does not make any additional statement about the formal relationship between the class of SKOS concepts and the class of OWL classes." Concepts = individuals, not owl:Class. [T1] SKOS Reference
+
+## SKOS scales in production [T1-2]
+- LCSH (id.loc.gov, maintained since 1898; first LC linked-data release Apr 2009 in SKOS/RDF). Getty AAT = SKOS + SKOS-XL + ISO 25964. EuroVoc v4.17 ~7,403 concepts / 202,008 prefLabels / 3.6M relations / 30 langs. AGROVOC 2023 ~40,983 concepts / 986,077 SKOS-XL prefLabels / ~5.9M relations / 58 langs. UNESCO Thesaurus v2 ~4,408 concepts.
+- Sources: https://id.loc.gov/authorities/subjects.html ; https://www.getty.edu/research/tools/vocabularies/lod/ ; https://aclanthology.org/2025.ldk-1.34.pdf (EuroVoc) ; https://www.w3.org/2005/Incubator/lld/wiki/Use_Case_AGROVOC_Thesaurus ; UNESCO via aims.fao.org
+
+## Cases of outgrowing SKOS [T1-2]
+- LCSH -> MADS/RDF: SKOS "does not provide a way to capture the multiple components, and their types, of pre-coordinated subject headings" (e.g. "Drama--17th century" flattened to literal). MODELING-EXPRESSIVITY gap, NOT reasoning. [T1] https://www.loc.gov/standards/mads/rdf/ ; arxiv 0805.2855
+- EMMeT + Digital Europa Thesaurus: lifted SKOS props to OWL object properties specifically for REASONING (consistency validation, infer implicit links, DL queries). [T1] OWLED 2015; [T3] medium Digital Europa Thesaurus; BestMap OWLED 2009 ceur-ws Vol-529
+
+## Blocked/weak
+- W3C WD "Using OWL and SKOS" (w3.org/2006/07/SWD/SKOS/skos-and-owl) fetched but extractor returned only generic pattern language; substituted authoritative SKOS Reference (Claim 3.2).
+
+## VERDICT (angle): F2 REFUTED
+SKOS is SUFFICIENT and is the purpose-built, industry-proven tool for a glossary linking doc concepts to code symbols with typed cross-scheme links. Every needed capability maps to a native SKOS construct: concepts + prefLabel/altLabel/hiddenLabel/notation (glossary terms), ConceptScheme (separate docs vocab from code-symbol vocab), mapping relations exactMatch/closeMatch/broadMatch/narrowMatch/relatedMatch (typed cross-scheme links) — same pattern LCSH/Getty/EuroVoc/AGROVOC run at millions of relations. W3C explicit SKOS "not a formal KR language" BY DESIGN; broader non-transitive w/ opt-in closure. SINGLE requirement forcing OWL = need to COMPUTE NEW FACTS BY LOGICAL ENTAILMENT (class axioms/disjointness/cardinality, reasoner contradiction detection or auto-classification, term-as-owl:Class subsumption w/ inheritance). Absent reasoning, SKOS is enough. Documented escalations all triggered by reasoning demand; the one non-reasoning escalation (LCSH->MADS) was internal-component-structure modeling, not reasoning.

--- a/.research-runs/2026-07-20-ontology-codegraph-bridge/raw-angle-wiki.md
+++ b/.research-runs/2026-07-20-ontology-codegraph-bridge/raw-angle-wiki.md
@@ -1,0 +1,24 @@
+# Angle: Wiki + ontology prior art (agent ad531, 9 tool_uses) — REFUTE F4
+
+## Semantic MediaWiki (SMW)
+- Typed properties via [[Property::Value]] => subject-predicate-object triples, queryable. Property: namespace; type via "Has type". Categories -> OWL/RDFS: category-in-article = rdf:type; category-on-category-page = rdfs:subClassOf. Formally interpreted in OWL DL, OWL/RDF export. #ask/#show queries; subobjects.
+- RDF export: per-page Special:ExportRDF, bulk dumpRDF.php (cronjob); external-vocab mapping (FOAF, Dublin Core); SPARQL endpoint.
+- Scale: "used successfully even with millions of rows"; limiting factor = overly-complex queries / template formatting, NOT data volume. Enterprise: J&J, Pfizer, NASA, NATO, UN.
+- [T1] semantic-mediawiki.org Help:Semantic_Web, Help:Properties, Help:RDF_export; meta.wikimedia Representation_in_database_and_RDF
+
+## Wikibase (Wikidata engine)
+- Data model: Entities (Items Q-IDs + Properties P-IDs) + Statements. Statements = snaks (value/novalue/somevalue) + qualifiers + references + ranks (Preferred/Normal/Deprecated). [T1] mediawiki.org Wikibase/DataModel
+- Heavier than SMW. "Wikibase on its own does not allow you to visualize or query the data stored in your wiki." Needs separate SPARQL service. Self-host heavyweight ("requires a relatively powerful server"); access all-or-nothing. Bridge to SMW (Semantic Wikibase) is LOSSY (only main-snak value). [T2] Professional Wiki
+- Fit: entity/fact-centric (atomic sourced statements), NOT document-centric. Poor fit for docs-per-project without heavy custom UI.
+
+## Lighter tools
+- Obsidian/Logseq: untyped links + backlinks; no native typed-relation/ontology layer ("typed links" = missing feature). Obsidian = doc-first page graph + Properties(YAML)+Dataview; Logseq = block outliner + Datalog query engine. Typed edges need plugins (Excalibrain, low perf at scale). [T3]
+- TiddlyWiki/Foam: backlink/link-centric, no enforced typed hierarchy (Foam issue #604 requested schemas it lacks). [T1 Foam]
+- Dendron: hierarchy as PRIMARY primitive (dot-delimited md) + OPTIONAL schema system = "type system for your notes" (autosuggest valid children, auto-template). Backlinks secondary. Refactor Hierarchy/Rename auto-updates links. [T1] wiki.dendron.so
+
+## "One concept, one place" match
+- Dendron = closest to single-authoritative-location semantic index ("one source of truth where a note can be filed"). Parallels living-docs' own "every doc lands in exactly one place". SMW/Wikibase do the OPPOSITE (concept = node reachable from many places via typed edges; many-to-many).
+- Cargo (SMW's lighter sibling): structured data tied to TEMPLATES, stored in standard SQL tables, SQL queries, built-in FTS + auto-drilldown. "Cargo's querying ~30-50% faster than SMW's." Created because SMW judged too heavyweight/wrongly-grained. table-per-doc-type maps cleanly to projects->typed docs (ADR/PRD/BDR). [T1] mediawiki.org Extension:Cargo
+
+## VERDICT (angle): F4 largely CONFIRMED (SMW/Wikibase don't fit well)
+No drop-in match. Best structural template = HYBRID of Dendron (organization/authoring: hierarchy-primary, one canonical home, optional schemas, refactor) + Cargo (structured/queryable: template-anchored SQL tables + FTS). SMW = credible middle only if you need standards-based RDF/OWL export out of the box (cost = query/template perf). Wikibase = weakest fit (atomic statements not docs, no in-wiki authoring/query, heavy self-host, all-or-nothing access).

--- a/.research-runs/2026-07-20-ontology-codegraph-bridge/run_manifest.json
+++ b/.research-runs/2026-07-20-ontology-codegraph-bridge/run_manifest.json
@@ -1,0 +1,21 @@
+{
+  "query": "open-source ontology tooling and its bridge to a code knowledge graph (codegraph) and a living-docs semantic index — Rust-native options prioritized",
+  "mode": "standard",
+  "epistemic_mode": "falsify",
+  "hypothesis": "A lightweight, Rust-native ontology layer (a SKOS controlled vocabulary held in an RDF store such as Oxigraph, with sophia as the toolkit) can bridge codegraph's symbol graph and the living-docs semantic index without introducing a non-Rust service — preserving the locked 'one language, one build' decision. Semantic MediaWiki / Wikibase are the best prior art for the wiki+ontology surface.",
+  "falsifiers": [
+    "F1: The Rust RDF ecosystem (Oxigraph, sophia, horned-owl) is immature or unmaintained, forcing a non-Rust service.",
+    "F2: SKOS is too weak for the code<->human bridge; OWL inference is actually required (heavier stack).",
+    "F3: A better-fit approach (property graph / Neo4j n10s, or a code-ontology standard like SCIP/LSIF/Kythe/CodeOntology) beats RDF-in-Rust.",
+    "F4: The Semantic MediaWiki / Wikibase model does not map to a docs-per-project wiki; different prior art fits better."
+  ],
+  "decision": "Which ontology substrate + serialization the Living Docs Atlas wiki adopts, and whether it stays Rust-native — feeding the future ADRs on repo structure (monorepo vs split) and the wiki PRD.",
+  "assumptions": [
+    "The web front stays Rust/axum reusing living-docs-core (locked decision).",
+    "codegraph is an available SQLite knowledge graph of code symbols and edges.",
+    "The docs already carry a semantic-index organization (living-docs skill)."
+  ],
+  "providers": ["WebSearch", "WebFetch", "GitHub"],
+  "started": "2026-07-20",
+  "current_date": "2026-07-20"
+}

--- a/.research-runs/2026-07-20-ontology-codegraph-bridge/sources.jsonl
+++ b/.research-runs/2026-07-20-ontology-codegraph-bridge/sources.jsonl
@@ -1,0 +1,36 @@
+{"id":1,"url":"https://www.w3.org/TR/skos-reference/","title":"SKOS Simple Knowledge Organization System Reference (W3C Rec)","type":"spec","tier":1}
+{"id":2,"url":"https://www.w3.org/TR/skos-primer/","title":"SKOS Primer (W3C)","type":"spec","tier":1}
+{"id":3,"url":"https://www.w3.org/TR/annotation-model/","title":"Web Annotation Data Model (W3C Rec)","type":"spec","tier":1}
+{"id":4,"url":"https://github.com/oxigraph/oxigraph","title":"Oxigraph repository","type":"repo","tier":1}
+{"id":5,"url":"https://crates.io/api/v1/crates/oxigraph","title":"oxigraph crate metadata 0.5.9 (2026-06-18)","type":"registry","tier":1}
+{"id":6,"url":"https://github.com/pchampin/sophia_rs","title":"sophia_rs repository","type":"repo","tier":1}
+{"id":7,"url":"https://github.com/phillord/horned-owl","title":"horned-owl repository","type":"repo","tier":1}
+{"id":8,"url":"https://crates.io/api/v1/crates/horned-owl","title":"horned-owl crate metadata 2.1.0 (2026-07-17)","type":"registry","tier":1}
+{"id":9,"url":"https://crates.io/api/v1/crates/rdftk_skos","title":"rdftk_skos crate metadata 0.2.0 (2021-06-14, dormant)","type":"registry","tier":1}
+{"id":10,"url":"https://sourcegraph.com/blog/announcing-scip","title":"SCIP - a better code indexing format than LSIF","type":"eng-blog","tier":1}
+{"id":11,"url":"https://microsoft.github.io/language-server-protocol/specifications/lsif/0.4.0/specification/","title":"LSIF Specification 0.4.0","type":"spec","tier":1}
+{"id":12,"url":"https://kythe.io/docs/kythe-storage.html","title":"Kythe Storage Model","type":"doc","tier":1}
+{"id":13,"url":"https://link.springer.com/chapter/10.1007/978-3-319-68204-4_2","title":"CodeOntology: RDF-ization of Source Code (ISWC 2017)","type":"paper","tier":1}
+{"id":14,"url":"https://github.com/codeontology","title":"CodeOntology org (last activity 2021-2022)","type":"repo","tier":1}
+{"id":15,"url":"https://en.wikipedia.org/wiki/Code_property_graph","title":"Code Property Graph (Yamaguchi et al. IEEE S&P 2014)","type":"encyclopedia","tier":2}
+{"id":16,"url":"https://arxiv.org/pdf/2002.09440","title":"A Toolkit for Generating Code Knowledge Graphs (GraphGen4Code)","type":"paper","tier":1}
+{"id":17,"url":"https://arxiv.org/abs/2503.07967","title":"Code Digital Twin (Peng, Wang)","type":"paper","tier":1}
+{"id":18,"url":"https://www.linkedin.com/blog/engineering/knowledge/building-the-linkedin-knowledge-graph","title":"Building the LinkedIn Knowledge Graph","type":"eng-blog","tier":1}
+{"id":19,"url":"https://www.semantic-mediawiki.org/wiki/Help:RDF_export","title":"Semantic MediaWiki Help:RDF export","type":"doc","tier":1}
+{"id":20,"url":"https://www.mediawiki.org/wiki/Wikibase/DataModel","title":"Wikibase DataModel","type":"doc","tier":1}
+{"id":21,"url":"https://professional.wiki/en/articles/managing-data-in-mediawiki","title":"Managing Data in MediaWiki: SMW vs Wikibase vs Cargo","type":"vendor-doc","tier":2}
+{"id":22,"url":"https://www.mediawiki.org/wiki/Extension:Cargo/Cargo_and_Semantic_MediaWiki","title":"Extension:Cargo and Semantic MediaWiki","type":"doc","tier":1}
+{"id":23,"url":"https://wiki.dendron.so/notes/c5e5adde-5459-409b-b34d-a0d75cbb1052/","title":"Dendron Schemas / Hierarchies","type":"doc","tier":1}
+{"id":24,"url":"https://github.com/neo4j-labs/neosemantics","title":"neosemantics (n10s) repository","type":"repo","tier":1}
+{"id":25,"url":"https://neo4j.com/labs/neosemantics/4.3/importing-ontologies/","title":"neosemantics Importing Ontologies","type":"doc","tier":1}
+{"id":26,"url":"https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0144578","title":"Property Graph vs RDF Triple Store: Glycan Substructure Search (PLOS ONE 2015)","type":"paper","tier":1}
+{"id":27,"url":"https://github.com/kuzudb/kuzu","title":"KuzuDB repository (archived 2025-10-10)","type":"repo","tier":1}
+{"id":28,"url":"https://jena.apache.org/documentation/tdb2/","title":"Apache Jena TDB2 Documentation","type":"doc","tier":1}
+{"id":29,"url":"https://martinfowler.com/bliki/UbiquitousLanguage.html","title":"Ubiquitous Language (Fowler)","type":"practitioner","tier":1}
+{"id":30,"url":"https://www.domainlanguage.com/wp-content/uploads/2016/05/DDD_Reference_2015-03.pdf","title":"Domain-Driven Design Reference (Evans, 2015)","type":"primary","tier":1}
+{"id":31,"url":"https://tianpan.co/blog/2026-04-17-graphrag-vs-vector-rag-knowledge-graphs","title":"GraphRAG vs Vector RAG","type":"blog","tier":2}
+{"id":32,"url":"https://dzone.com/articles/rdf-triple-stores-vs-labeled-property-graphs-whats","title":"RDF Triple Stores vs Labeled Property Graphs (Ontotext/DZone)","type":"vendor-adjacent","tier":2}
+{"id":33,"url":"https://cgi.csc.liv.ac.uk/~valli/OWLED2015/OWLED_2015_paper_9.pdf","title":"Lifting EMMeT to OWL: Getting the Most from SKOS (OWLED 2015)","type":"paper","tier":1}
+{"id":34,"url":"https://www.loc.gov/standards/mads/rdf/","title":"MADS/RDF; LCSH SKOS and Linked Data (arXiv:0805.2855)","type":"doc+paper","tier":1}
+{"id":35,"url":"https://aclanthology.org/2025.ldk-1.34.pdf","title":"EuroVoc as SKOS Linked Data (LDK 2025)","type":"paper","tier":1}
+{"id":36,"url":"https://model-engineering.info/publications/papers/ER24-Requirements2Code.pdf","title":"Establishing Traceability between NL Requirements and Software Artifacts (ER 2024) [PDF fetch blocked]","type":"paper","tier":1}

--- a/docs/adr/0006-web-read-only-axum.md
+++ b/docs/adr/0006-web-read-only-axum.md
@@ -2,9 +2,9 @@
 type: ADR
 title: The web view is a read-only axum server reusing living-docs-core
 description: The query web front is a Rust/axum server that reuses living-docs-core and reads the db-store read-model; it is read-only (no authoring in the browser), server-rendered, and never a second source of truth.
-status: Proposed
+status: Superseded
 supersedes:
-superseded_by:
+superseded_by: 0016
 tags: [architecture, web, axum, read-only, front, search]
 timestamp: 2026-07-16T00:00:00Z
 ---

--- a/docs/adr/0014-the-cli-serves-skill-content-from-an-embedded-corpus-harness-skill-md-files-are-slim-stubs.md
+++ b/docs/adr/0014-the-cli-serves-skill-content-from-an-embedded-corpus-harness-skill-md-files-are-slim-stubs.md
@@ -2,9 +2,9 @@
 type: ADR
 title: The CLI serves skill content from an embedded corpus; harness SKILL.md files are slim stubs
 description: Embed the skills/** tree in the living-docs binary and expose it via a `skill` subcommand (list, full body, per-topic); install ships a slim stub per harness that points at the CLI for detail, instead of copying the full rules/ + templates/ tree into every harness.
-status: Accepted
+status: Superseded
 supersedes:
-superseded_by:
+superseded_by: 0017
 tags: [documentation, tooling, skill-distribution, tokens, cli]
 timestamp: 2026-07-18T19:40:42Z
 ---

--- a/docs/adr/0016-atlas-makes-the-web-a-db-mode-authoring-front-superseding-web-read-only.md
+++ b/docs/adr/0016-atlas-makes-the-web-a-db-mode-authoring-front-superseding-web-read-only.md
@@ -1,0 +1,141 @@
+---
+type: ADR
+title: Atlas makes the web a db-mode authoring front, superseding web read-only
+description: The Living Docs Atlas web front becomes writable, but only in db-mode where the database is the single authoritative store (ADR 0003) — so there is still no second source of truth and no cross-backend sync; in file-mode the web stays read-only, and intra-db concurrency is single-store optimistic (a per-record revision precondition), never a merge.
+status: Proposed
+supersedes: 0006
+superseded_by:
+tags: [architecture, web, authoring, atlas, db-mode, source-of-truth, concurrency]
+timestamp: 2026-07-20T15:09:34Z
+---
+
+# 0016. Atlas Makes the Web a db-mode Authoring Front, Superseding Web Read-Only
+
+## Context
+
+The [Living Docs Atlas PRD](/prd/0001-living-docs-atlas-multi-project-authoring-wiki-over-living-docs-core.md)
+turns the web front from a read-only viewer into a **multi-project authoring wiki** — create,
+edit, supersede, delete in the browser. That directly reverses the central decision of
+[ADR 0006](/adr/0006-web-read-only-axum.md), which kept the web **read-only** precisely to
+avoid "reintroducing a second source of truth and the sync/conflict problem ADR 0003 killed."
+So the write path cannot be bolted on; it must be decided against the locked storage model.
+
+The binding constraints are two prior locked decisions, not open questions:
+
+- **[ADR 0003](/adr/0003-storage-backend-model.md)** made the `DocStore` backend
+  **config-selected and mutually exclusive**: *file-mode* (`.md` in git is the source of
+  truth; `search`/web read a **derived, never-authoritative read-model**) **or** *db-mode*
+  (the database **is** the authoritative store). Because exactly one backend is authoritative
+  per deployment, "there is no bidirectional sync and no conflict to resolve." ADR 0003
+  explicitly **rejects** co-authoritative equal-weight adapters. (Note: the "two interchangeable
+  adapters / both authoritative" phrasing still living in `CLAUDE.md` is stale relative to
+  ADR 0003; this ADR treats 0003 as the SSOT.)
+- **[ADR 0007](/adr/0007-db-mode-authoring-data-model-and-lossless-export-contract.md)** gave
+  db-mode a lossless, byte-stable `export` (db → `.md`) and `check` parity across backends.
+
+The naive framing of this decision — "define the fs↔db write-authority / sync-conflict
+contract" — is therefore a **category error**: ADR 0003 already dissolved cross-backend sync
+by exclusivity. The real questions Atlas forces are (a) *in which mode* browser authoring is
+even coherent, and (b) what the *single-store* concurrency contract is when several writers
+(Atlas tabs, a CLI db-mode writer, multiple users) hit the one authoritative DB.
+
+Epistemic type: **judgment** (no benchmark decides it; it is a safety/simplicity trade-off
+under the git-native, single-authoritative-store constraint). The critic applied below names
+the strongest rejected alternative.
+
+## Decision
+
+We will make the Atlas web front **writable only in db-mode, where the database is the single
+authoritative store (ADR 0003); in file-mode the web stays read-only.**
+
+1. **Authoring requires db-mode.** In db-mode the DB is the sole source of truth, so a browser
+   write introduces **no second source of truth and no cross-backend sync** — the exact hazard
+   ADR 0006 feared is avoided by *scoping authoring to the authoritative backend*, not by
+   forbidding authoring. In **file-mode** the web continues to render the derived read-model
+   read-only (ADR 0003: that projection is never authoritative, so it must not be written
+   through); file-mode authoring stays CLI + git-native `.md`.
+
+2. **Writes go through `living-docs-core`, gated by `check` inside the write transaction.**
+   Atlas handlers invoke the same core verbs as the CLI (`new`/edit/`supersede`/`delete`);
+   the write and its `check` run in one SQLite transaction. An invalid write (broken link,
+   bad frontmatter, size, Mermaid) **never commits** — the doc-gate is enforced on write, in
+   the browser exactly as on disk. This preserves ADR 0006's "web cannot drift from the CLI."
+
+3. **Concurrency is single-store optimistic, never a merge.** Each record carries a monotonic
+   `revision` (bumped on every committed write). A browser write submits the `base_revision`
+   it read; if the stored revision has moved, the write is **rejected** ("changed underneath
+   you — reload"), never silently overwritten or auto-merged. This is ordinary optimistic
+   concurrency against one store — categorically different from the cross-backend merge ADR
+   0003 rejected.
+
+4. **`.md` in a db-mode deployment is an export artifact, not a co-authoring surface.**
+   `living-docs export` (ADR 0007) is a one-way materialization (db → `.md`) for git/PR/diff/
+   backup. Hand-editing an exported `.md` and re-importing **normalizes** it (ADR 0007); the
+   file is never a second authoritative store. A project that wants git-native `.md` authoring
+   uses file-mode — and there the web is read-only, by decision 1.
+
+5. **Server-rendered Rust/axum reusing `living-docs-core` carries forward** from ADR 0006 (no
+   SPA, one language, one build); only the read-only clause is reversed.
+
+## Consequences
+
+**Easier / gained:**
+- The Atlas authoring vision (PRD 0001) becomes buildable without reopening the storage model:
+  authoring lands in the one authoritative backend, so ADR 0003's "no sync" guarantee holds.
+- The doc-gate runs on every browser write; a bad edit cannot be persisted.
+- "Which one wins" has a crisp answer per mode — file-mode: `.md`/git; db-mode: the DB — and a
+  real intra-store concurrency rule (revision precondition), with no distributed-merge machinery.
+
+**Harder / accepted trade-offs:**
+- **Authoring is a db-mode-only capability.** A file-mode (git-native) project does not get
+  in-browser authoring; it authors via CLI. Accepted: the alternative (writing through a
+  non-authoritative file-mode read-model) is exactly the second-source-of-truth ADR 0003/0006
+  forbid.
+- A hosted, writable, multi-project surface needs **authn/authz** and durable DB operations
+  (backup, migration) — new operational surface, spawned as follow-ups below.
+- Every record needs a `revision` column and every write path must honor the precondition — a
+  small schema + handler cost on top of ADR 0007's model.
+
+**Rejected alternative (the judgment critic):** *Let file-mode web author by writing `.md` and
+rebuilding the read-model.* This is the strongest tempting option (it would give git-native
+projects browser authoring). It loses because it makes the web a writer of the git tree from a
+process that only holds a derived projection — reintroducing exactly the divergence/sync
+problem ADR 0003 dissolved, and risking clobbering out-of-band git/editor/PR edits. Optimistic
+concurrency against a *projection* cannot be sound because the projection is not the truth.
+
+**Follow-ups:**
+- ADR: **authn/authz** for the hosted Atlas surface (who may read / who may edit).
+- ADR (gated): the **ontology substrate** (extend SQLite + JSON-LD projection vs embed
+  Oxigraph), opened only when the evidence-gate opens — research
+  [/research/0002-ontology-tooling-codegraph-docs-bridge.md](/research/0002-ontology-tooling-codegraph-docs-bridge.md).
+- ADR (later): whether Atlas's independent deploy cadence justifies splitting the `web` front
+  from the CLI (the locked monorepo's documented "reconsider when" trigger).
+
+## Verification
+
+**Implementation impact:** `db-store` (a `revision` column + optimistic-write check),
+`living-docs-core` (transactional write+`check`, `revision` bump, delete verb if absent),
+`web` (authoring routes for create/edit/supersede/delete, backend-mode guard), and browser
+specs under `tests/browser/`.
+
+**Verification criteria:**
+- **Mode guard (fitness function):** with backend=file, the web exposes **no** mutating route
+  (an HTTP test asserts every write endpoint returns not-available); with backend=db, the same
+  routes author successfully. — `verify_by: test`
+- **Doc-gate on write (fitness function):** a browser edit that violates an invariant is
+  rejected and the stored record is unchanged; a valid edit commits and passes `check`. —
+  `verify_by: browser`
+- **Optimistic concurrency:** two writes from the same `base_revision` — the first commits, the
+  second is rejected with a stale-revision error; no silent overwrite or merge. — `verify_by: test`
+- **No second source of truth (db-mode):** exercising the Atlas write path never writes a `.md`
+  under the docs dir except via an explicit `export`; the DB is the only store mutated by a
+  browser write. — `verify_by: test`
+- **Supersede parity:** superseding via the Atlas UI leaves both records linked and conformant,
+  identical to the CLI path (ADR 0001 fitness function). — `verify_by: test`
+
+# References
+
+[1] [ADR 0003 — storage backend is config-selected and mutually exclusive](/adr/0003-storage-backend-model.md)
+[2] [ADR 0006 — the web view is read-only (superseded by this ADR)](/adr/0006-web-read-only-axum.md)
+[3] [ADR 0007 — db-mode authoring data model and lossless export contract](/adr/0007-db-mode-authoring-data-model-and-lossless-export-contract.md)
+[4] [PRD 0001 — Living Docs Atlas](/prd/0001-living-docs-atlas-multi-project-authoring-wiki-over-living-docs-core.md)

--- a/docs/adr/0017-skill-md-stubs-are-pure-routers-the-spine-and-all-detail-move-to-cli-topics.md
+++ b/docs/adr/0017-skill-md-stubs-are-pure-routers-the-spine-and-all-detail-move-to-cli-topics.md
@@ -1,0 +1,135 @@
+---
+type: ADR
+title: SKILL.md stubs are pure routers; the spine and all detail move to CLI topics
+description: Every embedded skill's SKILL.md becomes a pure router — frontmatter trigger, a "Using this skill" progressive-disclosure block, and a task→topic table — with all substantive prose (including the five core invariants) relocated into CLI-served topics; this supersedes ADR 0014's clause that kept the spine inline in the stub.
+status: Proposed
+supersedes: 0014
+superseded_by:
+tags: [documentation, tooling, skill-distribution, progressive-disclosure, cli, tokens]
+timestamp: 2026-07-20T15:29:03Z
+---
+
+# 0017. SKILL.md Stubs Are Pure Routers; the Spine and All Detail Move to CLI Topics
+
+## Context
+
+[ADR 0014](/adr/0014-the-cli-serves-skill-content-from-an-embedded-corpus-harness-skill-md-files-are-slim-stubs.md)
+made the CLI the server of detailed skill content (the `skills/**` tree is embedded via
+`rust-embed` and served as `living-docs skill <name>` / `--topic <topic>`), and made each
+harness-installed `SKILL.md` a **slim stub**. But 0014's decision point 3 deliberately kept
+**substantive content inline** in the stub: the five core invariants (the "spine"), on the
+resilience argument that "the stub still carries the always-true spine so the invariants hold
+even without the binary on PATH."
+
+Two things make that clause the weak seam of an otherwise-good decision:
+
+- **The stubs are not actually pure routers.** `living-docs/SKILL.md` still carries the five
+  invariants *and* a 20-line "Hard rule — the CLI owns the mechanics" block that is **triplicated**
+  (it also lives in `rules/procedure.md` and `templates/claude-hard-rules.md`) — a direct
+  one-home-per-fact violation. `okf-knowledge-format/SKILL.md` carries its five conformance rules
+  inline; `public-export/SKILL.md` is a 142-line document with no `rules/` topics at all. Only
+  `research-artifacts/SKILL.md` is already a router.
+- **The resilience argument is thin.** `living-docs` is a **CLI-backed** skill: without the binary
+  on PATH the agent cannot run any deterministic verb (`new`, `supersede`, `index`, `check`,
+  `export`) — the entire workflow is inert. Preserving five lines of philosophy inline buys almost
+  nothing when the machinery those lines govern is already unavailable. The token cost is paid on
+  every load (and, for always-on Cursor/Copilot, every turn); the benefit accrues only in a
+  degraded state where the skill is already non-functional.
+
+The user's directive is a **pure casca**: one SKILL.md shell whose only job is to trigger and to
+route every substantive need to a CLI topic. That is a cleaner realization of 0014's own
+progressive-disclosure intent (L1 trigger → L2 router → L3 detail-on-demand), so this ADR
+**supersedes 0014** rather than amending it — MADR-lite is append-only, and 0014's spine-inline
+clause is load-bearing enough that editing it in place would rewrite history.
+
+Epistemic type: **judgment** (a token-economy / resilience trade-off, no benchmark decides it).
+
+## Decision
+
+We will make **every embedded skill's `SKILL.md` a pure router** and relocate **all** substantive
+prose — including the five core invariants — into CLI-served topic files under `rules/`.
+
+1. **The stub carries only three things:** (a) the `name` + `description` frontmatter (the L1
+   trigger, unchanged); (b) a near-the-top, imperative **`## Using this skill (progressive
+   disclosure)`** block that instructs the agent to load the relevant topic via
+   `living-docs skill <name> --topic <topic>` (or `--list`) **before authoring** and to operate
+   from the loaded topic; (c) a **`## When to invoke`** task→topic router table. No invariants, no
+   hard-rule prose, no conformance list, no procedure inline.
+
+2. **The five core invariants (the spine) become a topic.** They relocate verbatim into
+   `skills/living-docs/rules/spine.md`, served as `living-docs skill living-docs --topic spine`,
+   and the router links to it. The spine is no longer duplicated in the stub.
+
+3. **All remaining inline prose relocates to `rules/` topics, one home per fact.** The
+   triplicated "CLI owns the mechanics" block is removed from `living-docs/SKILL.md` (its home is
+   `rules/procedure.md`, reachable via `--topic procedure`; the project-guide copy in
+   `templates/claude-hard-rules.md` is a *different artifact* — a CLAUDE.md seed — and stays).
+   `okf-knowledge-format`'s conformance rules move to a `rules/` topic. `public-export`'s inline
+   sections (buckets, visibility model, hard rules, procedure, composition, provenance) move to
+   `rules/` topics, and its stub gains the `Using this skill` block and a `version` field it lacks.
+
+4. **Scope is all four embedded skills** — `living-docs`, `okf-knowledge-format`,
+   `research-artifacts` (already a router; audited, not rewritten), and `public-export`. The vendored
+   `okf-knowledge-format/reference/SPEC.md` is **not** a topic (topics derive only from `rules/` +
+   `templates/`); the stub keeps its pointer to the vendored spec.
+
+5. **No `skill.rs` change is required.** Topic resolution is generic over `rules/`/`templates/`
+   basenames, so a new `rules/spine.md` becomes `--topic spine` automatically. The other 0014
+   decisions — embed the corpus, serve per topic, TTY-aware JSON/plain output, install ships only the
+   stub — **carry forward unchanged**; only the spine-inline clause is reversed.
+
+## Consequences
+
+**Easier / gained:**
+- One home per fact: the spine, the CLI-mechanics rule, and every conformance/procedure block live
+  in exactly one topic file; the stub cannot drift from them because it no longer copies them.
+- Lower always-on and per-invocation token cost — the stub is trigger + router only.
+- A uniform shape across all four skills; `public-export` finally joins the progressive-disclosure
+  model instead of being a 142-line always-inline document.
+
+**Harder / accepted trade-offs:**
+- **Without the CLI on PATH the agent no longer sees the invariants inline.** Accepted: the skill is
+  CLI-backed and already non-functional without the binary, so the resilience 0014 bought was
+  largely notional. The `description` frontmatter still states what the skill enforces at L1.
+- **Prose updates still require a rebuild + reinstall** to reach agents via the CLI (unchanged from
+  0014).
+- **A one-time editorial relocation across four skills**, with the risk of losing a fact in the move —
+  bounded by `cargo test -p living-docs skill`, `living-docs check docs`, and the stub↔topic audit
+  below.
+
+**Rejected alternative (the judgment critic):** *Keep the spine inline (ADR 0014 as written).* The
+strongest tempting option — five lines of always-true philosophy is cheap, and it is the one thing an
+agent could still honor with no binary. It loses because the binary's absence already disables every
+verb the invariants describe, so the inline copy guards a state in which the skill cannot operate;
+meanwhile it perpetuates a per-load token cost and a two-representation drift surface (stub spine vs a
+future `rules/spine.md`). Pure routing is the cleaner equilibrium.
+
+**Follow-ups:**
+- If a stub↔topic cross-check proves worth automating, add the ADR 0014 fitness function (a test that
+  every router pointer resolves to an embedded topic and every `rules/` topic is reachable from its
+  stub) — currently unimplemented; this ADR does the audit by hand.
+
+## Verification
+
+**Implementation impact:** `skills/living-docs/SKILL.md` (drop the spine + CLI-mechanics blocks),
+`skills/living-docs/rules/spine.md` (new), `skills/okf-knowledge-format/SKILL.md` +
+`skills/okf-knowledge-format/rules/conformance.md` (new), `skills/research-artifacts/SKILL.md`
+(audit), `skills/public-export/SKILL.md` + `skills/public-export/rules/*.md` (new topics). No Rust
+change; no `install.sh` change.
+
+**Verification criteria:**
+- **Pure-router shape (fitness function, inspection):** each `SKILL.md` contains only frontmatter, a
+  `## Using this skill` block, and a `## When to invoke` router — no invariant list, conformance
+  list, hard-rule prose, or procedure inline. — `verify_by: inspection`
+- **No lost fact:** every substantive block removed from a stub resolves to a CLI topic —
+  `living-docs skill living-docs --topic spine` prints the five invariants; `--topic procedure`
+  prints the CLI-mechanics rule; the okf conformance rules and every public-export section resolve to
+  a `--topic`. — `verify_by: command`
+- **Serving unchanged:** `cargo test -p living-docs skill` stays green (`# Living Docs` H1 and the
+  `adr` topic still resolve). — `verify_by: test`
+- **Doc-gate:** `living-docs check docs` stays green with this ADR indexed and 0014 superseded. —
+  `verify_by: command`
+
+# References
+
+[1] [ADR 0014 — the CLI serves skill content from an embedded corpus; harness SKILL.md files are slim stubs (superseded by this ADR)](/adr/0014-the-cli-serves-skill-content-from-an-embedded-corpus-harness-skill-md-files-are-slim-stubs.md)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -15,7 +15,6 @@ repo teaches. The decision *log* is this listing plus each record's `status` /
 * [0003 — Storage backend is config-selected, mutually exclusive, and both modes authoritative](0003-storage-backend-model.md) - Proposed
 * [0004 — db-mode runs on ParadeDB by default with SQLite opt-in, over SeaORM](0004-db-engine-and-data-layer.md) - Proposed
 * [0005 — Normalized DB schema — projects root, typed records with an EAV tail, typed relations](0005-normalized-schema.md) - Proposed
-* [0006 — The web view is a read-only axum server reusing living-docs-core](0006-web-read-only-axum.md) - Proposed
 * [0007 — db-mode authoring data model and lossless export contract](0007-db-mode-authoring-data-model-and-lossless-export-contract.md) - Proposed
 * [0008 — BDR carries a required Contract section (public API + agent tool schemas)](0008-bdr-contract-section.md) - Accepted
 * [0009 — Document visibility is default-deny frontmatter data, validated and index-aware](0009-document-visibility-model.md) - Accepted
@@ -23,5 +22,11 @@ repo teaches. The decision *log* is this listing plus each record's `status` /
 * [0011 — Secret and PII detection stays deterministic — a curated ruleset plus Shannon entropy, never ML](0011-leak-detection-stays-deterministic-curated-ruleset-plus-shannon-entropy-never-ml.md) - Accepted
 * [0012 — Worldwide PII detection is checksum-tiered, two-stage, and deterministic](0012-worldwide-pii-detection-is-checksum-tiered-two-stage-and-deterministic.md) - Accepted
 * [0013 — Mermaid validation runs in-process via merman-core, not a Docker mermaid-cli shell-out](0013-mermaid-validation-runs-in-process-via-merman-core-not-a-docker-mermaid-cli-shell-out.md) - Accepted
-* [0014 — The CLI serves skill content from an embedded corpus; harness SKILL.md files are slim stubs](0014-the-cli-serves-skill-content-from-an-embedded-corpus-harness-skill-md-files-are-slim-stubs.md) - Accepted
 * [0015 — Web UX follows the three-pane doc-site archetype with a search-first Cmd+K palette](0015-web-ux-follows-the-three-pane-doc-site-archetype-with-search-first-cmd-k-palette.md) - Accepted
+* [0016 — Atlas makes the web a db-mode authoring front, superseding web read-only](0016-atlas-makes-the-web-a-db-mode-authoring-front-superseding-web-read-only.md) - Proposed
+* [0017 — SKILL.md stubs are pure routers; the spine and all detail move to CLI topics](0017-skill-md-stubs-are-pure-routers-the-spine-and-all-detail-move-to-cli-topics.md) - Proposed
+
+## Superseded
+
+* [0006 — The web view is a read-only axum server reusing living-docs-core](0006-web-read-only-axum.md) - Superseded
+* [0014 — The CLI serves skill content from an embedded corpus; harness SKILL.md files are slim stubs](0014-the-cli-serves-skill-content-from-an-embedded-corpus-harness-skill-md-files-are-slim-stubs.md) - Superseded

--- a/docs/prd/0001-living-docs-atlas-multi-project-authoring-wiki-over-living-docs-core.md
+++ b/docs/prd/0001-living-docs-atlas-multi-project-authoring-wiki-over-living-docs-core.md
@@ -1,0 +1,163 @@
+---
+type: PRD
+title: Living Docs Atlas — multi-project authoring wiki over living-docs-core
+description: A web surface to navigate across projects and their docs, author/edit/create/delete/supersede through the deterministic core, search full-text, and (gated) surface a code-to-concept ontology bridge — evolving the read-only web front into an authoring wiki without breaking the determinism boundary or the one-language build.
+status: Draft
+superseded_by:
+tags: [prd, atlas, web, authoring, wiki, multi-project, glossary, ontology, codegraph, search]
+timestamp: 2026-07-20T14:45:52Z
+---
+
+# 1. Living Docs Atlas — Multi-Project Authoring Wiki over `living-docs-core`
+
+## Problem / Motivation
+
+Living Docs today is authored through the CLI and read through a **read-only** web view
+(ADR [/adr/0006-web-read-only-axum.md](/adr/0006-web-read-only-axum.md)). Two pains follow
+from that shape as the practice spreads across projects:
+
+1. **Knowledge is siloed per repo and reachable only two ways** — the CLI or raw markdown.
+   A person who does not live in a terminal cannot browse a project's decisions, author an
+   ADR, or fix a stale doc. There is no single navigable surface across *projects*.
+2. **The connective tissue is invisible.** The relationships that make a docs corpus a
+   *system* — a term's definition, which decision superseded which, and eventually which
+   human concept maps to which code symbol — exist only implicitly. You cannot see, from
+   the docs, the line from a domain word down to the code that implements it, or back up.
+
+The underlying need is a **navigable, human-authorable surface** over the corpus that keeps
+every guarantee the CLI already gives (determinism, the doc-gate, "one doc, one place") and
+adds the missing halves: authoring in the browser, navigation across projects, and a place
+for the semantic layer (glossary now, code↔concept ontology later) to live.
+
+This is an evolution, not a rewrite: `living-docs-core` already implements the deterministic
+authoring verbs (`new`, `brief`, `supersede`, `index`, `export`, `check`), and the web front
+already ships the three-pane, search-first, Cmd+K shell (ADR
+[/adr/0015-web-ux-follows-the-three-pane-doc-site-archetype-with-search-first-cmd-k-palette.md](/adr/0015-web-ux-follows-the-three-pane-doc-site-archetype-with-search-first-cmd-k-palette.md)).
+Atlas adds the **write path**, **multi-project navigation**, and the **semantic layer** on top.
+
+## Goals
+
+- Navigate **across projects** and, within a project, across its docs in the "one doc, one
+  place" hierarchy — in the browser.
+- **Author, edit, create, delete, and supersede** docs through the UI, reusing the
+  deterministic core so browser authoring and CLI authoring produce identical, conformant records.
+- Enforce the **doc-gate on write**: a change that would violate an invariant is rejected
+  before it persists, in the browser just as `check` rejects it on disk.
+- Provide **cross-project full-text search** (FTS5) as the primary find surface.
+- Introduce a **glossary** layer (SKOS-shaped): a term defined once, in one place, with
+  typed relations to other terms.
+- Lay a **gated** path to a code↔concept ontology bridge over `codegraph` — built only when
+  an evidence-gate justifies it (research
+  [/research/0002-ontology-tooling-codegraph-docs-bridge.md](/research/0002-ontology-tooling-codegraph-docs-bridge.md)).
+- Preserve the two locked constraints: the **determinism boundary** and **one language / one build**.
+
+## Non-goals
+
+- **No LLM inside the tool.** Atlas authors nothing; humans author, the tool validates and projects.
+- **No OWL / reasoner** until a concrete logical-entailment requirement appears (research 0002, F2).
+- **No non-Rust service** (Neo4j/JVM) and **no separate triple store** in the initial shape;
+  the ontology begins as a *projection* of the existing SQLite records to RDF/JSON-LD.
+- **Not a general-purpose wiki** (Notion/Confluence replacement). Scope is the living-docs
+  doc types (ADR, BDR, PRD, issue, research, glossary).
+- **No real-time multiplayer editing** (shared cursors / OT/CRDT) in v1.
+- **No ontology graph-traversal / SPARQL layer** until the evidence-gate opens (research 0002, F5).
+
+## Requirements
+
+1. Atlas lists **registered projects** and opens one; each project renders its doc tree
+   grouped by type, one canonical location per doc.
+2. Reading a doc renders its markdown (pulldown-cmark) inside the three-pane shell + Cmd+K
+   palette (ADR 0015), unchanged from today's read view.
+3. **Create**: choosing a doc type + title in the UI invokes core `new`, producing a
+   conformant scaffold; the created record passes `check`.
+4. **Edit**: saving an edited doc writes through the store and runs `check`; a save that
+   would violate an invariant (broken link, size, malformed frontmatter, bad Mermaid) is
+   **rejected before persist** with the failing reason surfaced in the UI.
+5. **Supersede**: the UI invokes core `supersede`, leaving both records linked and
+   conformant (the ADR 0001 fitness function holds through the web path).
+6. **Delete**: removing a doc updates indexes and leaves no dangling links — `check` stays green.
+7. **Search**: cross-project full-text query (FTS5) returns ranked results, scopable to one
+   project or all.
+8. The **fs↔db sync / conflict contract** is explicit — which backend is authoritative on
+   write, and how the other is reconciled — decided in an ADR **before** the write path ships
+   (extends ADR [/adr/0007-db-mode-authoring-data-model-and-lossless-export-contract.md](/adr/0007-db-mode-authoring-data-model-and-lossless-export-contract.md),
+   which covers lossless export but not write-time conflict).
+9. **Glossary**: a `glossary` doc type where a term is a concept with `prefLabel`/`altLabel`
+   and typed relations (`broader`/`narrower`/`related`), each term in exactly one place,
+   validated by `check`.
+10. **[Gated]** Typed links between glossary concepts and `codegraph` symbols are stored and
+    projected to JSON-LD (SKOS mapping relations + W3C Web Annotation, Body = concept,
+    Target = code segment). Built **only after** the evidence-gate opens (research 0002, F5/F6).
+
+## Quality requirements (NFRs)
+
+| Quality attribute | Scenario (source · stimulus · artifact · environment · response · measure) | Verified by |
+|---|---|---|
+| Determinism | The tool · projects records to index/RDF/JSON-LD · the projection artifacts · run twice on the same records · produces byte-identical output · 0 diff | Idempotency fitness function in CI (ADR 0001 style) |
+| Integrity (doc-gate) | An author · saves a doc that violates an invariant · via the Atlas write path · in normal operation · the save is rejected and the record is unchanged · 100% of invalid saves blocked | `check` on write + browser-gate spec |
+| Performance | A reader · requests a doc page · Atlas render path · on a bundle of ~1k docs · returns rendered HTML · p95 < 200 ms (measure first, then lock the floor) | Timing test + CI floor |
+| One language / in-process | A maintainer · builds the workspace · Atlas + its stores · in CI · has no runtime dependency outside the Cargo workspace (no JVM/service) · 0 external runtimes | Dependency/build inspection (arch conformance) |
+| Frontend correctness | A user · exercises create/edit/supersede/delete/search · Atlas UI · in a seeded browser session · the flow behaves as specified · all browser specs pass | Browser gate (Playwright specs under `tests/browser/`) |
+
+## Acceptance criteria
+
+- Creating an ADR end-to-end **through the Atlas UI** yields a file on disk that passes `living-docs check`.
+- Editing a doc into an invalid state and saving shows the `check` failure and leaves the stored record untouched.
+- Superseding doc A with doc B via the UI leaves both records present, mutually linked, and conformant.
+- Deleting a doc removes it and its index entries with `check` still green (no dangling links).
+- A term authored in project X is found by a cross-project search from project Y's view.
+- The workspace builds and runs Atlas with no runtime outside the Rust workspace.
+
+## Success metrics
+
+- A new ADR/PRD can be authored, superseded, and found **without touching the CLI**.
+- Share of doc operations (create/edit/supersede) performed via Atlas vs CLI trends up after launch.
+- Median time-to-find a known doc across projects drops relative to the CLI/grep baseline.
+- (Gated) Once the ontology bridge ships, relational/traceability queries ("what concept does
+  this symbol implement", "what breaks if this term changes") are answerable in Atlas.
+
+## Behavior (BDRs)
+
+The observable flows each get a BDR (Given/When/Then + Mermaid) before their slice is built —
+forthcoming, not yet created:
+
+- Authoring lifecycle: create → edit → supersede → delete (one BDR per flow or a grouped one).
+- Cross-project search.
+- (Gated) Concept↔symbol link authoring and the code↔docs navigation it enables.
+
+## Open questions
+
+- **fs↔db write authority** — which backend wins on write, and how the other reconciles.
+  Heads to an ADR (extends ADR 0007). Blocks Requirement 4/8.
+- **Ontology substrate** — extend SQLite + project to JSON-LD, vs embed Oxigraph for SPARQL.
+  Heads to an ADR, opened only when the evidence-gate opens (research 0002, F3b/F5).
+- **Repo structure** — does Atlas's independent deploy cadence justify splitting the web front
+  from the CLI (vs the locked monorepo)? Heads to an ADR; the wiki is the documented "reconsider when" trigger.
+- **Multi-project registry** — how projects are registered/discovered/scoped in the db-store.
+- **AuthN / AuthZ** — for a hosted, multi-project, writable surface, who may read and who may
+  edit. Likely an ADR before any hosted deployment.
+
+## Decision log
+
+- Substrate/format findings that shape this PRD: research
+  [/research/0002-ontology-tooling-codegraph-docs-bridge.md](/research/0002-ontology-tooling-codegraph-docs-bridge.md)
+  (Rust-native SKOS-in-Oxigraph or SQLite-projection; wiki template = Dendron + Cargo, not SMW/Wikibase; ontology gated by evidence).
+- ADRs resolving the open questions above — to be linked as they are decided.
+
+## Delivery sequence (vertical, demoable slices)
+
+Each slice is a thin end-to-end change; the ontology is deliberately last and gated.
+
+- **A0 — fs↔db write-authority ADR.** Decide the sync/conflict contract (no code before the decision).
+- **A1 — write path (edit).** Atlas can edit an existing doc; save runs `check` and blocks invalid writes. Smallest demoable win.
+- **A2 — create + supersede + delete** through the UI, reusing core verbs.
+- **A3 — multi-project registry + cross-project navigation and search.**
+- **A4 — glossary doc type** (SKOS-shaped, `check`-validated). Human value with zero new infra.
+- **A5 — [gated] evidence corpus** proving FTS+embeddings fall short on the relational/traceability queries that matter. Gate to A6.
+- **A6 — [gated] code↔concept bridge** (typed links + JSON-LD projection; Oxigraph only if SPARQL is needed).
+
+## Related
+
+- Constitution: [/constitution.md](/constitution.md)
+- Research: [/research/0002-ontology-tooling-codegraph-docs-bridge.md](/research/0002-ontology-tooling-codegraph-docs-bridge.md)
+- ADRs: [/adr/0006-web-read-only-axum.md](/adr/0006-web-read-only-axum.md) · [/adr/0007-db-mode-authoring-data-model-and-lossless-export-contract.md](/adr/0007-db-mode-authoring-data-model-and-lossless-export-contract.md) · [/adr/0015-web-ux-follows-the-three-pane-doc-site-archetype-with-search-first-cmd-k-palette.md](/adr/0015-web-ux-follows-the-three-pane-doc-site-archetype-with-search-first-cmd-k-palette.md)

--- a/docs/prd/index.md
+++ b/docs/prd/index.md
@@ -1,3 +1,5 @@
 # PRDs
 
 ## Active
+
+* [0001 — Living Docs Atlas — multi-project authoring wiki over living-docs-core](0001-living-docs-atlas-multi-project-authoring-wiki-over-living-docs-core.md) - Draft

--- a/docs/research/0002-ontology-tooling-codegraph-docs-bridge.md
+++ b/docs/research/0002-ontology-tooling-codegraph-docs-bridge.md
@@ -1,0 +1,178 @@
+---
+type: Research
+title: Ontology tooling and the code-to-docs bridge — Rust-native options for a living-docs knowledge layer
+description: A source-cited survey of open-source ontology tooling evaluated as the bridge between codegraph's symbol graph and the living-docs semantic index. Finding — an embedded, Rust-native RDF store (Oxigraph) with a SKOS concept scheme is the least-cost substrate; SKOS is sufficient until logical reasoning is required; the wiki prior art is Dendron+Cargo, not Semantic MediaWiki/Wikibase; and the bridge layer should be built only after an eval corpus shows FTS+embeddings failing.
+status: Accepted
+supersedes:
+superseded_by:
+tags: [research, ontology, knowledge-graph, skos, rdf, oxigraph, codegraph, semantic-index, wiki, rust]
+timestamp: 2026-07-20T00:00:00Z
+---
+
+# Ontology Tooling and the Code-to-Docs Bridge — Rust-Native Options for a Living-Docs Knowledge Layer
+
+Compiled: 2026-07-20
+Scope: open-source ontology substrates and formats evaluated for one job — bridging codegraph's code-symbol graph and the living-docs semantic index ("from code up to the human, and back"), under this repo's locked constraints (one language / one build; determinism boundary; "every doc lands in exactly one place").
+Epistemic mode: `falsify` (a working hypothesis existed). Depth: `standard`.
+
+---
+
+## Method
+
+Six independent retrieval angles ran in parallel, chosen **refute-first** so each falsifier of the working hypothesis got a dedicated angle. Every angle was instructed to prefer tier-1 sources (W3C specs, arХiv/peer-reviewed papers, primary project repos and their crates.io/GitHub API metadata) and to report blocked fetches rather than omit them.
+
+**Working hypothesis.** A lightweight, Rust-native ontology layer — a SKOS controlled vocabulary held in an embedded RDF store (Oxigraph), with sophia as the toolkit — can bridge the codegraph symbol graph and the living-docs semantic index without introducing a non-Rust service, and Semantic MediaWiki/Wikibase are the best prior art for the wiki+ontology surface.
+
+**Falsifiers and their verdicts** (graded from the evidence below):
+
+| # | Falsifier | Verdict |
+|---|---|---|
+| F1 | The Rust RDF ecosystem (Oxigraph/sophia/horned-owl) is immature or unmaintained, forcing a non-Rust service. | **REFUTED** |
+| F2 | SKOS is too weak for the code↔human bridge; OWL inference is actually required. | **REFUTED** (conditional) |
+| F3 | A code-ontology standard (SCIP/Kythe/CodeOntology) or a property-graph service beats RDF-in-Rust. | **REFUTED** for the bridge; wins only for the code-symbol layer |
+| F4 | The Semantic MediaWiki/Wikibase model does not fit a docs-per-project wiki; other prior art fits better. | **CONFIRMED** — hypothesis updated |
+
+**Decision at stake.** Which ontology substrate + serialization the planned "Living Docs Atlas" wiki adopts, and whether it stays Rust-native — feeding the future ADRs on repo structure (monorepo vs split) and the wiki PRD.
+
+**Blocked / weakened fetches (confidence downgraded accordingly, never silently dropped):** the ER-2024 *Requirements2Code* PDF returned FlateDecode binary — its claim rests on a search summary, marked `[unverified — single source]`; the *Code Digital Twin* (arХiv 2503.07967) "code symbol graph vs domain knowledge graph" phrasing is a summarizer paraphrase — only the "physical and conceptual layers … hybrid knowledge representations" wording is verbatim; the W3C working draft *Using OWL and SKOS* extracted only generic pattern language, so the Concept-vs-Class point rests on the SKOS Reference itself; GitHub contributor-graph counts for sophia/horned-owl did not render (maintenance judged from commits/issues/stars instead); no tier-1 source benchmarks JVM-vs-Rust integration overhead, so that comparison is qualitative/architectural, marked `[inference]`.
+
+---
+
+## Findings
+
+### F1 — The Rust RDF ecosystem is production-viable as an embedded library; Oxigraph is the strongest [confidence: high]
+
+**Oxigraph** is an actively developed, embeddable, in-process RDF store implementing the SPARQL 1.1 standard, with a RocksDB-backed on-disk store plus an in-memory mode [4]. As of this survey its latest release is 0.5.9 (2026-06-18) on a near-monthly cadence, with commits landing within a day of the survey date, a healthy open:closed issue ratio (~112:247), and named commercial users [4][5]. Its one explicit caveat is a performance note in its own README — "SPARQL query evaluation has not been optimized yet" — a performance caveat, not a "not for production" warning [4]. **horned-owl** (OWL 2 DL modeling/parsing, academically backed, peer-reviewed 20–40× speedups over the Java OWL API) released a 2.1.0 major bump three days before the survey and is clearly active — but it is a modeling library, not a store or reasoner (reasoning lives in the companion whelk-rs) [7][8]. **sophia** is standards-current (RDF 1.2, JSON-LD 1.1) but its SPARQL is explicitly "partial" with no Update and no in-tree persistent store, making it a toolkit layer rather than a database [6].
+
+Two real qualifications temper F1's refutation. First, **SKOS has no actively-maintained dedicated Rust crate**: `rdftk_skos` has been dormant since 2021-06-14 and self-describes as limited [9]; SKOS in Rust therefore means building on a general RDF library (Oxigraph/sophia) with `rdf_vocabularies`, or the newer `oxirs-rule` validation module — not adopting a turnkey SKOS crate. Second, all three core libraries lean on a **single principal maintainer** — the ecosystem's real bus-factor risk. Neither qualification points back toward a non-Rust service; both are absorbed by treating SKOS as a vocabulary you assert over Oxigraph rather than a library you import.
+
+### F2 — SKOS is sufficient for the glossary + typed cross-scheme links; OWL is required only for logical reasoning [confidence: high]
+
+Every capability the bridge names maps to a native SKOS construct: `skos:Concept` with `prefLabel`/`altLabel`/`hiddenLabel`/`notation` for glossary terms; `skos:ConceptScheme` to separate the docs vocabulary from the code-symbol vocabulary; and the mapping relations `exactMatch`/`closeMatch`/`broadMatch`/`narrowMatch`/`relatedMatch` for typed cross-scheme links between them [1]. This is exactly the pattern that LCSH, Getty AAT, EuroVoc (≈202k prefLabels, ≈3.6M relations) and AGROVOC (≈5.9M relations) run in production at scale [1][35]. The W3C is explicit that this is a **deliberate design line, not a defect**: "SKOS is not a formal knowledge representation language" [1], and `skos:broader` is deliberately non-transitive with an opt-in `skos:broaderTransitive` closure [1][2]. The single specific requirement that forces a move up to OWL is a need to **compute new facts by logical entailment** — enforcing class axioms (disjointness, domain/range or cardinality restrictions), running a reasoner to detect contradictions or auto-classify a symbol under a concept, or treating each glossary term as an `owl:Class` so instances inherit through it [33]. The documented real-world escalations (EMMeT, Digital Europa Thesaurus) were all triggered by exactly that reasoning demand [33]; the one non-reasoning escalation (LCSH → MADS/RDF) was triggered by needing to model a heading's internal component structure, not by reasoning [34].
+
+### F3a — No off-the-shelf standard bridges code symbols to human doc concepts; the code-symbol layer alone has mature standards [confidence: high]
+
+The industrial code-intelligence standards — LSIF (Microsoft), SCIP (Sourcegraph), and Kythe (Google) — are purpose-built graphs (Protobuf / labeled-property, not RDF/OWL) that model definitions, references, hovers, and types and **stop at the code boundary**; none carries a documentation-concept or SKOS layer, and SCIP explicitly disclaims being a queryable/semantic store [10][11][12]. Code Property Graphs (Joern) are a security/dataflow property graph, also non-RDF and doc-agnostic [15]. The one project that genuinely does code→RDF/OWL *and* a documentation-to-concept bridge, **CodeOntology** (OWL 2 + a parser serializing Java to RDF triples, linking doc comments to DBpedia via TagMe), is precisely the design a hand-rolled bridge would emulate — but it is Java-only and unmaintained since ~2021–2022 [13][14]. The SEON ontologies are SE-domain *reference* ontologies, not per-repo symbol indexers. Consequently the current research frontier treats the code-symbol↔NL-concept link as something you **build or learn** (heterogeneous GNNs, embeddings, or LLM trace-link recovery), and states outright that the domain-concept graph must be supplied [16][17]. **Net:** codegraph is already the right kind of artifact for the code-symbol side (a SCIP/Kythe-shaped graph); nothing standard covers the bridge, so a hand-rolled SKOS/annotation map is not made redundant.
+
+### F3b — Embedded RDF (Oxigraph) or extending SQLite beats a property-graph service for a one-language, in-process codebase [confidence: high]
+
+The only credible in-process, same-language options are Oxigraph (Rust RDF/SPARQL) and extending the existing SQLite graph — both single-binary, zero new runtime [4]. The embeddable property graph that could have matched them, **KuzuDB, was archived on 2025-10-10** (read-only, on-disk format never stabilized), which disqualifies it as a foundation to build on now [27]. Reaching for **Neo4j + neosemantics (n10s)** buys mature Cypher and a lossless RDF round-trip, but imposes a JVM plus a separate server, and its ontology loader is lossy — it processes `rdfs:domain`/`range` and `owl:Restriction` and "all other elements will be ignored by this loader" [24][25]. A neutral peer-reviewed benchmark shows paradigm-bridging (SPARQL-on-LPG via plugin) running 2.4–27× slower than a native triple store *before* any cross-process hop [26]. Because a "documentation ontology" with SKOS/OWL semantics is RDF's home turf (standards, W3C vocabularies), a non-Rust graph service is warranted only if the project specifically needs heavy Cypher analytics or Neo4j's operational tooling — neither of which an ontology-linking bridge implies [`inference`].
+
+### F4 — Semantic MediaWiki/Wikibase are a poor fit for a docs-per-project wiki; Dendron + Cargo is the better prior-art template [confidence: high — hypothesis updated]
+
+This is where the working hypothesis was **wrong**. Wikibase's unit is an atomic, individually-sourced *statement* (snak + qualifiers + references + rank), not a document; it "does not allow you to visualize or query the data stored in your wiki" on its own, is heavy to self-host, and its access control is all-or-nothing [20][21]. Semantic MediaWiki fits better (typed `[[Property::Value]]` triples, OWL/RDF export, cross-vocabulary mapping) and scales to millions of rows — its real cost is query/template-formatting performance, not data volume [19] — but its own community built **Cargo** precisely because SMW was judged too heavyweight and wrongly-grained, storing template-anchored structured data in plain SQL tables with built-in FTS and ~30–50% faster queries [22]. Crucially, RDF's many-to-many "a concept is reachable from many places" model is the **opposite** of this repo's "every doc lands in exactly one place" invariant. **Dendron** matches that invariant almost exactly: hierarchy is the primary primitive, every doc has one canonical home ("one source of truth where a note can be filed"), schemas give an optional lightweight type system, and refactor/rename commands keep links from rotting [23]. The strongest structural template for the wiki is therefore a **hybrid of Dendron (organization/authoring) + Cargo (structured, queryable layer)** — with the SKOS/RDF ontology as an *export/projection* for interoperability, not as the primary store.
+
+### F5 — The demonstrated value of the ontology/graph bridge is conditional and narrow — measure first [confidence: high]
+
+An ontology/graph layer earns its keep, with evidence, for three things: **entity disambiguation** (explicit edges resolve a term where embeddings blur it — LinkedIn's "uber" mismap; GraphGen4Code's 79% code→doc linking accuracy) [18][16]; **multi-hop / relational and traceability queries** ("what requirement does this class satisfy", "what breaks if I rename this concept") that FTS/vector search degrade on [16][36]; and **stable, human-readable cross-artifact identity** (SCIP string IDs and SKOS mapping relations give durable anchors that per-model embeddings cannot) [10][1]. For plain "find docs about X" retrieval, the graph adds latency (graph traversal ~200–300 ms vs sub-50 ms vector ANN), schema-maintenance cost, and complexity for no measurable gain; every credible source says measure your query distribution first and expect a hybrid (vector-seeded, graph-enriched) system, not graph-only [31]. This maps directly onto this repo's own `evidence-gate` discipline: build the bridge layer only after an eval corpus shows FTS+embeddings actually failing on the relational/disambiguation queries that matter.
+
+### F6 — The minimal viable bridge shape, and a DDD constraint on it [confidence: medium-high]
+
+In practice the bridge is: a code-symbol graph with human-readable stable IDs (SCIP-style — codegraph already approximates this) on one side; a lightweight human concept scheme on the other; and, between them, typed links expressed with **existing standards** rather than a bespoke schema — `skos:exactMatch`/`closeMatch`/`relatedMatch` for concept↔concept alignment, and the **W3C Web Annotation model** (Body = concept, Target = a code segment/symbol) for concept↔code-location, both serialized as **JSON-LD** so the bridge is itself a queryable graph [1][3]. A load-bearing constraint from Domain-Driven Design: the human vocabulary must be **bounded-context-scoped** — the same term legitimately means different things in different contexts, and DDD explicitly rejects a single global unified model [29][30]. Any concept↔symbol mapping must therefore be context-qualified, not global — which aligns naturally with a per-project docs structure.
+
+---
+
+## Contradictions
+
+- **Pro-property-graph vs pro-RDF framing.** Vendor-adjacent sources (Neo4j) argue the property graph is the pragmatic default because relationships are first-class and edge properties are native, and that one should "layer in RDF's organizing principles only when needed" [pro-LPG, treat as `[COI: Neo4j]`]. The neutral peer-reviewed benchmark and the standards case cut the other way for *this* use: an ontology with SKOS/OWL semantics is RDF-shaped, and bridging paradigms inside a server already costs 2.4–27× [26]. The contradiction resolves on the specific workload — ontology-linking favors RDF; heavy traversal analytics favor LPG.
+- **Graph adds value vs graph adds only overhead.** GraphRAG advocates and skeptics disagree; the honest synthesis (adopted above) is that the graph wins only on a specific query distribution (multi-hop, disambiguation, traceability) and is pure overhead for topical retrieval [31].
+
+---
+
+## Analysis
+
+The evidence converges on a coherent picture that survives the refute-first pass. The Rust-native path is real: Oxigraph is a production-viable embedded RDF/SPARQL store that keeps the "one language, one build" locked decision intact (F1), and SKOS — asserted over that store — is the purpose-built, industry-proven vocabulary for a glossary with typed cross-scheme links, needing no OWL until a genuine reasoning requirement appears (F2). No existing standard bridges code symbols to human concepts, so codegraph (the code-symbol side) plus a hand-authored SKOS scheme (the human side) plus W3C standard link types (SKOS mapping relations + Web Annotation) is not reinventing a wheel — it is assembling the wheels that exist (F3a, F6). A non-Rust graph service is not justified by an ontology-linking workload (F3b).
+
+The one place the hypothesis broke is instructive: the wiki's prior art is **not** Semantic MediaWiki/Wikibase (many-to-many, statement-centric, heavy) but the **Dendron+Cargo** shape (hierarchy-primary "one place", template-anchored SQL tables), which is a near-exact match for this repo's existing semantic-index invariant (F4). This reframes the ontology from "the store" to "an export/projection at the boundary" — which sits comfortably inside the determinism boundary: humans author docs and the glossary; the tool deterministically *projects* records and typed links into RDF/JSON-LD, never authoring rationale or inferring meaning.
+
+Finally, the whole ontology/graph layer is subject to this repo's own evidence-gate: its demonstrated value is narrow (disambiguation, multi-hop/traceability, stable identity), so it should be built only after a measured gap shows FTS+embeddings failing (F5). The "from code up to the human, and back" north star is real and has a named research lineage (Code Digital Twin, GraphGen4Code) — but it is a later slice, gated by evidence, not a foundational rebuild.
+
+---
+
+## Recommendations
+
+Each recommendation is caveated by the confidence of the evidence under it.
+
+1. **Stay Rust-native; do not introduce a JVM/Neo4j service for the ontology.** [high] Adopt embedded **Oxigraph** as the RDF/SPARQL substrate *if and when* an ontology layer is built. Cheaper first step: extend the existing SQLite graph with a typed-links table shaped by SKOS, and *project* to RDF/JSON-LD at the boundary — deferring a second store until the query distribution justifies it.
+2. **Model the human layer as a SKOS concept scheme, not OWL.** [high] Use `skos:Concept` + `prefLabel`/`altLabel`/`notation` for the glossary, a separate `ConceptScheme` per side (docs vocabulary vs code-symbol vocabulary), and `exactMatch`/`closeMatch`/`relatedMatch` for the typed cross-scheme links. Reserve OWL for a concrete, later reasoning requirement (consistency checking / auto-classification) — and record that trigger in an ADR when it arrives.
+3. **Express concept↔code-location links with the W3C Web Annotation model, serialized as JSON-LD.** [medium-high] Body = concept, Target = code segment/symbol. This keeps the bridge a standard, queryable graph and reuses codegraph's stable symbol IDs as anchors.
+4. **Scope the human vocabulary per project/bounded-context, never as one global ontology.** [high] This aligns with DDD and with the per-project docs structure.
+5. **Gate the bridge layer behind an eval corpus (evidence-gate).** [high] Build a 50–100 query set from real navigation/QA needs; only build graph traversal/reasoning when FTS+embeddings measurably fail on relational/disambiguation/traceability queries. Until then, the semantic index (FTS5) already in flight is the right primitive.
+6. **Emulate Dendron (organization) + Cargo (structured layer) for the wiki, not SMW/Wikibase.** [high] Hierarchy-primary "one doc, one place", optional schemas, refactor-safe links, template-anchored queryable tables — the ontology is an export, not the store.
+7. **Sequencing.** [inference] This note should feed three separate decisions, in order: (a) the **wiki PRD** ("Living Docs Atlas") which sets the north star; (b) an **ADR on the ontology substrate** (Oxigraph-embedded vs SQLite-projection) written only when the evidence-gate opens; (c) the **repo-structure ADR** (monorepo vs splitting the web front), where the wiki's independent deploy cadence is the trigger to weigh. The ontology is deliberately the *last* of these to reach code.
+
+# References
+
+<!-- Full entries per skills/living-docs/rules/citation-conventions.md. Access date 2026-07-20. -->
+
+[1] W3C. **SKOS Simple Knowledge Organization System Reference** (W3C Recommendation). 2009. Available at: https://www.w3.org/TR/skos-reference/. Accessed on: 2026-07-20.
+
+[2] W3C. **SKOS Simple Knowledge Organization System Primer**. 2009. Available at: https://www.w3.org/TR/skos-primer/. Accessed on: 2026-07-20.
+
+[3] W3C. **Web Annotation Data Model** (W3C Recommendation). 2017. Available at: https://www.w3.org/TR/annotation-model/. Accessed on: 2026-07-20.
+
+[4] OXIGRAPH PROJECT. **Oxigraph — a graph database implementing the SPARQL standard** (repository). 2026. Available at: https://github.com/oxigraph/oxigraph. Accessed on: 2026-07-20.
+
+[5] CRATES.IO. **oxigraph crate metadata** (0.5.9, 2026-06-18). Available at: https://crates.io/api/v1/crates/oxigraph. Accessed on: 2026-07-20.
+
+[6] CHAMPIN, Pierre-Antoine. **sophia_rs — a Rust toolkit for RDF and Linked Data** (repository). 2026. Available at: https://github.com/pchampin/sophia_rs. Accessed on: 2026-07-20.
+
+[7] LORD, Phillip. **horned-owl — a library for OWL ontologies in Rust** (repository). 2026. Available at: https://github.com/phillord/horned-owl. Accessed on: 2026-07-20.
+
+[8] CRATES.IO. **horned-owl crate metadata** (2.1.0, 2026-07-17). Available at: https://crates.io/api/v1/crates/horned-owl. Accessed on: 2026-07-20.
+
+[9] CRATES.IO. **rdftk_skos crate metadata** (0.2.0, 2021-06-14). Available at: https://crates.io/api/v1/crates/rdftk_skos. Accessed on: 2026-07-20.
+
+[10] SOURCEGRAPH. **SCIP — a better code indexing format than LSIF**. Available at: https://sourcegraph.com/blog/announcing-scip. Accessed on: 2026-07-20.
+
+[11] MICROSOFT. **Language Server Index Format (LSIF) Specification 0.4.0**. Available at: https://microsoft.github.io/language-server-protocol/specifications/lsif/0.4.0/specification/. Accessed on: 2026-07-20.
+
+[12] KYTHE PROJECT. **Kythe Storage Model**. Available at: https://kythe.io/docs/kythe-storage.html. Accessed on: 2026-07-20.
+
+[13] ATZORI, Mauro et al. **CodeOntology: RDF-ization of Source Code** (ISWC 2017). Available at: https://link.springer.com/chapter/10.1007/978-3-319-68204-4_2. Accessed on: 2026-07-20.
+
+[14] CODEONTOLOGY. **CodeOntology organization** (repositories, last activity 2021–2022). Available at: https://github.com/codeontology. Accessed on: 2026-07-20.
+
+[15] YAMAGUCHI, Fabian et al. **Modeling and Discovering Vulnerabilities with Code Property Graphs** (IEEE S&P 2014); overview: https://en.wikipedia.org/wiki/Code_property_graph. Accessed on: 2026-07-20.
+
+[16] ABDELAZIZ, Ibrahim et al. **A Toolkit for Generating Code Knowledge Graphs (GraphGen4Code)**. arXiv:2002.09440. Available at: https://arxiv.org/pdf/2002.09440. Accessed on: 2026-07-20.
+
+[17] PENG, Xin; WANG, Chong. **Code Digital Twin: A Knowledge Infrastructure for AI-Assisted Complex Software Development**. arXiv:2503.07967. Available at: https://arxiv.org/abs/2503.07967. Accessed on: 2026-07-20.
+
+[18] LINKEDIN ENGINEERING. **Building the LinkedIn Knowledge Graph**. Available at: https://www.linkedin.com/blog/engineering/knowledge/building-the-linkedin-knowledge-graph. Accessed on: 2026-07-20.
+
+[19] SEMANTIC MEDIAWIKI. **Help:RDF export**. Available at: https://www.semantic-mediawiki.org/wiki/Help:RDF_export. Accessed on: 2026-07-20.
+
+[20] MEDIAWIKI. **Wikibase/DataModel**. Available at: https://www.mediawiki.org/wiki/Wikibase/DataModel. Accessed on: 2026-07-20.
+
+[21] PROFESSIONAL WIKI. **Managing Data in MediaWiki: SMW vs Wikibase vs Cargo**. Available at: https://professional.wiki/en/articles/managing-data-in-mediawiki. Accessed on: 2026-07-20.
+
+[22] MEDIAWIKI. **Extension:Cargo — Cargo and Semantic MediaWiki**. Available at: https://www.mediawiki.org/wiki/Extension:Cargo/Cargo_and_Semantic_MediaWiki. Accessed on: 2026-07-20.
+
+[23] DENDRON. **Schemas** and **Hierarchies**. Available at: https://wiki.dendron.so/notes/c5e5adde-5459-409b-b34d-a0d75cbb1052/. Accessed on: 2026-07-20.
+
+[24] NEO4J LABS. **neosemantics (n10s) — RDF for Neo4j** (repository). Available at: https://github.com/neo4j-labs/neosemantics. Accessed on: 2026-07-20.
+
+[25] NEO4J. **neosemantics — Importing Ontologies**. Available at: https://neo4j.com/labs/neosemantics/4.3/importing-ontologies/. Accessed on: 2026-07-20.
+
+[26] ALOCCI, Davide et al. **Property Graph vs RDF Triple Store: A Comparison on Glycan Substructure Search** (PLOS ONE, 2015). Available at: https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0144578. Accessed on: 2026-07-20.
+
+[27] KUZUDB. **Kuzu — an embeddable property graph database** (repository, archived 2025-10-10). Available at: https://github.com/kuzudb/kuzu. Accessed on: 2026-07-20.
+
+[28] APACHE JENA. **TDB2 Documentation**. Available at: https://jena.apache.org/documentation/tdb2/. Accessed on: 2026-07-20.
+
+[29] FOWLER, Martin. **Ubiquitous Language**. Available at: https://martinfowler.com/bliki/UbiquitousLanguage.html. Accessed on: 2026-07-20.
+
+[30] EVANS, Eric. **Domain-Driven Design Reference**. 2015. Available at: https://www.domainlanguage.com/wp-content/uploads/2016/05/DDD_Reference_2015-03.pdf. Accessed on: 2026-07-20.
+
+[31] PAN, Tian. **GraphRAG vs Vector RAG: When Knowledge Graphs Outperform Semantic Search**. 2026. Available at: https://tianpan.co/blog/2026-04-17-graphrag-vs-vector-rag-knowledge-graphs. Accessed on: 2026-07-20.
+
+[32] ONTOTEXT / DZONE. **RDF Triple Stores vs. Labeled Property Graphs: What's the Difference?**. Available at: https://dzone.com/articles/rdf-triple-stores-vs-labeled-property-graphs-whats. Accessed on: 2026-07-20.
+
+[33] MININI, Alan et al. **Lifting EMMeT to OWL: Getting the Most from SKOS** (OWLED 2015). Available at: https://cgi.csc.liv.ac.uk/~valli/OWLED2015/OWLED_2015_paper_9.pdf. Accessed on: 2026-07-20.
+
+[34] LIBRARY OF CONGRESS. **MADS/RDF (Metadata Authority Description Schema in RDF)**; and SUMMERS, Ed et al. **LCSH, SKOS and Linked Data** (arXiv:0805.2855). Available at: https://www.loc.gov/standards/mads/rdf/ and https://arxiv.org/pdf/0805.2855. Accessed on: 2026-07-20.
+
+[35] EUROVOC / LDK 2025. **EuroVoc as SKOS Linked Data** (scale metrics). Available at: https://aclanthology.org/2025.ldk-1.34.pdf. Accessed on: 2026-07-20.
+
+[36] MENDEZ, David et al. **Establishing Traceability between Natural Language Requirements and Software Artifacts** (ER 2024). Available at: https://model-engineering.info/publications/papers/ER24-Requirements2Code.pdf. Accessed on: 2026-07-20. `[unverified — single source: PDF fetch blocked, claim rests on search summary]`

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -5,3 +5,4 @@ append-only (evidence is dated) and sourced; an accepted recommendation becomes 
 spawns implementation slices.
 
 * [Worldwide PII detection catalog — deterministic regex + checksum reference](0001-worldwide-pii-detection-catalog.md)
+* [Ontology tooling and the code-to-docs bridge — Rust-native options for a living-docs knowledge layer](0002-ontology-tooling-codegraph-docs-bridge.md)

--- a/skills/living-docs/SKILL.md
+++ b/skills/living-docs/SKILL.md
@@ -27,23 +27,17 @@ stub:**
 - `living-docs skill living-docs --topic <topic>` — load that topic's full rules (+ template).
 
 Piped output is minified JSON (machine default); `--plain` for human text, `--json` to force
-JSON. Topics: adr, prd, bdr, constitution, issue-workflow, glossary, architecture-diagrams,
-semantic-index, doc-language, citation, procedure, enforcement-modes, check, okf-format,
-doc-trail, size-targets, about (run --list for the full set).
+JSON. Topics: spine, procedure, adr, prd, bdr, constitution, issue-workflow, glossary,
+architecture-diagrams, semantic-index, doc-language, citation, enforcement-modes, check,
+okf-format, doc-trail, size-targets, about (run --list for the full set).
 
----
+This stub is a **pure router** (ADR 0017): it triggers and points at topics — it holds no rules
+inline. The **five core invariants** and the **CLI-owns-the-mechanics hard rule** are topics, not
+stub prose; load them before authoring:
 
-## Core invariants (the spine)
-
-These hold across every document type. Everything else is detail.
-
-1. **Docs-first.** Author the body in the repo (`docs/…`) *before* publishing anywhere external (tracker, wiki). The repo file is the source of truth; the external copy is a mirror.
-2. **One home per fact.** Each concept, decision, or requirement lives in exactly one file. No duplication — cross-reference instead of copying. Duplicated prose is drift waiting to happen.
-3. **Indexed or it doesn't exist.** Every doc is reachable from an index (an `index.md` listing in its directory, and the bundle-root `docs/index.md` that the project guide links). No orphan files.
-4. **Supersede, never rewrite history.** Decisions and requirements are append-only records. When something changes, mark the old record superseded and write a new one — never silently edit the past.
-5. **No structural change without its doc.** New module, moved files, schema change, new data flow → update the relevant doc *and its diagram* in the same change. No "I'll document it later."
-
-When in doubt, re-derive the right action from these five. The rules files below are just these invariants applied to each document type.
+- The five invariants (the spine) → `living-docs skill living-docs --topic spine`.
+- Authoring mechanics — CLI owns every deterministic step, you write only the prose →
+  `living-docs skill living-docs --topic procedure`.
 
 ---
 

--- a/skills/living-docs/rules/procedure.md
+++ b/skills/living-docs/rules/procedure.md
@@ -1,5 +1,21 @@
 # Procedure
 
+## Authoring mechanics — CLI-first (hard rule)
+
+The dividing line is **determinism**: a step with a single correct output given its inputs is
+the CLI's job; the judgment prose (the "why") is yours to write directly in the file. Applied:
+
+- **Use the CLI verb for every mechanical step — never hand-do it:** `new` (number + frontmatter
+  + skeleton), `supersede <old> <new>` (links + status on both records), `index` (regenerate the
+  listing), `check` (the gate, must pass), `export`/`brief` (byte-stable materialization /
+  pre-filled scaffold).
+- **Write the body prose directly.** The CLI must never author rationale, so there is no
+  paragraph-editing verb — editing the body is a normal edit, not a process error. What *is* a
+  process error is hand-numbering a doc, hand-writing frontmatter, hand-maintaining an index row,
+  or hand-wiring `supersedes`/`superseded_by` when `supersede` does it deterministically.
+- **When a deterministic frontmatter mutation has no verb yet** (e.g. set status, add a tag) and
+  you keep doing it by hand, harden it into a new CLI verb rather than normalizing the hand-edit.
+
 ## Setting up living docs in a new project
 
 1. **Ask the enforcement-mode question** (see *Enforcement modes* → *First-run question*) before anything else, since no preference is persisted yet. Record the answer as the `## Living Docs` block in the project guide; default to `strict` if the user has no preference.

--- a/skills/living-docs/rules/spine.md
+++ b/skills/living-docs/rules/spine.md
@@ -1,0 +1,21 @@
+# Core invariants (the spine)
+
+These five invariants hold across **every** document type — ADR, BDR, PRD, constitution, issue,
+research, glossary, architecture. Everything else in this skill is one of these five applied to a
+specific document type. When a rule seems unclear, re-derive the right action from these.
+
+1. **Docs-first.** Author the body in the repo (`docs/…`) *before* publishing anywhere external
+   (tracker, wiki). The repo file is the source of truth; the external copy is a mirror.
+2. **One home per fact.** Each concept, decision, or requirement lives in exactly one file. No
+   duplication — cross-reference instead of copying. Duplicated prose is drift waiting to happen.
+3. **Indexed or it doesn't exist.** Every doc is reachable from an index (an `index.md` listing in
+   its directory, and the bundle-root `docs/index.md` that the project guide links). No orphan
+   files.
+4. **Supersede, never rewrite history.** Decisions and requirements are append-only records. When
+   something changes, mark the old record superseded and write a new one — never silently edit the
+   past.
+5. **No structural change without its doc.** New module, moved files, schema change, new data flow
+   → update the relevant doc *and its diagram* in the same change. No "I'll document it later."
+
+When in doubt, re-derive the right action from these five. The other topics are just these
+invariants applied to each document type.

--- a/skills/living-docs/templates/claude-hard-rules.md
+++ b/skills/living-docs/templates/claude-hard-rules.md
@@ -86,3 +86,11 @@ All of the following must pass on every PR. No exceptions, no deferrals.
 | Mutation testing (changed code, per file) | `<mutation testing >= N% on changed code, per file>` |
 
 The docs-update rule from rule 1 is also a quality gate: a PR failing the docs check does not merge.
+
+### 10. Author docs through the living-docs CLI — never hand-do deterministic steps
+
+The dividing line is determinism: any documentation step with a single correct output given its inputs goes through the `living-docs` CLI; only the judgment prose (the "why") is authored by hand, directly in the file.
+
+- Use the CLI verb for every mechanical step: `living-docs new <type> "<title>"` (number + frontmatter + skeleton), `living-docs supersede <old> <new>` (wires `supersedes`/`superseded_by` + status on both records), `living-docs index [type]` (regenerates the index), `living-docs check` (the doc-gate, must pass), `living-docs export`/`brief` (byte-stable materialization / pre-filled scaffold).
+- Write the body prose directly — there is no paragraph-editing verb, because wrapping a text edit in the CLI adds no determinism. Editing the body is a normal edit; hand-numbering a doc, hand-writing frontmatter, hand-maintaining an index row, or hand-wiring supersede links is a process error.
+- When a deterministic frontmatter mutation has no verb yet (e.g. set status, add a tag) and it keeps being done by hand, harden it into a new CLI verb rather than normalizing the hand-edit.

--- a/skills/okf-knowledge-format/SKILL.md
+++ b/skills/okf-knowledge-format/SKILL.md
@@ -25,24 +25,17 @@ This SKILL.md is a **slim stub** — a trigger plus a task->topic router. The `l
 - `living-docs skill okf-knowledge-format --list` — discover every topic.
 - `living-docs skill okf-knowledge-format --topic <topic>` — load that topic.
 
-Piped output is minified JSON (machine default); `--plain` for human text, `--json` to force JSON. Topics: model, procedure, concept, index, log, about. The vendored spec lives at reference/SPEC.md.
+Piped output is minified JSON (machine default); `--plain` for human text, `--json` to force JSON. Topics: conformance, model, procedure, concept, index, log, about. The vendored spec lives at reference/SPEC.md.
 
----
-
-## Hard rules (these define conformance — §9)
-
-1. **Every non-reserved `.md` file has a parseable YAML frontmatter block** delimited by `---` on its own line at the top and a closing `---`.
-2. **Every frontmatter block has a non-empty `type` field.** `type` is the only required field. Everything else is optional.
-3. **Reserved filenames are reserved.** `index.md` (directory listing, §6) and `log.md` (update history, §7) must follow their defined structure and must **not** be used for concept documents.
-4. **`index.md` carries no frontmatter** — the sole exception is the bundle-root `index.md`, which MAY declare `okf_version: "0.1"` (§11).
-5. **Consume permissively.** Never reject a bundle for missing optional fields, unknown `type` values, unknown extra keys, broken cross-links, or a missing `index.md`. OKF stays useful as bundles grow and get partially agent-generated.
+This stub is a **pure router** (ADR 0017): it triggers and points at topics — it holds no rules inline. The **five conformance hard rules** that define OKF (§9) are a topic, not stub prose; load them before authoring or checking a bundle: `living-docs skill okf-knowledge-format --topic conformance`.
 
 ---
 
 ## When to invoke
 
 - Standing up a new knowledge bundle/catalog, or organizing existing markdown knowledge into one.
+- Reviewing the **five conformance hard rules** that define OKF (§9) → `living-docs skill okf-knowledge-format --topic conformance`.
 - Writing a **concept document** or normalizing its frontmatter → `living-docs skill okf-knowledge-format --topic concept`.
 - Adding or regenerating a directory **`index.md`** → `living-docs skill okf-knowledge-format --topic index`; or a **`log.md`** → `living-docs skill okf-knowledge-format --topic log`.
 - Deciding how to cross-link concepts, cite sources, name a `type`, or reviewing the core model / frontmatter fields / bundle structure → `living-docs skill okf-knowledge-format --topic model`.
-- Checking a corpus for **OKF conformance** (the five hard rules above), authoring a concept or maintaining a directory step by step, or refreshing the vendored spec from upstream (`scripts/update-spec.sh`) → `living-docs skill okf-knowledge-format --topic procedure`.
+- Checking a corpus for **OKF conformance**, authoring a concept or maintaining a directory step by step, or refreshing the vendored spec from upstream (`scripts/update-spec.sh`) → `living-docs skill okf-knowledge-format --topic procedure`.

--- a/skills/okf-knowledge-format/rules/conformance.md
+++ b/skills/okf-knowledge-format/rules/conformance.md
@@ -1,0 +1,17 @@
+# OKF conformance (§9)
+
+These five hard rules define OKF conformance. They summarize the vendored spec at
+`reference/SPEC.md` §9 — when a detail is ambiguous, the vendored spec wins. If
+`scripts/update-spec.sh` reports a changed spec, reconcile these rules against the new §9.
+
+1. **Every non-reserved `.md` file has a parseable YAML frontmatter block** delimited by `---` on
+   its own line at the top and a closing `---`.
+2. **Every frontmatter block has a non-empty `type` field.** `type` is the only required field.
+   Everything else is optional.
+3. **Reserved filenames are reserved.** `index.md` (directory listing, §6) and `log.md` (update
+   history, §7) must follow their defined structure and must **not** be used for concept documents.
+4. **`index.md` carries no frontmatter** — the sole exception is the bundle-root `index.md`, which
+   MAY declare `okf_version: "0.1"` (§11).
+5. **Consume permissively.** Never reject a bundle for missing optional fields, unknown `type`
+   values, unknown extra keys, broken cross-links, or a missing `index.md`. OKF stays useful as
+   bundles grow and get partially agent-generated.

--- a/skills/okf-knowledge-format/rules/procedure.md
+++ b/skills/okf-knowledge-format/rules/procedure.md
@@ -14,7 +14,7 @@
 3. Declare `okf_version: "0.1"` in the bundle-root `index.md` frontmatter only.
 
 ### Check conformance
-Walk the four hard rules: every non-reserved `.md` has parseable frontmatter; every block has non-empty `type`; reserved files follow §6/§7; root `index.md` is the only `index.md` with frontmatter.
+Walk the five conformance hard rules (`--topic conformance`): every non-reserved `.md` has parseable frontmatter; every block has non-empty `type`; reserved files follow §6/§7; root `index.md` is the only `index.md` with frontmatter; consumers stay permissive.
 
 ---
 
@@ -27,4 +27,4 @@ skills/okf-knowledge-format/scripts/update-spec.sh          # default ref: main
 skills/okf-knowledge-format/scripts/update-spec.sh v0.2     # a tag/branch/commit
 ```
 
-The script overwrites `reference/SPEC.md`, rewrites `reference/SPEC.source.md` (URL, ref, retrieval time, sha256), and reports whether the content changed. **If it changed, review the diff and reconcile the Hard rules / field tables above** before committing — this SKILL.md must not drift from the vendored spec. The vendored copy is the offline source of truth; the script is the only sanctioned way to update it.
+The script overwrites `reference/SPEC.md`, rewrites `reference/SPEC.source.md` (URL, ref, retrieval time, sha256), and reports whether the content changed. **If it changed, review the diff and reconcile the conformance rules (`--topic conformance`) and the field tables (`--topic model`)** before committing — the topics must not drift from the vendored spec. The vendored copy is the offline source of truth; the script is the only sanctioned way to update it.

--- a/skills/public-export/SKILL.md
+++ b/skills/public-export/SKILL.md
@@ -10,6 +10,7 @@ description: >-
   deterministic leak gate, and a human-gated clean-history publish. The
   three-bucket model — scaffold (public), accumulation (never), curated showcase
   (deliberately published). Invocable as /public-export.
+version: "0.7.0"
 metadata:
   type: skill
   layer: procedural
@@ -19,124 +20,34 @@ allowed-tools: Read, Grep, Glob, Bash, AskUserQuestion
 
 # public-export — ship the method, keep the moat
 
-Your written method was never the moat — the practiced judgment, the accumulated
-lessons, and the decision trail are. So you *can* publish the scaffold and a curated
-showcase of your reasoning (a strong credibility signal) while keeping the
-accumulation private. This skill is the disciplined way to do that without leaking.
+Publish the scaffold and a curated showcase of your reasoning while keeping the accumulation
+private. The public repo is a **build artifact** of the private one — generated, gated, and
+human-published, never hand-edited.
 
-**Mental model: the public repo is a build artifact of the private one.** You never
-hand-edit it; you *generate* it. One-way flow: private (source of truth) → build →
-gate → clean-history publish. In this repo the deterministic parts are the
-`living-docs` tool itself — `export --visibility` (the allowlist build) and
-`leak-gate` (the fail-closed backstop), decided in [ADR 0010](/adr/0010-public-export-is-a-deterministic-allowlist-build-with-a-leak-gate-publish-is-a-human-gated-procedure.md).
-This skill owns the **judgment** the tool cannot: what belongs in the curated
-showcase, and the human review of the diff before any push.
+---
 
-The split is deliberate (ADR 0001 + ADR 0010): the tool is deterministic and never
-runs destructive git; the irreversible clean-history publish is a human step this
-skill documents, never a tool subcommand.
+## Using this skill (progressive disclosure)
 
-## The three buckets (decide per doc, explicitly)
+This SKILL.md is a **pure router** (ADR 0017) — a trigger plus a task→topic router. The
+`living-docs` CLI holds the full model, rules, and procedure and discloses them progressively.
+**Before exporting or publishing, load the topic for your step:**
 
-| Bucket | Examples | Public? |
-|---|---|---|
-| **Scaffold** — the method | `skills/*/SKILL.md`, templates, engine source, README, LICENSE | yes |
-| **Accumulation** — the moat | full lessons, memory DB, client specs, in-flight bets, outcome data | **never** |
-| **Curated showcase** — portfolio | hand-picked, cleaned ADRs/research (e.g. a "why I rejected X" record) | yes, deliberately |
+- `living-docs skill public-export --list` — discover every topic.
+- `living-docs skill public-export --topic <topic>` — load that topic.
 
-The showcase is the only nuance: each showcased doc is elevated **one at a time** by
-setting `visibility: showcase` on it, never by publishing `docs/adr/**` wholesale.
-Curation is manual on purpose.
+Piped output is minified JSON (machine default); `--plain` for human text, `--json` to force JSON.
+Topics: about, buckets, visibility-model, rules, procedure.
 
-**Derived artifacts sit in the same bucket as their sources.** Embeddings, traces,
-and eval outputs derived from Accumulation content are Accumulation — an embedding is
-a **copy** of its source text, not an opaque transform. A memory DB (vectors
-included) never exports, and that line is the reason, so the rule survives future
-judgment calls.
+---
 
-## How private stays separate from public (the tool never judges at publish)
+## When to invoke
 
-Do **not** trust an LLM to decide, at export time, what is private — that is
-LLM-as-judge on a security boundary, the exact failure this system forbids (ADR
-0009). The judgment is made **once, by the human, at authoring time**, recorded as
-**data** in the living-docs/OKF frontmatter, and enforced deterministically forever:
-
-- Every OKF concept doc carries **`visibility: private | public | showcase`** in
-  frontmatter, set when the doc is written and confirmed by you.
-- **Missing or unknown `visibility` ⇒ private** (default-deny). Omission can never
-  publish something by accident. `living-docs check` validates the domain (a typo
-  fails), so the rule is an instrument, not a vibe.
-- The export is driven by that declaration: `living-docs export --visibility
-  public,showcase <out>` materializes only allowlisted docs, so **no LLM judgment
-  sits in the publish path**.
-- The **leak gate is the backstop**: even a mismarked-public doc is caught if it
-  links to a withheld doc, or carries a secret.
-
-The AI's only role is at *authoring*: when it writes an ADR/PRD/BDR/research note, it
-proposes a `visibility` (defaulting to private) for you to confirm — never to decide
-what ships at publish.
-
-## Hard rules
-
-- **Allowlist, never denylist.** Only `visibility: public|showcase` docs export
-  (default-deny). A denylist leaks the day you add a new private doc and forget it.
-- **Visibility is declared at authoring time, never judged at publish.** Missing ⇒
-  private.
-- **Never hand-edit the public repo.** It is regenerated. Hand edits become a second
-  source that silently diverges.
-- **The gate vetoes the push.** `living-docs leak-gate` must pass before publishing.
-  It fails closed on a private doc present in the bundle, a published doc linking to a
-  withheld doc, or a secret/PII pattern match. Fix every finding at the *source*
-  (the doc's `visibility`, the link, or the secret), never by editing the built output.
-- **Strip the narrative, keep the credit.** Remove internal decision narrative when
-  curating a showcase doc; **keep external provenance/attribution**. Stripping
-  research ≠ stripping credit.
-- **A leaked secret is compromised — rotate it.** Force-push/orphan history removes a
-  secret from `main` but not from forks/clones/caches/the SHA. History hygiene is the
-  backstop; the gate + allowlist are the real control.
-- **git push is human-gated.** The tool builds and gates; it never pushes. You review
-  the diff, then push by hand.
-- **The destination repo is created PRIVATE, always.** Create with `gh repo create
-  <owner>/<name> --private`, push the built+gated bundle, verify once more while it is
-  still private, and only then flip it public (`gh repo edit <owner>/<name>
-  --visibility public`). Never create a public repo and push in one shot — the first
-  commit is instantly world-readable and a leak cannot be recalled.
-
-## Procedure
-
-1. **Set visibility at the source.** Confirm each doc that should ship carries
-   `visibility: public` (scaffold) or `visibility: showcase` (curated portfolio);
-   everything else stays absent/private. `living-docs check docs` must be green (it
-   validates the visibility domain).
-2. **Build the allowlist bundle.** `living-docs export --visibility public,showcase
-   <out>` materializes only the allowlisted docs into `<out>` — default-deny, so a
-   private or absent-visibility doc never lands there.
-3. **Gate.** `living-docs leak-gate <out>`. It exits non-zero on any private doc in
-   the bundle, any published doc linking to a withheld doc, or any secret/PII pattern
-   match. Fix every finding at the source (visibility, link, or secret), rebuild, and
-   re-gate — never edit `<out>` by hand.
-4. **Create the destination repo PRIVATE (first time only).** `gh repo create
-   <owner>/<name> --private --description "<one-liner>"`.
-5. **Clean-history publish (with the human).** In the still-private destination,
-   create the curated release commit (orphan branch or history filter that keeps only
-   `<out>`), review the diff, then `git push --force-with-lease`. Private keeps the
-   real granular history; public shows curated release commits.
-6. **Flip to public only after verifying clean while private.** Re-run `living-docs
-   leak-gate` against the pushed tree, eyeball it, then `gh repo edit <owner>/<name>
-   --visibility public`. Anything ever wrong is caught while still private.
-7. **Record** the decision (what is published, what stays private) via `living-docs`.
-
-## Distinct from / composes
-
-- **`living-docs`** — owns document authoring, the `visibility` field (ADR 0009), and
-  records the publish decision; this skill does not author docs.
-- **`okf-knowledge-format`** — the export respects OKF; this skill removes *internal*
-  narrative from showcased docs, not the format.
-
-## Provenance — instrumentalization, not invention
-
-The "public repo as generated artifact / one-way source→public" pattern is standard
-docs-as-code practice; allowlist-over-denylist is the least-privilege/default-deny
-security principle applied to publishing; orphan-branch history hygiene and "rotate a
-leaked secret" are established git-secrets guidance. This skill is the composition and
-the calibrated leak gate, not a new method.
+- Understanding **why** this skill exists, its build-artifact mental model, how it composes with
+  `living-docs`/`okf-knowledge-format`, and its provenance → `living-docs skill public-export --topic about`.
+- Deciding **what goes where** — scaffold vs accumulation vs curated showcase, and the
+  derived-artifacts rule → `living-docs skill public-export --topic buckets`.
+- Understanding **how private stays private** — the `visibility` frontmatter field, default-deny,
+  and why the tool never judges at publish → `living-docs skill public-export --topic visibility-model`.
+- Enforcing the **hard rules** (allowlist-not-denylist, gate vetoes the push, PRIVATE-first repo,
+  rotate a leaked secret) → `living-docs skill public-export --topic rules`.
+- Running the **export → gate → clean-history publish** steps → `living-docs skill public-export --topic procedure`.

--- a/skills/public-export/rules/about.md
+++ b/skills/public-export/rules/about.md
@@ -1,0 +1,36 @@
+# public-export — mental model, composition, provenance
+
+## Why this skill exists
+
+Your written method was never the moat — the practiced judgment, the accumulated lessons, and the
+decision trail are. So you *can* publish the scaffold and a curated showcase of your reasoning (a
+strong credibility signal) while keeping the accumulation private. This skill is the disciplined
+way to do that without leaking.
+
+## Mental model: the public repo is a build artifact of the private one
+
+You never hand-edit the public repo; you *generate* it. One-way flow: private (source of truth) →
+build → gate → clean-history publish. In this repo the deterministic parts are the `living-docs`
+tool itself — `export --visibility` (the allowlist build) and `leak-gate` (the fail-closed
+backstop), decided in
+[ADR 0010](/adr/0010-public-export-is-a-deterministic-allowlist-build-with-a-leak-gate-publish-is-a-human-gated-procedure.md).
+This skill owns the **judgment** the tool cannot: what belongs in the curated showcase, and the
+human review of the diff before any push.
+
+The split is deliberate (ADR 0001 + ADR 0010): the tool is deterministic and never runs
+destructive git; the irreversible clean-history publish is a human step this skill documents, never
+a tool subcommand.
+
+## Composes with
+
+- **`living-docs`** — owns document authoring, the `visibility` field (ADR 0009), and records the
+  publish decision; this skill does not author docs.
+- **`okf-knowledge-format`** — the export respects OKF; this skill removes *internal* narrative from
+  showcased docs, not the format.
+
+## Provenance — instrumentalization, not invention
+
+The "public repo as generated artifact / one-way source→public" pattern is standard docs-as-code
+practice; allowlist-over-denylist is the least-privilege/default-deny security principle applied to
+publishing; orphan-branch history hygiene and "rotate a leaked secret" are established git-secrets
+guidance. This skill is the composition and the calibrated leak gate, not a new method.

--- a/skills/public-export/rules/buckets.md
+++ b/skills/public-export/rules/buckets.md
@@ -1,0 +1,16 @@
+# The three buckets (decide per doc, explicitly)
+
+| Bucket | Examples | Public? |
+|---|---|---|
+| **Scaffold** — the method | `skills/*/SKILL.md`, templates, engine source, README, LICENSE | yes |
+| **Accumulation** — the moat | full lessons, memory DB, client specs, in-flight bets, outcome data | **never** |
+| **Curated showcase** — portfolio | hand-picked, cleaned ADRs/research (e.g. a "why I rejected X" record) | yes, deliberately |
+
+The showcase is the only nuance: each showcased doc is elevated **one at a time** by setting
+`visibility: showcase` on it, never by publishing `docs/adr/**` wholesale. Curation is manual on
+purpose.
+
+**Derived artifacts sit in the same bucket as their sources.** Embeddings, traces, and eval outputs
+derived from Accumulation content are Accumulation — an embedding is a **copy** of its source text,
+not an opaque transform. A memory DB (vectors included) never exports, and that line is the reason,
+so the rule survives future judgment calls.

--- a/skills/public-export/rules/procedure.md
+++ b/skills/public-export/rules/procedure.md
@@ -1,0 +1,21 @@
+# public-export procedure
+
+1. **Set visibility at the source.** Confirm each doc that should ship carries `visibility: public`
+   (scaffold) or `visibility: showcase` (curated portfolio); everything else stays absent/private.
+   `living-docs check docs` must be green (it validates the visibility domain).
+2. **Build the allowlist bundle.** `living-docs export --visibility public,showcase <out>`
+   materializes only the allowlisted docs into `<out>` — default-deny, so a private or
+   absent-visibility doc never lands there.
+3. **Gate.** `living-docs leak-gate <out>`. It exits non-zero on any private doc in the bundle, any
+   published doc linking to a withheld doc, or any secret/PII pattern match. Fix every finding at the
+   source (visibility, link, or secret), rebuild, and re-gate — never edit `<out>` by hand.
+4. **Create the destination repo PRIVATE (first time only).** `gh repo create <owner>/<name>
+   --private --description "<one-liner>"`.
+5. **Clean-history publish (with the human).** In the still-private destination, create the curated
+   release commit (orphan branch or history filter that keeps only `<out>`), review the diff, then
+   `git push --force-with-lease`. Private keeps the real granular history; public shows curated
+   release commits.
+6. **Flip to public only after verifying clean while private.** Re-run `living-docs leak-gate`
+   against the pushed tree, eyeball it, then `gh repo edit <owner>/<name> --visibility public`.
+   Anything ever wrong is caught while still private.
+7. **Record** the decision (what is published, what stays private) via `living-docs`.

--- a/skills/public-export/rules/rules.md
+++ b/skills/public-export/rules/rules.md
@@ -1,0 +1,22 @@
+# public-export hard rules
+
+- **Allowlist, never denylist.** Only `visibility: public|showcase` docs export (default-deny). A
+  denylist leaks the day you add a new private doc and forget it.
+- **Visibility is declared at authoring time, never judged at publish.** Missing ⇒ private.
+- **Never hand-edit the public repo.** It is regenerated. Hand edits become a second source that
+  silently diverges.
+- **The gate vetoes the push.** `living-docs leak-gate` must pass before publishing. It fails closed
+  on a private doc present in the bundle, a published doc linking to a withheld doc, or a secret/PII
+  pattern match. Fix every finding at the *source* (the doc's `visibility`, the link, or the
+  secret), never by editing the built output.
+- **Strip the narrative, keep the credit.** Remove internal decision narrative when curating a
+  showcase doc; **keep external provenance/attribution**. Stripping research ≠ stripping credit.
+- **A leaked secret is compromised — rotate it.** Force-push/orphan history removes a secret from
+  `main` but not from forks/clones/caches/the SHA. History hygiene is the backstop; the gate +
+  allowlist are the real control.
+- **git push is human-gated.** The tool builds and gates; it never pushes. You review the diff, then
+  push by hand.
+- **The destination repo is created PRIVATE, always.** Create with `gh repo create <owner>/<name>
+  --private`, push the built+gated bundle, verify once more while it is still private, and only then
+  flip it public (`gh repo edit <owner>/<name> --visibility public`). Never create a public repo and
+  push in one shot — the first commit is instantly world-readable and a leak cannot be recalled.

--- a/skills/public-export/rules/visibility-model.md
+++ b/skills/public-export/rules/visibility-model.md
@@ -1,0 +1,19 @@
+# How private stays separate from public (the tool never judges at publish)
+
+Do **not** trust an LLM to decide, at export time, what is private — that is LLM-as-judge on a
+security boundary, the exact failure this system forbids (ADR 0009). The judgment is made **once, by
+the human, at authoring time**, recorded as **data** in the living-docs/OKF frontmatter, and
+enforced deterministically forever:
+
+- Every OKF concept doc carries **`visibility: private | public | showcase`** in frontmatter, set
+  when the doc is written and confirmed by you.
+- **Missing or unknown `visibility` ⇒ private** (default-deny). Omission can never publish something
+  by accident. `living-docs check` validates the domain (a typo fails), so the rule is an
+  instrument, not a vibe.
+- The export is driven by that declaration: `living-docs export --visibility public,showcase <out>`
+  materializes only allowlisted docs, so **no LLM judgment sits in the publish path**.
+- The **leak gate is the backstop**: even a mismarked-public doc is caught if it links to a withheld
+  doc, or carries a secret.
+
+The AI's only role is at *authoring*: when it writes an ADR/PRD/BDR/research note, it proposes a
+`visibility` (defaulting to private) for you to confirm — never to decide what ships at publish.

--- a/skills/research-artifacts/SKILL.md
+++ b/skills/research-artifacts/SKILL.md
@@ -25,6 +25,8 @@ This SKILL.md is a **slim stub** — a trigger plus a task->topic router. The `l
 
 Piped output is minified JSON (machine default); `--plain` for human text, `--json` to force JSON. Topics: rules, structure, research-report, research-index, research-general-references, about.
 
+This stub is a **pure router** (ADR 0017): it triggers and points at topics — it holds no rules inline. The source discipline and the research → decision → issue chain are topics, loaded before authoring via `--topic rules` / `--topic structure`.
+
 ---
 
 ## When to invoke


### PR DESCRIPTION
## Summary

Two related bodies of work on the living-docs docs trail and skill distribution.

### Group A — Atlas authoring vision
- **PRD 0001** — Living Docs Atlas: a multi-project authoring wiki over `living-docs-core` (create/edit/supersede/delete in the browser).
- **Research 0002** — ontology tooling ↔ codegraph ↔ docs bridge (deep-research, falsify mode, tier-1 sources). Verdict: stay Rust-native (SKOS-in-Oxigraph), gate the graph layer behind measured need. Raw evidence trail under `.research-runs/`.
- **ADR 0016** — makes the web a **db-mode authoring front**, superseding **ADR 0006** (web read-only). Writable only where the DB is the single authoritative store (ADR 0003), so no second source of truth and no cross-backend sync; optimistic single-store concurrency (per-record `revision`), never a merge.

### Group B — pure-router skill stubs (ADR 0017, supersedes 0014)
Every embedded `SKILL.md` becomes a **pure router** — frontmatter trigger + `Using this skill` + `When to invoke` table — with all substantive prose relocated into CLI-served `--topic`s:
- `living-docs`: five invariants → `--topic spine`; the triplicated "CLI owns the mechanics" block removed (home is `--topic procedure`).
- `okf-knowledge-format`: five conformance rules → `--topic conformance`; stale "Hard rules above" pointer fixed.
- `public-export`: 142-line document split into five `rules/` topics (`about`, `buckets`, `visibility-model`, `rules`, `procedure`); stub gains `Using this skill` + `version`.
- `research-artifacts`: already a router; consistency note only.

## Verification
- No Rust change — topic resolution is generic over `rules/`/`templates/` basenames.
- `cargo test -p living-docs --test skill` — 12 passed.
- `living-docs check docs` — 37 docs, no invariant violations.
- All new topics resolve; supersede links wired (0006→0016, 0014→0017).

## Notes
- ADRs 0016 and 0017 are `Proposed` — there is no CLI `status`/`accept` verb yet; hardening one is a tracked follow-up (hit twice now).

🤖 Co-authored with Claude Code

Evaldo Klock <neto.nemesis@gmail.com>
