### PR TITLE
feat: add status verb to set record lifecycle frontmatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@
 
 # Dev-env docker-compose secrets (issue 0007) — only env.example is committed
 /.env
+
+# cargo-mutants scratch output — regenerated per run, never committed
+mutants.out/
+mutants.out.old/

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -64,6 +64,14 @@ enum Command {
         old: String,
         new: String,
     },
+    /// Sets a record's `status:` frontmatter field directly — for the
+    /// `Proposed`/`Accepted`/`Deprecated` lifecycle only. `Superseded` is
+    /// rejected; use `supersede`, which also wires the
+    /// `supersedes`/`superseded_by` links.
+    Status {
+        number: String,
+        new_status: String,
+    },
     Next {
         doc_type: String,
     },
@@ -242,6 +250,9 @@ fn main() -> ExitCode {
             visibility,
         } => run_index(cli.backend, &cli.docs_dir, doc_type, visibility),
         Command::Supersede { old, new } => run_supersede(cli.backend, &cli.docs_dir, &old, &new),
+        Command::Status { number, new_status } => {
+            run_status(cli.backend, &cli.docs_dir, &number, &new_status)
+        }
         Command::Check {
             paths,
             mermaid_only,
@@ -337,6 +348,13 @@ fn run_index(
 fn run_supersede(backend: Backend, docs_dir: &Path, old: &str, new: &str) -> ExitCode {
     match build_backend_store(backend, docs_dir) {
         Ok(store) => commands::supersede::run(store.as_ref(), docs_dir, old, new),
+        Err(err) => report_failure(&err),
+    }
+}
+
+fn run_status(backend: Backend, docs_dir: &Path, number: &str, new_status: &str) -> ExitCode {
+    match build_backend_store(backend, docs_dir) {
+        Ok(store) => commands::status::run(store.as_ref(), docs_dir, number, new_status),
         Err(err) => report_failure(&err),
     }
 }

--- a/cli/tests/index_supersede.rs
+++ b/cli/tests/index_supersede.rs
@@ -47,6 +47,19 @@ fn run_supersede(docs: &Path, old: &str, new: &str) -> Output {
         .expect("failed to run living-docs supersede")
 }
 
+fn run_status(docs: &Path, number: &str, new_status: &str) -> Output {
+    living_docs()
+        .args([
+            "--docs-dir",
+            docs.to_str().unwrap(),
+            "status",
+            number,
+            new_status,
+        ])
+        .output()
+        .expect("failed to run living-docs status")
+}
+
 fn write_record(docs: &Path, dir: &str, filename: &str, title: &str, status: &str) {
     let type_dir = docs.join(dir);
     fs::create_dir_all(&type_dir).unwrap();
@@ -613,6 +626,92 @@ fn supersede_fails_when_a_record_number_does_not_exist() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("no record found"), "got: {stderr}");
+
+    let _ = fs::remove_dir_all(&docs);
+}
+
+#[test]
+fn status_sets_the_field_and_preserves_body_and_other_frontmatter() {
+    let docs = temp_dir("status-set");
+    assert!(run_new(&docs, "adr", "A Decision").status.success());
+
+    let output = run_status(&docs, "0001", "Accepted");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let contents = fs::read_to_string(docs.join("adr/0001-a-decision.md")).unwrap();
+    assert!(contents.contains("status: Accepted"), "got: {contents}");
+    assert!(
+        contents.contains("We will <the choice, in active voice"),
+        "body lost: {contents}"
+    );
+    assert!(
+        contents.contains("# Proposed | Accepted | Superseded | Deprecated"),
+        "comment lost: {contents}"
+    );
+
+    let _ = fs::remove_dir_all(&docs);
+}
+
+#[test]
+fn status_rejects_superseded_and_points_to_the_supersede_command_leaving_the_file_unchanged() {
+    let docs = temp_dir("status-reject-superseded");
+    assert!(run_new(&docs, "adr", "A Decision").status.success());
+    let before = fs::read_to_string(docs.join("adr/0001-a-decision.md")).unwrap();
+
+    let output = run_status(&docs, "0001", "Superseded");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("living-docs supersede"), "got: {stderr}");
+
+    let after = fs::read_to_string(docs.join("adr/0001-a-decision.md")).unwrap();
+    assert_eq!(before, after, "file must be left unchanged");
+
+    let _ = fs::remove_dir_all(&docs);
+}
+
+#[test]
+fn status_rejects_an_unknown_value_leaving_the_file_unchanged() {
+    let docs = temp_dir("status-reject-unknown");
+    assert!(run_new(&docs, "adr", "A Decision").status.success());
+    let before = fs::read_to_string(docs.join("adr/0001-a-decision.md")).unwrap();
+
+    let output = run_status(&docs, "0001", "Acepted");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Proposed"), "got: {stderr}");
+    assert!(stderr.contains("Accepted"), "got: {stderr}");
+    assert!(stderr.contains("Deprecated"), "got: {stderr}");
+
+    let after = fs::read_to_string(docs.join("adr/0001-a-decision.md")).unwrap();
+    assert_eq!(before, after, "file must be left unchanged");
+
+    let _ = fs::remove_dir_all(&docs);
+}
+
+#[test]
+fn status_setting_the_current_status_again_is_a_byte_identical_no_op() {
+    let docs = temp_dir("status-idempotent");
+    assert!(run_new(&docs, "adr", "A Decision").status.success());
+    let before = fs::read(docs.join("adr/0001-a-decision.md")).unwrap();
+
+    let output = run_status(&docs, "0001", "Proposed");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let after = fs::read(docs.join("adr/0001-a-decision.md")).unwrap();
+    assert_eq!(
+        before, after,
+        "re-setting the same status must be byte-identical"
+    );
 
     let _ = fs::remove_dir_all(&docs);
 }

