### PR TITLE
feat(enforcement): ship write-gate, session teaching, and pre-commit doc-gate in-repo (ADR 0021/0022)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/skills/living-docs/hooks/block-docs-handwrite.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/skills/living-docs/hooks/session-context.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# pre-commit — living-docs doc-gate (ADR 0021 layer 3).
+#
+# Runs `living-docs check` over the docs bundle so a hand-written or drifted
+# record fails in the authoring session, not at CI. Fail-open when no binary
+# is resolvable (CI still gates); never bypass a real failure with --no-verify.
+
+set -u
+
+ROOT="$(git rev-parse --show-toplevel)"
+BUNDLE="${LIVING_DOCS_BUNDLE:-docs}"
+
+resolve_bin() {
+  if command -v living-docs >/dev/null 2>&1; then
+    command -v living-docs
+  elif [ -x "$ROOT/target/release/living-docs" ]; then
+    printf '%s' "$ROOT/target/release/living-docs"
+  fi
+}
+
+BIN="$(resolve_bin)"
+if [ -z "$BIN" ]; then
+  echo "living-docs pre-commit: no binary found (PATH or target/release) — doc-gate skipped, CI will enforce it. Build with \`make build\`." >&2
+  exit 0
+fi
+
+exec "$BIN" check "$ROOT/$BUNDLE"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,5 +90,11 @@ fronts:
 - Every architectural fork (adapter sync contract, DB schema, web surface) gets an ADR via
   `living-docs new adr "..."` **before** code. Decide, then implement.
 - `living-docs check` must pass over `docs/` — it is the doc-gate.
+- **Docs authoring is CLI-first and gate-enforced (ADR 0021).** Write ONLY the body below
+  the closing `---` of a record; numbering, frontmatter, supersede links, and index rows
+  come from `living-docs new`/`status`/`supersede`/`index`/`fmt`. A PreToolUse hook
+  (`.claude/settings.json` → `skills/living-docs/hooks/block-docs-handwrite.sh`) blocks
+  hand-writes under `docs/{adr,bdr,prd,issues}/`, and `.githooks/pre-commit` runs the
+  doc-gate before every commit.
 - Conventional Commits; ticket ID when one exists. No AI attribution in commit messages.
 - Never bypass a failing hook with `--no-verify`; fix the cause.

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ LIVING_DOCS_BIN := target/release/living-docs
 .PHONY: help install install-claude install-cursor install-copilot \
         install-opencode install-codex install-pi install-all install-pocock \
         project-claude project-opencode project-codex project-pi \
-        uninstall uninstall-all check lint test-fixtures version \
+        uninstall uninstall-all check lint test-fixtures test-hooks version \
         cli-dev-image cli-build cli-test cli-fmt cli-clippy build cli-install \
         up down db-up db-psql db-logs db-test
 
@@ -83,7 +83,7 @@ uninstall: ## Remove the global Claude Code install
 uninstall-all: ## Remove the install for every supported harness
 	$(INSTALL) all --uninstall
 
-check: version build test-fixtures ## Check version sync, validate install.sh, run Rust tests, living-docs check + mermaid, dry-run harnesses
+check: version build test-fixtures test-hooks ## Check version sync, validate install.sh, run Rust tests, living-docs check + mermaid, hook fixtures, dry-run harnesses
 	bash -n install.sh
 	bash -n scripts/check-version.sh
 	cargo test --manifest-path cli/Cargo.toml
@@ -93,6 +93,9 @@ check: version build test-fixtures ## Check version sync, validate install.sh, r
 
 test-fixtures: build ## Run the hostile/negative fixtures that guard the check parsers
 	LIVING_DOCS_BIN=$(LIVING_DOCS_BIN) ./skills/living-docs/tests/run.sh
+
+test-hooks: ## Run the write-gate hook fixtures (ADR 0021)
+	./skills/living-docs/tests/hooks/run.sh
 
 version: ## Assert the release version is consistent across VERSION and every SKILL.md
 	./scripts/check-version.sh