--- a/docs/adr/0016-atlas-makes-the-web-a-db-mode-authoring-front-superseding-web-read-only.md
+++ b/docs/adr/0016-atlas-makes-the-web-a-db-mode-authoring-front-superseding-web-read-only.md
@@ -2,7 +2,7 @@
 type: ADR
 title: Atlas makes the web a db-mode authoring front, superseding web read-only
 description: The Living Docs Atlas web front becomes writable, but only in db-mode where the database is the single authoritative store (ADR 0003) — so there is still no second source of truth and no cross-backend sync; in file-mode the web stays read-only, and intra-db concurrency is single-store optimistic (a per-record revision precondition), never a merge.
-status: Proposed
+status: Accepted
 supersedes: 0006
 superseded_by:
 tags: [architecture, web, authoring, atlas, db-mode, source-of-truth, concurrency]

--- a/docs/adr/0017-skill-md-stubs-are-pure-routers-the-spine-and-all-detail-move-to-cli-topics.md
+++ b/docs/adr/0017-skill-md-stubs-are-pure-routers-the-spine-and-all-detail-move-to-cli-topics.md
@@ -2,7 +2,7 @@
 type: ADR
 title: SKILL.md stubs are pure routers; the spine and all detail move to CLI topics
 description: Every embedded skill's SKILL.md becomes a pure router — frontmatter trigger, a "Using this skill" progressive-disclosure block, and a task→topic table — with all substantive prose (including the five core invariants) relocated into CLI-served topics; this supersedes ADR 0014's clause that kept the spine inline in the stub.
-status: Proposed
+status: Accepted
 supersedes: 0014
 superseded_by:
 tags: [documentation, tooling, skill-distribution, progressive-disclosure, cli, tokens]

--- a/living-docs-core/src/commands/mod.rs
+++ b/living-docs-core/src/commands/mod.rs
@@ -4,4 +4,5 @@ pub mod index;
 pub mod leak_gate;
 pub mod new;
 pub mod next;
+pub mod status;
 pub mod supersede;