--- a/cli/tests/check_core.rs
+++ b/cli/tests/check_core.rs
@@ -68,31 +68,30 @@ fn run_new(docs_dir: &Path, doc_type: &str, title: &str) -> Output {
 
 /// The fixture's `type` value is spread across three files as a double-quoted,
 /// single-quoted, and trailing-commented scalar to prove the type-extraction
-/// invariant tolerates all three forms — a concern independent of ADR 0019's
-/// canonical round-trip check, which now (correctly) flags all three as
-/// hand-written, since none of them matches `living-docs fmt`'s plain,
-/// comment-free output.
+/// invariant tolerates all three forms. Its docs sit at the bundle root, so
+/// the ADR 0019 canonical round-trip check does not apply (ADR 0022 scopes it
+/// to CLI-owned type directories) and the bundle checks clean.
 #[test]
-fn fixture_04_quoted_and_commented_frontmatter_parses_type_but_fails_the_canonical_check() {
+fn fixture_04_quoted_and_commented_frontmatter_parses_type_and_checks_clean() {
     let output = run_check(&fixture("04-frontmatter-quoted-commented"));
     let stdout = stdout_of(&output);
 
-    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(output.status.code(), Some(0), "got:\n{stdout}");
     assert!(!stdout.contains("non-empty 'type'"));
-    assert!(stdout.contains("living-docs fmt"));
+    assert!(!stdout.contains("living-docs fmt"));
 }
 
 /// The fixture's `type: |\n  ADR\n` block scalar proves the type-extraction
-/// invariant tolerates YAML block-scalar syntax, independent of the canonical
-/// check, which (correctly) flags it as non-canonical.
+/// invariant tolerates YAML block-scalar syntax; at the bundle root it is
+/// outside the canonical check's ADR 0022 scope and the bundle checks clean.
 #[test]
-fn fixture_06_block_scalar_type_parses_but_fails_the_canonical_check() {
+fn fixture_06_block_scalar_type_parses_and_checks_clean() {
     let output = run_check(&fixture("06-block-scalar-ok"));
     let stdout = stdout_of(&output);
 
-    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(output.status.code(), Some(0), "got:\n{stdout}");
     assert!(!stdout.contains("non-empty 'type'"));
-    assert!(stdout.contains("living-docs fmt"));
+    assert!(!stdout.contains("living-docs fmt"));
 }
 
 #[test]

--- a/docs/adr/0021-enforcement-layers-ship-with-the-repo-write-gate-hook-session-teaching-and-pre-commit-doc-gate.md
+++ b/docs/adr/0021-enforcement-layers-ship-with-the-repo-write-gate-hook-session-teaching-and-pre-commit-doc-gate.md
@@ -1,0 +1,96 @@
+---
+type: ADR
+title: "Enforcement layers ship with the repo: write-gate hook, session teaching, and pre-commit doc-gate"
+description: Ship the ADR 0019 enforcement layers inside this repository — a versioned write-gate hook in the skill bundle wired via .claude/settings.json, a SessionStart hook that injects the body-only rule at t=0, and a pre-commit doc-gate — instead of depending on an externally installed enforcer plugin.
+status: Accepted
+tags: [check, cli, enforcement, hooks, tokens]
+timestamp: 2026-07-29T01:51:15Z
+---
+
+# 0021. Enforcement layers ship with the repo: write-gate hook, session teaching, and pre-commit doc-gate
+
+## Context
+
+ADR 0019 established three enforcement layers for the CLI-owns-the-mechanics rule, and
+ADR 0020 scoped the write-time layer to the four CLI-owned type directories. Two of the
+three layers (the canonical round-trip in `check`/`fmt`, the point-of-use teaching in
+`new` and `--help`) live in this repository. The decisive layer — the PreToolUse hook
+that blocks a hand-write *before* the tokens are spent — lives only in the
+`living-docs-enforcer` plugin in the external `ai-configs` repository.
+
+Dogfooding shows the consequence: any session that has not installed that plugin
+(fresh clones, web agents, CI agents, other harnesses) runs with zero write-time
+enforcement, and agents keep authoring whole records by hand. The two in-repo layers
+fire post-hoc: by the time `check` flags a hand-written record, the tokens for the
+frontmatter, the numbering, and the index row were already spent. The rule's delivery
+is also probabilistic — it sits behind a skill trigger plus a `--topic` load — while
+the agent's decision to Write happens before either.
+
+The constraint from ADR 0019 stands: instructions never block; only gates block.
+The gap is distribution, not design — the gate must travel with the repository.
+
+## Decision
+
+We will ship the enforcement layers inside this repository, harness-wired at the repo
+boundary:
+
+1. **Write-gate hook in the skill bundle.** `block-docs-handwrite.sh` lives at
+   `skills/living-docs/hooks/` — versioned with the skill, testable in this repo's CI —
+   and `.claude/settings.json` wires it as a PreToolUse hook on `Write|Edit|MultiEdit`.
+   It enforces the three ADR 0019 block rules under the ADR 0020 directory scope
+   (`adr|bdr|prd|issues` under the bundle), honors `LIVING_DOCS_ENFORCE=block|warn`
+   (default `block`), and fails open on any ambiguity.
+2. **Session teaching hook.** `session-context.sh` (same bundle directory) runs on
+   SessionStart: it emits the body-only rule plus the resolved CLI binary path into the
+   session context unconditionally — closing the disclosure gap deterministically at
+   t=0 instead of probabilistically behind a skill trigger — and points `core.hooksPath`
+   at `.githooks/` when that directory exists.
+3. **Pre-commit doc-gate.** `.githooks/pre-commit` runs `living-docs check <bundle>`
+   with the resolved binary, so a hand-written record that slipped past the write gate
+   fails in the same session it was authored, not at CI. When no binary is resolvable
+   the gate skips with a notice (fail-open; CI still gates).
+
+The external enforcer plugin remains valid for consumers; this decision makes the repo
+self-enforcing without it. The hard-rules template gains the wiring snippet so consumer
+projects can adopt the same layers.
+
+## Consequences
+
+**Easier / gained:**
+- A hand-write inside a CLI-owned directory fails at the tool call in any Claude Code
+  session of this repo, with the correct verb named — no tokens spent on frontmatter,
+  numbering, or index rows the CLI generates for free.
+- The body-only rule reaches every session deterministically via SessionStart, instead
+  of depending on skill triggering.
+- The hook is versioned and tested alongside the skill it enforces, in one CI.
+
+**Harder / accepted trade-offs:**
+- The block rules now exist in two places (this repo and the enforcer plugin); the
+  plugin remains the distribution for non-repo contexts. Accepted: both mirror the same
+  ADR 0019/0020 contract, and this repo's fixture tests pin the behavior.
+- `.claude/settings.json` binds this repo to Claude Code hook semantics; other
+  harnesses rely on the pre-commit and CI gates only. Accepted: fail-open by design.
+- Sessions started before this change do not pick up the hooks (hook wiring snapshots
+  at session start).
+
+**Follow-ups:**
+- A `living-docs hooks install` verb so consumer projects wire the same layers through
+  the CLI instead of copying files by hand.
+
+## Verification
+
+**Implementation impact:** `skills/living-docs/hooks/{block-docs-handwrite.sh,session-context.sh}`,
+`.claude/settings.json`, `.githooks/pre-commit`,
+`skills/living-docs/tests/hooks/test-block-docs-handwrite.sh`, `Makefile` (`test-hooks`
+target inside `check`), `skills/living-docs/templates/claude-hard-rules.md` (rule 10).
+
+**Verification criteria:**
+- A `Write` creating `docs/adr/NNNN-*.md`, a write to `docs/adr/index.md`, and an
+  `Edit` touching a CLI-owned frontmatter key in a record each exit 2 naming the
+  correct verb; body, `description`, and `tags` edits exit 0; a `status:` line inside
+  a body code fence exits 0; paths under `docs/research/` and the bundle-root
+  `docs/index.md` exit 0 (ADR 0020 scope).
+- `LIVING_DOCS_ENFORCE=warn` turns every block into a stderr notice with exit 0; a
+  missing `jq` or unparsable payload exits 0 (fail-open).
+- Fitness function: `make test-hooks` (run by `make check`) passes all fixture
+  sections.

--- a/docs/adr/0022-canonical-frontmatter-check-is-scoped-to-cli-owned-type-directories.md
+++ b/docs/adr/0022-canonical-frontmatter-check-is-scoped-to-cli-owned-type-directories.md
@@ -1,0 +1,65 @@
+---
+type: ADR
+title: Canonical frontmatter check is scoped to CLI-owned type directories
+description: Apply the ADR 0020 category fix to the ADR 0019 canonical round-trip check — it flags non-canonical frontmatter only for records directly inside the four CLI-owned type directories, leaving hand-authored docs (research, bundle-root notes) free-form.
+status: Accepted
+tags: [check, cli, enforcement, frontmatter]
+timestamp: 2026-07-29T01:57:27Z
+---
+
+# 0022. Canonical frontmatter check is scoped to CLI-owned type directories
+
+## Context
+
+The ADR 0019 canonical round-trip check (`check_canonical_frontmatter`) flags any record
+whose frontmatter block deviates from its canonical re-serialization, naming
+`living-docs fmt` as remediation. As landed, it runs over **every** non-reserved record
+in the bundle. Dogfooding surfaced the mis-fire the moment it met the repo's own
+hostile fixtures: `04-frontmatter-quoted-commented` and `06-block-scalar-ok` exist to
+prove that *valid but non-canonical* YAML (quoted values, inline comments, block
+scalars) is read correctly — and the bundle-wide canonical check now fails them,
+breaking `make check` on a clean tree.
+
+This is the same category error ADR 0020 corrected for the write-time hook: "inside
+the bundle" is not "CLI-owned". Canonical form is a property of CLI *output*; the CLI
+scaffolds only the four type directories (`paths::doc_type_for_dir` is the source of
+truth). Hand-authored docs — `research` records, bundle-root notes — never came from a
+CLI verb, so demanding they byte-match one is unactionable in the ADR 0020 sense, even
+if `fmt` could technically rewrite them.
+
+## Decision
+
+We will scope `check_canonical_frontmatter` to records **directly inside a CLI-owned
+type directory** — a record whose parent directory name resolves through
+`paths::doc_type_for_dir` (`adr`, `bdr`, `prd`, `issues`). Every other record with a
+frontmatter block is skipped by this check; the ordinary frontmatter invariants
+(non-empty `type`, supersede symmetry, indexing) continue to cover it. This mirrors,
+in the check layer, exactly the scope ADR 0020 gave the write-time hook, and amends
+ADR 0020's statement that the round-trip check was "unchanged".
+
+## Consequences
+
+**Easier / gained:**
+- `make check` is green again on a clean tree: fixtures 04/06 pass because their docs
+  sit at the bundle root, outside any CLI-owned directory.
+- The check, the write-time hook, and `paths` now agree on one definition of
+  CLI-owned, keyed off the same mapping.
+
+**Harder / accepted trade-offs:**
+- A hand-authored record outside the four directories can carry non-canonical
+  frontmatter indefinitely. Accepted: that is the definition of hand-authored; there
+  is no CLI verb whose output it should match.
+
+**Follow-ups:**
+- None.
+
+## Verification
+
+**Implementation impact:** `living-docs-core/src/check/canonical.rs` (scope guard +
+unit tests).
+
+**Verification criteria:**
+- A non-canonical record under `adr/`, `bdr/`, `prd/`, or `issues/` is flagged; the
+  same content under `research/` or the bundle root is not.
+- Fitness function: `make test-fixtures` passes 04/06 again, and the canonical.rs unit
+  tests pin both sides of the scope.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -27,6 +27,8 @@ repo teaches. The decision *log* is this listing plus each record's `status` /
 * [0017 — SKILL.md stubs are pure routers; the spine and all detail move to CLI topics](0017-skill-md-stubs-are-pure-routers-the-spine-and-all-detail-move-to-cli-topics.md) - Accepted
 * [0018 — Atlas delete is a soft-delete, scoped to non-decision doc types, refused on inbound relations](0018-atlas-delete-is-a-soft-delete-scoped-to-non-decision-doc-types-refused-on-inbound-relations.md) - Accepted
 * [0020 — Hand-write hook is scoped to CLI-owned type directories, not the whole bundle](0020-hand-write-hook-is-scoped-to-cli-owned-type-directories-not-the-whole-bundle.md) - Accepted
+* [0021 — Enforcement layers ship with the repo: write-gate hook, session teaching, and pre-commit doc-gate](0021-enforcement-layers-ship-with-the-repo-write-gate-hook-session-teaching-and-pre-commit-doc-gate.md) - Accepted
+* [0022 — Canonical frontmatter check is scoped to CLI-owned type directories](0022-canonical-frontmatter-check-is-scoped-to-cli-owned-type-directories.md) - Accepted
 
 ## Superseded
 

--- a/examples/linkly/docs/adr/0001-in-memory-store.md
+++ b/examples/linkly/docs/adr/0001-in-memory-store.md
@@ -3,7 +3,6 @@ type: ADR
 title: In-memory store for minted links
 description: Store links in a process-local map for the first prototype.
 status: Superseded
-supersedes:
 superseded_by: 0002
 tags: [storage]
 timestamp: 2026-06-20T00:00:00Z

--- a/examples/linkly/docs/adr/0002-sqlite-store.md
+++ b/examples/linkly/docs/adr/0002-sqlite-store.md
@@ -4,7 +4,6 @@ title: SQLite store for minted links
 description: Persist links in a single-file SQLite database so they survive restarts.
 status: Accepted
 supersedes: 0001
-superseded_by:
 tags: [storage]
 timestamp: 2026-06-20T00:00:00Z
 ---

--- a/examples/linkly/docs/bdr/0001-shorten-and-redirect.md
+++ b/examples/linkly/docs/bdr/0001-shorten-and-redirect.md
@@ -3,7 +3,6 @@ type: BDR
 title: Shorten & redirect
 description: Mint a short code for a valid URL and redirect that code to the original.
 status: Accepted
-superseded_by:
 tags: [phase-1]
 timestamp: 2026-06-20T00:00:00Z
 ---

--- a/examples/linkly/docs/context/domain-concepts.md
+++ b/examples/linkly/docs/context/domain-concepts.md
@@ -1,6 +1,6 @@
 ---
 type: Context
-title: "Domain concepts"
+title: Domain concepts
 description: Core domain entities and rules for Linkly.
 tags: [domain, vocabulary]
 timestamp: 2026-06-20T00:00:00Z

--- a/examples/linkly/docs/context/glossary.md
+++ b/examples/linkly/docs/context/glossary.md
@@ -1,8 +1,8 @@
 ---
 type: Context
-title: "Glossary"
+title: Glossary
 description: Terms and acronyms used across the Linkly docs.
-tags: [glossary, vocabulary, context]
+tags: [context, glossary, vocabulary]
 timestamp: 2026-06-20T00:00:00Z
 ---
 

--- a/examples/linkly/docs/issues/0001-implement-shorten-endpoint.md
+++ b/examples/linkly/docs/issues/0001-implement-shorten-endpoint.md
@@ -5,7 +5,6 @@ description: Build the two Phase 1 endpoints against the SQLite store.
 status: open
 labels: [phase-1, backend]
 blocked_by: []
-tracker:
 timestamp: 2026-06-20T00:00:00Z
 ---
 

--- a/examples/linkly/docs/prd/0001-link-shortening.md
+++ b/examples/linkly/docs/prd/0001-link-shortening.md
@@ -3,7 +3,6 @@ type: PRD
 title: Link shortening & redirect
 description: Mint a short code for a URL and redirect that code back to the original.
 status: Accepted
-superseded_by:
 tags: [phase-1]
 timestamp: 2026-06-20T00:00:00Z
 ---

--- a/living-docs-core/src/check/canonical.rs
+++ b/living-docs-core/src/check/canonical.rs
@@ -13,24 +13,38 @@
 use super::records::is_reserved;
 use super::{file_name_str, Reporter};
 use crate::frontmatter::frontmatter_block;
+use crate::paths::doc_type_for_dir;
 use crate::record::{extract_record, to_canonical_markdown};
 use crate::store::DocStore;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 const NON_CANONICAL_MESSAGE: &str =
     "non-canonical (hand-written?) frontmatter — run `living-docs fmt` or author via the CLI verbs";
 
-/// Flags every non-reserved record in `all_md` whose on-disk frontmatter
-/// block differs from its canonical re-serialization. A record carrying no
-/// frontmatter block at all is the existing untyped-doc check's concern and
-/// is skipped here.
+/// True when the record sits directly inside one of the CLI-owned type
+/// directories (`paths::doc_type_for_dir` — ADR 0020's scope, applied to the
+/// check layer by ADR 0022). Only those records are scaffolded by `new`, so
+/// only they can be expected to byte-match canonical serialization.
+fn in_cli_owned_dir(path: &Path) -> bool {
+    path.parent()
+        .and_then(Path::file_name)
+        .and_then(|name| name.to_str())
+        .and_then(doc_type_for_dir)
+        .is_some()
+}
+
+/// Flags every non-reserved record inside a CLI-owned type directory whose
+/// on-disk frontmatter block differs from its canonical re-serialization.
+/// Hand-authored records (research, bundle-root notes) are out of scope, and
+/// a record carrying no frontmatter block at all is the existing untyped-doc
+/// check's concern — both are skipped here.
 pub(crate) fn check_canonical_frontmatter(
     store: &dyn DocStore,
     all_md: &[PathBuf],
     reporter: &mut Reporter,
 ) {
     for path in all_md {
-        if is_reserved(&file_name_str(path)) {
+        if is_reserved(&file_name_str(path)) || !in_cli_owned_dir(path) {
             continue;
         }
         let Ok(contents) = store.read(path) else {
@@ -121,8 +135,35 @@ mod tests {
     }
 
     #[test]
+    fn check_canonical_frontmatter_skips_records_outside_cli_owned_directories() {
+        let commented = "---\ntype: Research\ntitle: Field Notes  # a comment\n---\n\nBody.\n";
+        for path in ["/bundle/research/0001-notes.md", "/bundle/0001-notes.md"] {
+            let (store, all_md) = store_with(path, commented);
+            let mut reporter = Reporter::new();
+
+            check_canonical_frontmatter(&store, &all_md, &mut reporter);
+
+            assert!(reporter.into_violations().is_empty());
+        }
+    }
+
+    #[test]
+    fn check_canonical_frontmatter_flags_every_cli_owned_directory() {
+        let commented = "---\ntype: ADR\ntitle: X  # comment\n---\n\nBody.\n";
+        for dir in ["adr", "bdr", "prd", "issues"] {
+            let path = format!("/bundle/{dir}/0001-doc.md");
+            let (store, all_md) = store_with(&path, commented);
+            let mut reporter = Reporter::new();
+
+            check_canonical_frontmatter(&store, &all_md, &mut reporter);
+
+            assert_eq!(reporter.into_violations().len(), 1);
+        }
+    }
+
+    #[test]
     fn check_canonical_frontmatter_skips_a_record_with_no_frontmatter_block() {
-        let (store, all_md) = store_with("/bundle/notes.md", "# Just a heading\n\nBody.\n");
+        let (store, all_md) = store_with("/bundle/adr/notes.md", "# Just a heading\n\nBody.\n");
         let mut reporter = Reporter::new();
 
         check_canonical_frontmatter(&store, &all_md, &mut reporter);
@@ -133,7 +174,7 @@ mod tests {
     #[test]
     fn check_canonical_frontmatter_skips_reserved_files() {
         let commented = "---\ntype: ADR\ntitle: X  # comment\n---\n\nBody.\n";
-        let (store, all_md) = store_with("/bundle/index.md", commented);
+        let (store, all_md) = store_with("/bundle/adr/index.md", commented);
         let mut reporter = Reporter::new();
 
         check_canonical_frontmatter(&store, &all_md, &mut reporter);

--- a/skills/living-docs/hooks/block-docs-handwrite.sh
+++ b/skills/living-docs/hooks/block-docs-handwrite.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# block-docs-handwrite.sh — PreToolUse gate enforcing CLI-owned doc authoring
+# (ADR 0019 block rules, ADR 0020 scope, ADR 0021 in-repo distribution).
+#
+# Reads the Claude Code PreToolUse payload (JSON) on stdin. Inside the four
+# CLI-owned type directories of the docs bundle (adr|bdr|prd|issues) it blocks:
+#   - a Write creating a new NNNN-*.md record    -> `living-docs new`
+#   - any direct write to a type index.md        -> `living-docs index`
+#   - a Write/Edit/MultiEdit whose result changes a CLI-owned frontmatter key
+#     (type, title, status, supersedes, superseded_by, timestamp)
+#                                                -> `living-docs status`/`supersede`/`fmt`
+# The frontmatter guard simulates the change and compares the CLI-owned key
+# lines before vs after, so body prose, `description`, and `tags` stay freely
+# editable — including CLI-owned key names quoted inside body code fences.
+#
+# Env:  LIVING_DOCS_ENFORCE=block|warn (default block)
+#       LIVING_DOCS_BUNDLE=<dir>       (default docs)
+# Exit: 0 allow (also on warn or any ambiguity — fail-open), 2 block.
+
+set -u
+LC_ALL=C
+shopt -u patsub_replacement 2>/dev/null || true
+
+MODE="${LIVING_DOCS_ENFORCE:-block}"
+BUNDLE="${LIVING_DOCS_BUNDLE:-docs}"
+CLI_OWNED_KEYS='type|title|status|supersedes|superseded_by|timestamp'
+
+allow() { exit 0; }
+
+deny() {
+  printf 'living-docs: %s\n' "$1" >&2
+  [ "$MODE" = "warn" ] && exit 0
+  exit 2
+}
+
+deny_frontmatter() {
+  deny "frontmatter keys (${CLI_OWNED_KEYS//|/, }) are CLI-owned — use \`living-docs status <NNNN> <Status>\`, \`living-docs supersede <old> <new>\`, or \`living-docs fmt\`. Edit ONLY the body below the closing ---."
+}
+
+json_field() {
+  jq -r "$1 // empty" <<<"$INPUT" 2>/dev/null || printf ''
+}
+
+frontmatter_of() {
+  awk 'NR==1 { if ($0 != "---") exit; next } $0 == "---" { exit } { print }' <<<"$1"
+}
+
+owned_lines_of() {
+  frontmatter_of "$1" | grep -E "^(${CLI_OWNED_KEYS}):" || true
+}
+
+deny_unless_owned_lines_kept() {
+  local before="$1" after="$2"
+  [ "$(owned_lines_of "$before")" = "$(owned_lines_of "$after")" ] || deny_frontmatter
+}
+
+apply_edit() {
+  local content="$1" old="$2" new="$3" replace_all="$4"
+  if [ "$replace_all" = "true" ]; then
+    printf '%s' "${content//"$old"/$new}"
+  else
+    printf '%s' "${content/"$old"/$new}"
+  fi
+}
+
+guard_write() {
+  if [ ! -e "$FILE" ]; then
+    deny "records are scaffolded by the CLI — run \`living-docs new <adr|bdr|prd|issue> \"<title>\"\` (numbering + frontmatter + skeleton), then write ONLY the body below the closing ---. Binary missing? \`make build\`."
+  fi
+  deny_unless_owned_lines_kept "$(cat "$FILE")" "$(json_field '.tool_input.content')"
+}
+
+guard_edit() {
+  local content old new
+  old="$(json_field '.tool_input.old_string')"
+  new="$(json_field '.tool_input.new_string')"
+  [ -n "$old" ] || return 0
+  content="$(cat "$FILE" 2>/dev/null)" || return 0
+  case "$content" in *"$old"*) ;; *) return 0 ;; esac
+  deny_unless_owned_lines_kept "$content" \
+    "$(apply_edit "$content" "$old" "$new" "$(json_field '.tool_input.replace_all')")"
+}
+
+guard_multi_edit() {
+  local content updated count i old new
+  content="$(cat "$FILE" 2>/dev/null)" || return 0
+  updated="$content"
+  count="$(jq '.tool_input.edits | length' <<<"$INPUT" 2>/dev/null)"
+  case "$count" in '' | *[!0-9]*) return 0 ;; esac
+  i=0
+  while [ "$i" -lt "$count" ]; do
+    old="$(json_field ".tool_input.edits[$i].old_string")"
+    new="$(json_field ".tool_input.edits[$i].new_string")"
+    if [ -n "$old" ]; then
+      updated="$(apply_edit "$updated" "$old" "$new" "$(json_field ".tool_input.edits[$i].replace_all")")"
+    fi
+    i=$((i + 1))
+  done
+  deny_unless_owned_lines_kept "$content" "$updated"
+}
+
+command -v jq >/dev/null 2>&1 || allow
+INPUT="$(cat 2>/dev/null)" || allow
+TOOL="$(json_field '.tool_name')"
+FILE="$(json_field '.tool_input.file_path')"
+[ -n "$FILE" ] || allow
+
+[[ "$FILE" =~ (^|/)"$BUNDLE"/(adr|bdr|prd|issues)/([^/]+)$ ]] || allow
+NAME="${BASH_REMATCH[3]}"
+
+if [ "$NAME" = "index.md" ]; then
+  deny "type indexes are generated — run \`living-docs index\` instead of writing $NAME by hand."
+fi
+
+[[ "$NAME" =~ ^[0-9]{4}-.*\.md$ ]] || allow
+
+case "$TOOL" in
+Write) guard_write ;;
+Edit) guard_edit ;;
+MultiEdit) guard_multi_edit ;;
+esac
+
+allow

--- a/skills/living-docs/hooks/session-context.sh
+++ b/skills/living-docs/hooks/session-context.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# session-context.sh — SessionStart hook for the living-docs authoring contract
+# (ADR 0021 layer 2: deterministic point-of-use teaching).
+#
+# Emits one context line stating the body-only rule and the resolved CLI binary,
+# so every session receives the rule at t=0 instead of behind a skill trigger.
+# Also points core.hooksPath at .githooks/ when the repo ships one, arming the
+# pre-commit doc-gate. Always exits 0.
+
+set -u
+
+ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+
+resolve_bin() {
+  if command -v living-docs >/dev/null 2>&1; then
+    command -v living-docs
+  elif [ -x "$ROOT/target/release/living-docs" ]; then
+    printf '%s' "$ROOT/target/release/living-docs"
+  fi
+}
+
+arm_githooks() {
+  [ -d "$ROOT/.githooks" ] || return 0
+  git -C "$ROOT" config core.hooksPath .githooks 2>/dev/null || true
+}
+
+arm_githooks
+
+BIN="$(resolve_bin)"
+if [ -n "$BIN" ]; then
+  BIN_NOTE="CLI: $BIN"
+else
+  BIN_NOTE="CLI not built — run \`make build\` (or \`cargo build --release --manifest-path cli/Cargo.toml\`) before authoring docs"
+fi
+
+printf 'living-docs: %s. Docs authoring contract: write ONLY the body below the closing --- of a record. Numbering, frontmatter, supersede links, and index rows are CLI-owned — `living-docs new <type> "<title>"`, `living-docs status <NNNN> <Status>`, `living-docs supersede <old> <new>`, `living-docs index`, `living-docs fmt`. Hand-writes to those are blocked by a PreToolUse hook.\n' "$BIN_NOTE"
+
+exit 0

--- a/skills/living-docs/templates/claude-hard-rules.md
+++ b/skills/living-docs/templates/claude-hard-rules.md
@@ -94,3 +94,11 @@ The dividing line is determinism: any documentation step with a single correct o
 - Use the CLI verb for every mechanical step: `living-docs new <type> "<title>"` (number + frontmatter + skeleton), `living-docs supersede <old> <new>` (wires `supersedes`/`superseded_by` + status on both records), `living-docs index [type]` (regenerates the index), `living-docs check` (the doc-gate, must pass), `living-docs export`/`brief` (byte-stable materialization / pre-filled scaffold).
 - Write the body prose directly — there is no paragraph-editing verb, because wrapping a text edit in the CLI adds no determinism. Editing the body is a normal edit; hand-numbering a doc, hand-writing frontmatter, hand-maintaining an index row, or hand-wiring supersede links is a process error.
 - When a deterministic frontmatter mutation has no verb yet (e.g. set status, add a tag) and it keeps being done by hand, harden it into a new CLI verb rather than normalizing the hand-edit.
+
+**Write ONLY the body below the closing `---`.** Numbering, frontmatter (`type`, `title`, `status`, `supersedes`, `superseded_by`, `timestamp`), and index rows are CLI-owned; `description` and `tags` are yours.
+
+This rule is enforced by gates, not prose (instructions never block; only gates block). Wire them once per project:
+
+- **Write-time gate (Claude Code):** copy `skills/living-docs/hooks/block-docs-handwrite.sh` from the living-docs repo into the project and register it in `.claude/settings.json` as a `PreToolUse` hook on `Write|Edit|MultiEdit`. It blocks hand-writes to CLI-owned frontmatter keys, new `NNNN-*.md` records, and type `index.md` files, naming the correct verb. Knobs: `LIVING_DOCS_ENFORCE=block|warn`, `LIVING_DOCS_BUNDLE=<dir>`.
+- **Session teaching:** register `skills/living-docs/hooks/session-context.sh` as a `SessionStart` hook so every session receives this rule and the resolved CLI path at start.
+- **Commit-time gate:** a `pre-commit` hook running `living-docs check <bundle>` (see `.githooks/pre-commit` in the living-docs repo), so a hand-written record fails in the session that authored it, not at CI.

--- a/skills/living-docs/tests/hooks/run.sh
+++ b/skills/living-docs/tests/hooks/run.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+#
+# run.sh — fixture tests for the block-docs-handwrite PreToolUse hook
+# (ADR 0021 verification criteria; ADR 0019 block rules under ADR 0020 scope).
+#
+# Each case feeds a synthetic PreToolUse JSON payload to the hook against a
+# throwaway docs bundle and asserts the exit code AND a message substring
+# (present on stderr for blocks, absent for allows).
+#
+# Exit: 0 = all cases pass, 1 = at least one failed.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$HERE/../../hooks/block-docs-handwrite.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+unset LIVING_DOCS_ENFORCE LIVING_DOCS_BUNDLE
+
+RECORD="$TMP/docs/adr/0001-test-decision.md"
+mkdir -p "$TMP/docs/adr" "$TMP/docs/research" "$TMP/src"
+cat >"$RECORD" <<'EOF'
+---
+type: ADR
+title: Test decision
+description: A fixture record.
+status: Proposed
+tags: [fixture]
+timestamp: 2026-01-01T00:00:00Z
+---
+
+# 0001. Test decision
+
+## Context
+
+Body prose mentioning frontmatter in passing.
+
+```yaml
+status: Rejected
+type: Example
+```
+
+## Decision
+
+We will keep this fixture minimal.
+EOF
+printf '# ADR index\n' >"$TMP/docs/adr/index.md"
+printf '# Docs\n' >"$TMP/docs/index.md"
+
+fail=0
+
+payload_write() { # payload_write <file> <content>
+	jq -n --arg f "$1" --arg c "$2" \
+		'{tool_name: "Write", tool_input: {file_path: $f, content: $c}}'
+}
+
+payload_edit() { # payload_edit <file> <old> <new>
+	jq -n --arg f "$1" --arg o "$2" --arg n "$3" \
+		'{tool_name: "Edit", tool_input: {file_path: $f, old_string: $o, new_string: $n}}'
+}
+
+run_case() { # run_case <name> <expected_exit> <present|absent> <substring> <env...> -- <payload>
+	local name="$1" exp="$2" mode="$3" sub="$4"
+	shift 4
+	local envs=()
+	while [[ "$1" != "--" ]]; do
+		envs+=("$1")
+		shift
+	done
+	shift
+	local out rc ok=1
+	out="$(printf '%s' "$1" | env "${envs[@]}" bash "$HOOK" 2>&1)"
+	rc=$?
+	[[ "$rc" == "$exp" ]] || ok=0
+	if [[ "$mode" == "present" ]]; then
+		grep -qF -- "$sub" <<<"$out" || ok=0
+	else
+		grep -qF -- "$sub" <<<"$out" && ok=0
+	fi
+	if ((ok == 1)); then
+		printf '  ok    %s\n' "$name"
+	else
+		printf '  FAIL  %s — exit %s (expected %s), expected %s: "%s"\n' \
+			"$name" "$rc" "$exp" "$mode" "$sub"
+		printf '%s\n' "$out" | sed 's/^/          | /'
+		fail=1
+	fi
+}
+
+echo "block-docs-handwrite hook fixtures"
+echo
+
+run_case new-record-write-blocked 2 present "living-docs new" _=1 -- \
+	"$(payload_write "$TMP/docs/adr/0002-new-thing.md" $'---\ntype: ADR\n---\nbody')"
+run_case type-index-write-blocked 2 present "living-docs index" _=1 -- \
+	"$(payload_write "$TMP/docs/adr/index.md" '# ADR index')"
+run_case owned-key-edit-blocked 2 present "CLI-owned" _=1 -- \
+	"$(payload_edit "$RECORD" 'status: Proposed' 'status: Accepted')"
+run_case owned-value-edit-blocked 2 present "CLI-owned" _=1 -- \
+	"$(payload_edit "$RECORD" 'Proposed' 'Accepted')"
+run_case timestamp-rewrite-blocked 2 present "CLI-owned" _=1 -- \
+	"$(payload_write "$RECORD" "$(sed 's/^timestamp:.*/timestamp: 2027-01-01T00:00:00Z/' "$RECORD")")"
+
+run_case body-edit-allowed 0 absent "living-docs" _=1 -- \
+	"$(payload_edit "$RECORD" 'keep this fixture minimal' 'keep this fixture tiny')"
+run_case description-edit-allowed 0 absent "living-docs" _=1 -- \
+	"$(payload_edit "$RECORD" 'description: A fixture record.' 'description: A better fixture record.')"
+run_case tags-edit-allowed 0 absent "living-docs" _=1 -- \
+	"$(payload_edit "$RECORD" 'tags: [fixture]' 'tags: [fixture, hooks]')"
+run_case fenced-status-edit-allowed 0 absent "living-docs" _=1 -- \
+	"$(payload_edit "$RECORD" 'status: Rejected' 'status: Retired')"
+run_case same-frontmatter-rewrite-allowed 0 absent "living-docs" _=1 -- \
+	"$(payload_write "$RECORD" "$(cat "$RECORD")")"
+
+run_case research-record-allowed 0 absent "living-docs" _=1 -- \
+	"$(payload_write "$TMP/docs/research/0003-notes.md" $'---\ntype: Research\n---\nbody')"
+run_case bundle-root-index-allowed 0 absent "living-docs" _=1 -- \
+	"$(payload_write "$TMP/docs/index.md" '# Docs')"
+run_case non-docs-path-allowed 0 absent "living-docs" _=1 -- \
+	"$(payload_write "$TMP/src/main.rs" 'fn main() {}')"
+
+run_case warn-mode-allows-with-notice 0 present "CLI-owned" LIVING_DOCS_ENFORCE=warn -- \
+	"$(payload_edit "$RECORD" 'status: Proposed' 'status: Accepted')"
+run_case custom-bundle-scoped 2 present "living-docs new" LIVING_DOCS_BUNDLE=documentation -- \
+	"$(payload_write "$TMP/documentation/adr/0002-x.md" 'body')"
+run_case garbage-payload-fails-open 0 absent "living-docs" _=1 -- \
+	'not json at all'
+
+multi_bad="$(jq -n --arg f "$RECORD" '{tool_name: "MultiEdit", tool_input: {file_path: $f, edits: [
+	{old_string: "fixture minimal", new_string: "fixture small"},
+	{old_string: "status: Proposed", new_string: "status: Accepted"}]}}')"
+run_case multiedit-owned-key-blocked 2 present "CLI-owned" _=1 -- "$multi_bad"
+
+multi_ok="$(jq -n --arg f "$RECORD" '{tool_name: "MultiEdit", tool_input: {file_path: $f, edits: [
+	{old_string: "fixture minimal", new_string: "fixture small"},
+	{old_string: "Body prose", new_string: "Prose"}]}}')"
+run_case multiedit-body-allowed 0 absent "living-docs" _=1 -- "$multi_ok"
+
+echo
+if ((fail == 0)); then
+	echo "All hook fixtures passed."
+	exit 0
+else
+	echo "Hook fixture failures."
+	exit 1
+fi


### PR DESCRIPTION
## Why

Agents keep hand-writing whole records — frontmatter, numbering, index rows — instead of letting the CLI generate them, burning tokens on deterministic output. The diagnosis (ADR 0021 Context): the only write-time gate lived in the external `living-docs-enforcer` plugin (almost never installed), and the body-only rule sat behind a probabilistic skill trigger. Instructions never block; only gates block — and the gates didn't travel with the repo.

## What

**ADR 0021 — enforcement layers ship with the repo:**

- **Write-time gate** (`skills/living-docs/hooks/block-docs-handwrite.sh`, wired via `.claude/settings.json` as a `PreToolUse` hook on `Write|Edit|MultiEdit`). Under `docs/{adr,bdr,prd,issues}` it blocks: creating a new `NNNN-*.md` by hand (→ `living-docs new`), writing a type `index.md` (→ `living-docs index`), and any change to a CLI-owned frontmatter key (→ `living-docs status`/`supersede`/`fmt`). The frontmatter guard **simulates the edit and diffs the CLI-owned key lines before/after**, so body prose, `description`, `tags`, and fenced `status:` mentions stay freely editable — and sneaky value-only edits are still caught. Knobs: `LIVING_DOCS_ENFORCE=block|warn`, `LIVING_DOCS_BUNDLE`; fail-open on any ambiguity (missing `jq`, garbage payload).
- **Session teaching** (`session-context.sh`, `SessionStart`): emits the body-only rule + resolved CLI path into context at t=0 — deterministic delivery instead of hoping the skill triggers — and arms `core.hooksPath` → `.githooks/`.
- **Pre-commit doc-gate** (`.githooks/pre-commit`): runs `living-docs check` over the bundle so a hand-written record fails in the authoring session, not at CI; skips fail-open when no binary is resolvable.
- **Fixture suite**: `make test-hooks` (18 cases, run by `make check`) pins block/allow/warn/fail-open behavior per the ADR 0021 verification criteria.
- Hard-rules template rule 10 gains the body-only rule and the wiring instructions for consumer projects; `CLAUDE.md` states the gate for this repo.