--- a/living-docs-core/src/commands/status.rs
+++ b/living-docs-core/src/commands/status.rs
@@ -1,0 +1,184 @@
+use crate::commands::supersede::{find_record, parse_record_number, set_frontmatter_fields};
+use crate::store::DocStore;
+use std::path::Path;
+use std::process::ExitCode;
+
+/// The only statuses this verb may set directly. `Superseded` is deliberately
+/// excluded — it must go through `supersede`, which also wires the
+/// `supersedes`/`superseded_by` links.
+const VALID_STATUSES: [&str; 3] = ["Proposed", "Accepted", "Deprecated"];
+
+pub fn run(store: &dyn DocStore, docs_dir: &Path, number: &str, new_status: &str) -> ExitCode {
+    match status(store, docs_dir, number, new_status) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(message) => {
+            eprintln!("living-docs status: {message}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+/// Sets a record's `status:` frontmatter field, reusing `supersede`'s
+/// record-resolution ([`find_record`]) and frontmatter-mutation
+/// ([`set_frontmatter_fields`]) helpers rather than duplicating them (lesson
+/// 3717). `new_status` is validated before any read/write, so an invalid
+/// value never reaches the frontmatter writer or partially mutates a file.
+fn status(
+    store: &dyn DocStore,
+    docs_dir: &Path,
+    number: &str,
+    new_status: &str,
+) -> Result<(), String> {
+    validate_status(new_status)?;
+    let record_number = parse_record_number(number)?;
+    let path = find_record(store, docs_dir, record_number)?;
+    set_frontmatter_fields(store, &path, &[("status", new_status.to_string())])
+}
+
+fn validate_status(new_status: &str) -> Result<(), String> {
+    if VALID_STATUSES.contains(&new_status) {
+        return Ok(());
+    }
+    if new_status.eq_ignore_ascii_case("superseded") {
+        return Err(
+            "'Superseded' must be set via `living-docs supersede <old> <new>`, which also wires the supersedes/superseded_by links".to_string(),
+        );
+    }
+    Err(format!(
+        "'{new_status}' is not a valid status; expected one of {}",
+        VALID_STATUSES.join(", ")
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::collections::BTreeMap;
+    use std::io;
+    use std::path::PathBuf;
+
+    #[test]
+    fn validate_status_accepts_every_known_value() {
+        for value in VALID_STATUSES {
+            assert!(
+                validate_status(value).is_ok(),
+                "expected {value} to be valid"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_status_rejects_superseded_case_insensitively_with_a_supersede_hint() {
+        for value in ["Superseded", "superseded", "SUPERSEDED"] {
+            let err = validate_status(value).expect_err("Superseded must be rejected");
+            assert!(err.contains("living-docs supersede"), "got: {err}");
+        }
+    }
+
+    #[test]
+    fn validate_status_rejects_an_unknown_value_and_lists_valid_ones() {
+        let err = validate_status("Acepted").expect_err("typo status must be rejected");
+        assert!(err.contains("Proposed"), "got: {err}");
+        assert!(err.contains("Accepted"), "got: {err}");
+        assert!(err.contains("Deprecated"), "got: {err}");
+    }
+
+    struct MapStore {
+        files: RefCell<BTreeMap<PathBuf, String>>,
+    }
+
+    impl MapStore {
+        fn seeded(seed: &[(&str, &str)]) -> Self {
+            let files = seed
+                .iter()
+                .map(|(path, contents)| (PathBuf::from(path), (*contents).to_string()))
+                .collect();
+            Self {
+                files: RefCell::new(files),
+            }
+        }
+    }
+
+    impl DocStore for MapStore {
+        fn list(&self, root: &Path) -> io::Result<Vec<PathBuf>> {
+            Ok(self
+                .files
+                .borrow()
+                .keys()
+                .filter(|path| path.starts_with(root))
+                .cloned()
+                .collect())
+        }
+
+        fn read(&self, path: &Path) -> io::Result<String> {
+            self.files
+                .borrow()
+                .get(path)
+                .cloned()
+                .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "not found"))
+        }
+
+        fn write(&self, path: &Path, contents: &str) -> io::Result<()> {
+            self.files
+                .borrow_mut()
+                .insert(path.to_path_buf(), contents.to_string());
+            Ok(())
+        }
+    }
+
+    const RECORD: &str =
+        "---\ntype: ADR\nstatus: Proposed\nsupersedes:\nsuperseded_by:\n---\n\n# Record\n";
+
+    #[test]
+    fn status_sets_the_status_field_and_preserves_the_rest_of_the_record() {
+        let store = MapStore::seeded(&[("/bundle/adr/0001-record.md", RECORD)]);
+
+        status(&store, Path::new("/bundle"), "0001", "Accepted").expect("status should succeed");
+
+        let updated = store.read(Path::new("/bundle/adr/0001-record.md")).unwrap();
+        assert!(updated.contains("status: Accepted"), "got: {updated}");
+        assert!(updated.contains("# Record\n"), "got: {updated}");
+        assert!(updated.contains("supersedes:\n"), "got: {updated}");
+    }
+
+    #[test]
+    fn status_rejects_superseded_without_touching_the_store() {
+        let store = MapStore::seeded(&[("/bundle/adr/0001-record.md", RECORD)]);
+
+        let err = status(&store, Path::new("/bundle"), "0001", "Superseded")
+            .expect_err("Superseded must be rejected");
+
+        assert!(err.contains("living-docs supersede"), "got: {err}");
+        let unchanged = store.read(Path::new("/bundle/adr/0001-record.md")).unwrap();
+        assert_eq!(unchanged, RECORD);
+    }
+
+    #[test]
+    fn status_fails_when_the_store_lists_no_record_for_a_number() {
+        let store = MapStore::seeded(&[("/bundle/adr/0001-record.md", RECORD)]);
+
+        let err = status(&store, Path::new("/bundle"), "0099", "Accepted")
+            .expect_err("status must fail when the record cannot be found");
+
+        assert!(err.contains("no record found for 0099"), "got: {err}");
+    }
+
+    #[test]
+    fn run_returns_the_success_exit_code_when_status_is_set() {
+        let store = MapStore::seeded(&[("/bundle/adr/0001-record.md", RECORD)]);
+
+        let code = run(&store, Path::new("/bundle"), "0001", "Accepted");
+
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::SUCCESS));
+    }
+
+    #[test]
+    fn run_returns_a_non_success_exit_code_for_an_unknown_status() {
+        let store = MapStore::seeded(&[("/bundle/adr/0001-record.md", RECORD)]);
+
+        let code = run(&store, Path::new("/bundle"), "0001", "Acepted");
+
+        assert_ne!(format!("{code:?}"), format!("{:?}", ExitCode::SUCCESS));
+    }
+}

--- a/living-docs-core/src/commands/supersede.rs
+++ b/living-docs-core/src/commands/supersede.rs
@@ -36,7 +36,7 @@ fn supersede(store: &dyn DocStore, docs_dir: &Path, old: &str, new: &str) -> Res
     Ok(())
 }
 
-fn parse_record_number(arg: &str) -> Result<u32, String> {
+pub(crate) fn parse_record_number(arg: &str) -> Result<u32, String> {
     arg.parse()
         .map_err(|_| format!("'{arg}' is not a valid record number"))
 }
@@ -44,8 +44,13 @@ fn parse_record_number(arg: &str) -> Result<u32, String> {
 /// Finds the record whose filename opens with `number`'s zero-padded `NNNN-`
 /// prefix among every path the active store lists under `docs_dir` — backend
 /// agnostic, so a db-mode store's own project-scoped enumeration is honored
-/// exactly like a filesystem walk.
-fn find_record(store: &dyn DocStore, docs_dir: &Path, number: u32) -> Result<PathBuf, String> {
+/// exactly like a filesystem walk. Shared with `status.rs` (lesson 3717: no
+/// duplicated record-resolution logic).
+pub(crate) fn find_record(
+    store: &dyn DocStore,
+    docs_dir: &Path,
+    number: u32,
+) -> Result<PathBuf, String> {
     let prefix = format!("{number:04}-");
     store
         .list(docs_dir)
@@ -68,8 +73,9 @@ fn matches_record_prefix(path: &Path, prefix: &str) -> bool {
 /// the body survive untouched — then writes the result back once. Templates
 /// ship most supersede keys as an empty line to fill; when a key is absent
 /// entirely (e.g. BDR/PRD templates have no `supersedes` line), it is
-/// inserted at the end of the frontmatter block instead.
-fn set_frontmatter_fields(
+/// inserted at the end of the frontmatter block instead. Shared with
+/// `status.rs` (lesson 3717: no duplicated frontmatter-mutation logic).
+pub(crate) fn set_frontmatter_fields(
     store: &dyn DocStore,
     path: &Path,
     fields: &[(&str, String)],


### PR DESCRIPTION
## What

Adds `living-docs status <number> <new_status>` — a deterministic CLI verb
that sets a record's `status:` frontmatter field, hardening the recurring
hand-edit into a reproducible command per the project hard rule (*author docs
through the CLI; harden deterministic frontmatter mutations into verbs*).

## Why

Marking an ADR `Accepted` (or `Deprecated`) was a manual frontmatter edit —
error-prone and off-contract with the determinism boundary (ADR 0001). This
promotes that mutation into a verb alongside `supersede`, closing the last
common hand-edit of record frontmatter.

## Scope & behavior

- Accepts the `Proposed` / `Accepted` / `Deprecated` lifecycle.
- Rejects `Superseded` → directs to `supersede`, which also wires the
  `supersedes` / `superseded_by` links (never a bare status flip).
- Rejects unknown values with a non-success exit code.
- Idempotent: re-running with the same status leaves the file byte-identical.
- Reuses `supersede`'s frontmatter helpers (`parse_record_number`,
  `find_record`, `set_frontmatter_fields`), promoted to `pub(crate)`.

## Tests

- **Core crate:** unit tests asserting `ExitCode` on both the success and the
  error path (kills the `run -> Default::default()` mutant — cargo-mutants
  scores per-crate, so cli integration tests don't cover the core wrapper).
- **CLI crate:** integration tests for set, reject-superseded, reject-unknown,
  and byte-identical idempotence.

## Dogfooding

ADRs **0016** and **0017** were moved `Proposed → Accepted` using the new verb
itself. `living-docs check docs` passes (37 docs, no invariant violations).

## Pipeline

Coder → quality-gate → Reviewer, verdict **approved** (7/7 ACs). rustfmt /
clippy / cargo-check / cargo-test green; in-diff mutation survivor addressed.

🤖 Co-authored with Claude Code

Evaldo Klock <neto.nemesis@gmail.com>