**ADR 0022 — canonical check scoped to CLI-owned dirs (fixes a pre-existing red `make check`):**

Dogfooding surfaced that the ADR 0019 canonical round-trip check ran bundle-wide, failing hostile fixtures 04/06 (valid-but-non-canonical YAML at the bundle root) — the same category error ADR 0020 fixed for the hook. `check_canonical_frontmatter` now covers only records directly inside `adr|bdr|prd|issues` (keyed off `paths::doc_type_for_dir`), with unit tests pinning both sides of the scope. The `check_core.rs` integration tests that asserted the bundle-wide behavior are updated, and the linkly example corpus is canonicalized via `living-docs fmt`.

Both ADRs were authored through the CLI (`new` → body edit → `status` → `index`), and the new pre-commit gate ran on this PR's own commit.

## Verification

- `make check` green end-to-end (was red on a clean tree before, via fixtures 04/06): version sync, release build, hostile fixtures, **hook fixtures (18/18)**, cargo tests (cli + core), `living-docs check` on the example corpus + mermaid, installer dry-runs.
- `living-docs check docs` — 46 docs, no invariant violations (it caught and `fmt` remediated a non-canonical frontmatter in ADR 0022 during authoring — the loop works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0137Tkn2xoPzsFK5yjYK5VN7

---
_Generated by [Claude Code](https://claude.ai/code/session_0137Tkn2xoPzsFK5yjYK5VN7)_