### PR TITLE
feat: ship hooks through a Claude Code plugin and a living-docs hooks install verb

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "living-docs",
+  "owner": {
+    "name": "Evaldo Klock",
+    "url": "https://github.com/ejklock"
+  },
+  "plugins": [
+    {
+      "name": "living-docs",
+      "source": "./",
+      "description": "Deterministic Living Docs authoring with write-time enforcement gates."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "living-docs",
+  "description": "Deterministic Living Docs authoring: CLI-owned scaffolding, indexing, and write-time enforcement gates.",
+  "version": "0.8.0",
+  "author": {
+    "name": "Evaldo Klock"
+  },
+  "homepage": "https://github.com/ejklock/living-docs-skill",
+  "repository": "https://github.com/ejklock/living-docs-skill",
+  "license": "MIT",
+  "keywords": ["documentation", "adr", "living-docs"]
+}

--- a/.cursor/rules/living-docs.mdc
+++ b/.cursor/rules/living-docs.mdc
@@ -6,7 +6,7 @@ alwaysApply: false
 ---
 name: living-docs
 description: Run a project's documentation as a living system — docs-first issues/PRDs, MADR-lite ADRs (supersede, never delete), Behavior Decision Records (BDRs), a project constitution, research artifacts, living Mermaid architecture diagrams, and semantic-index organization where every doc lands in exactly one place and indexes never drift. Use when setting up or maintaining project docs, writing an ADR/PRD/BDR/constitution/issue/research note, defining a term or acronym in the glossary, drawing or updating an architecture/flow/sequence diagram, splitting an oversized doc into an index, or enforcing the no-drift maintenance rule.
-version: "0.7.0"
+version: "0.8.0"
 metadata:
   type: skill
   layer: procedural
@@ -39,6 +39,8 @@ okf-format, doc-trail, size-targets, about (run --list for the full set).
 This stub is a **pure router** (ADR 0017): it triggers and points at topics — it holds no rules
 inline. The **five core invariants** and the **CLI-owns-the-mechanics hard rule** are topics, not
 stub prose; load them before authoring:
+
+Write ONLY the body below the closing ---. Frontmatter and indexes are CLI-owned: `living-docs status` / `supersede` / `index`. (ADR 0019)
 
 - The five invariants (the spine) → `living-docs skill living-docs --topic spine`.
 - Authoring mechanics — CLI owns every deterministic step, you write only the prose →

--- a/.github/instructions/living-docs.instructions.md
+++ b/.github/instructions/living-docs.instructions.md
@@ -4,7 +4,7 @@ applyTo: "docs/**,**/*.md"
 ---
 name: living-docs
 description: Run a project's documentation as a living system — docs-first issues/PRDs, MADR-lite ADRs (supersede, never delete), Behavior Decision Records (BDRs), a project constitution, research artifacts, living Mermaid architecture diagrams, and semantic-index organization where every doc lands in exactly one place and indexes never drift. Use when setting up or maintaining project docs, writing an ADR/PRD/BDR/constitution/issue/research note, defining a term or acronym in the glossary, drawing or updating an architecture/flow/sequence diagram, splitting an oversized doc into an index, or enforcing the no-drift maintenance rule.
-version: "0.7.0"
+version: "0.8.0"
 metadata:
   type: skill
   layer: procedural
@@ -37,6 +37,8 @@ okf-format, doc-trail, size-targets, about (run --list for the full set).
 This stub is a **pure router** (ADR 0017): it triggers and points at topics — it holds no rules
 inline. The **five core invariants** and the **CLI-owns-the-mechanics hard rule** are topics, not
 stub prose; load them before authoring:
+
+Write ONLY the body below the closing ---. Frontmatter and indexes are CLI-owned: `living-docs status` / `supersede` / `index`. (ADR 0019)
 
 - The five invariants (the spine) → `living-docs skill living-docs --topic spine`.
 - Authoring mechanics — CLI owns every deterministic step, you write only the prose →

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,8 +30,10 @@ change before you invest time.
 ## Repository layout
 
 ```
+.claude-plugin/            Claude Code plugin manifest + marketplace entry (repo root is the plugin bundle)
+hooks/                     hooks.json wiring the plugin's PreToolUse/SessionStart hooks
 skills/
-  living-docs/             the skill: SKILL.md + rules/ + templates/
+  living-docs/             the skill: SKILL.md + rules/ + templates/ + hooks/ (enforcement scripts)
   okf-knowledge-format/    the file format (OKF spec vendored verbatim)
   research-artifacts/      the research-note format
 references/
@@ -41,6 +43,17 @@ cli/                       the living-docs binary (embeds skills/ via rust-embed
 install.sh                 multi-harness installer
 Makefile                   convenience wrapper around install.sh
 ```
+
+The repo root doubles as the **Claude Code plugin bundle**:
+`.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` declare the
+plugin, `hooks/hooks.json` wires its `PreToolUse`/`SessionStart` hooks, and
+`skills/` auto-discovers from the same root — no duplicated layout.
+`skills/living-docs/hooks/` is the **single source of truth** for all three
+enforcement scripts (`block-docs-handwrite.sh`, `session-context.sh`,
+`pre-commit`): the plugin addresses them through `${CLAUDE_PLUGIN_ROOT}` and
+`living-docs hooks install` materializes them from the same embedded corpus
+(ADR 0023). Edit them there — never in a materialized copy under a consumer
+project's `.living-docs/hooks/`.
 
 Each `SKILL.md` is a slim, self-bootstrapping stub: a trigger plus a task->topic
 router. The per-doc-type prose lives in `skills/<name>/rules/*.md` (one file per

--- a/README.md
+++ b/README.md
@@ -151,14 +151,14 @@ make test-fixtures   # run the hostile/negative fixtures guarding the parsers
 
 ### Where each tool loads from
 
-| Tool | Mechanism | Default location (global · `--project`) |
-|---|---|---|
-| **Claude Code** | native `SKILL.md` skills | `~/.claude/skills` · `.claude/skills` |
-| **OpenCode** | native `SKILL.md` skills (also reads `.claude/skills`) | `~/.config/opencode/skills` · `.opencode/skills` |
-| **Codex** | native `SKILL.md` skills | `~/.codex/skills` · `.codex/skills` |
-| **Cursor** | project rule | `.cursor/rules/living-docs.mdc` (project-scoped) |
-| **GitHub Copilot** | path-scoped instruction | `.github/instructions/living-docs.instructions.md` (project-scoped) |
-| **Pi** | skills dir + `AGENTS.md` pointer | `~/.pi/agent/skills` · `.pi/skills` |
+| Tool | Mechanism | Default location (global · `--project`) | Enforcement |
+|---|---|---|---|
+| **Claude Code** | native `SKILL.md` skills | `~/.claude/skills` · `.claude/skills` | Plugin **or** `living-docs hooks install` — write-gate + session teaching + pre-commit |
+| **OpenCode** | native `SKILL.md` skills (also reads `.claude/skills`) | `~/.config/opencode/skills` · `.opencode/skills` | `living-docs hooks install` — pre-commit doc-gate only |
+| **Codex** | native `SKILL.md` skills | `~/.codex/skills` · `.codex/skills` | `living-docs hooks install` — pre-commit doc-gate only |
+| **Cursor** | project rule | `.cursor/rules/living-docs.mdc` (project-scoped) | None — pre-commit + CI only |
+| **GitHub Copilot** | path-scoped instruction | `.github/instructions/living-docs.instructions.md` (project-scoped) | None — pre-commit + CI only |
+| **Pi** | skills dir + `AGENTS.md` pointer | `~/.pi/agent/skills` · `.pi/skills` | `living-docs hooks install` — pre-commit doc-gate only |
 
 **Claude Code**, **OpenCode**, and **Codex** share the same model: they
 auto-discover folders of `SKILL.md` files from their skills directory, so the
@@ -176,6 +176,41 @@ skills/okf-knowledge-format/SKILL.md, and skills/research-artifacts/SKILL.md.
 ```
 
 Then restart the session so the tool picks up the skills.
+
+### Enforcement — write-time gates, not just instructions
+
+`./install.sh` ships **skills only** — it copies markdown instructions and never
+touches a hook script or wires any settings file ([ADR 0023](docs/adr/0023-hooks-ship-through-two-deterministic-channels-an-in-repo-claude-code-plugin-and-a-living-docs-hooks-install-verb.md)).
+The write-gate, the session-teaching hook, and the pre-commit doc-gate are
+distributed through two separate, deterministic channels:
+
+- **Claude Code plugin** (Claude Code only):
+  `/plugin marketplace add ejklock/living-docs-skill` then
+  `/plugin install living-docs@living-docs` (add `--scope project` to commit the
+  choice to the repo). Installs the write-gate (`PreToolUse` on
+  `Write|Edit|MultiEdit`, blocking hand-written docs before they land) and the
+  session-teaching hook (`SessionStart`), both resolved through
+  `${CLAUDE_PLUGIN_ROOT}` so no checkout of this bundle is required.
+- **`living-docs hooks install [--dir <project>] [--docs-dir <bundle>] [--dry-run]`**
+  (every harness): materializes the two hook scripts into `.living-docs/hooks/`,
+  wires `.claude/settings.json` with the resolved bundle pinned as
+  `LIVING_DOCS_BUNDLE=`, and installs the pre-commit doc-gate at
+  `.githooks/pre-commit` (pointing `core.hooksPath` at it). The pre-commit gate
+  is git-level and catches every harness at commit time; the
+  `.claude/settings.json` wiring is what gives Claude Code its write-time gate.
+  Remove everything it wrote with the sibling
+  `living-docs hooks uninstall [--dir <project>] [--dry-run]` — `install` and
+  `uninstall` are separate subcommands, not a flag.
+
+**Cursor and GitHub Copilot have no write-time hook surface at all** — neither
+tool exposes a pre-write hook, so they rely entirely on the pre-commit gate and
+CI to catch a hand-written doc after the fact.
+
+One caveat worth knowing: plugin hooks and `.claude/settings.json` hooks fire
+independently, with no deduplication. Installing both channels in the same
+Claude Code project duplicates the `SessionStart` notice and the (still
+correct) block — an accepted trade-off recorded in
+[ADR 0023](docs/adr/0023-hooks-ship-through-two-deterministic-channels-an-in-repo-claude-code-plugin-and-a-living-docs-hooks-install-verb.md).
 
 ### Skill content — served by the CLI, not copied to disk
 

--- a/cli/src/hooks.rs
+++ b/cli/src/hooks.rs
@@ -4,13 +4,17 @@ use std::borrow::Cow;
 use std::fs;
 use std::io;
 use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 const HOOK_ASSET_PATHS: [&str; 2] = [
     "living-docs/hooks/block-docs-handwrite.sh",
     "living-docs/hooks/session-context.sh",
 ];
+
+const PRE_COMMIT_ASSET_PATH: &str = "living-docs/hooks/pre-commit";
+const GIT_HOOKS_DEST_SUBDIR: &str = ".githooks";
+const GIT_HOOKS_PATH_VALUE: &str = ".githooks";
 
 const HOOKS_DEST_SUBDIR: &str = ".living-docs/hooks";
 const SCRIPT_MODE: u32 = 0o755;
@@ -31,21 +35,29 @@ struct HookEntrySpec {
 }
 
 /// Materializes the corpus hook scripts into `<project_root>/.living-docs/hooks/`
-/// at mode 0755, then wires them into `<project_root>/.claude/settings.json`
+/// at mode 0755, materializes the pre-commit doc-gate to
+/// `<project_root>/.githooks/pre-commit` and points `core.hooksPath` at it,
+/// then wires the two Claude Code hooks into `<project_root>/.claude/settings.json`
 /// via a `serde_json::Value` parse/mutate/serialize merge — idempotently,
 /// replacing any prior living-docs entry by identity rather than appending.
 /// The bundle pinned into each generated command's `LIVING_DOCS_BUNDLE=` is
 /// `docs_dir`, resolved against `project_root` and required to already
 /// exist. Under `dry_run`, reports the same plan on stdout and changes
-/// nothing on disk. A missing embedded asset, a non-existent `docs_dir`, or
-/// a settings file that fails to parse as JSON are hard errors — named on
-/// stderr, no file written, `ExitCode::from(2)`.
+/// nothing on disk — including `core.hooksPath`. A missing embedded asset, a
+/// non-existent `docs_dir`, or a settings file that fails to parse as JSON
+/// are hard errors — named on stderr, no file written, `ExitCode::from(2)`.
+/// A failure setting `core.hooksPath` (e.g. `project_root` is not a git
+/// repository) is only a stderr warning; the verb still succeeds.
 pub(crate) fn install(project_root: &Path, docs_dir: &Path, dry_run: bool) -> ExitCode {
     if let Err(message) = validate_docs_dir(project_root, docs_dir) {
         return report_failure(&message);
     }
     let scripts = match resolve_scripts() {
         Ok(scripts) => scripts,
+        Err(message) => return report_failure(&message),
+    };
+    let pre_commit = match resolve_one(PRE_COMMIT_ASSET_PATH) {
+        Ok(script) => script,
         Err(message) => return report_failure(&message),
     };
     let settings_path = project_root.join(SETTINGS_REL_PATH);
@@ -57,12 +69,17 @@ pub(crate) fn install(project_root: &Path, docs_dir: &Path, dry_run: bool) -> Ex
     apply_hook_entries(&mut settings, &bundle);
     if dry_run {
         announce_dry_run(&scripts);
+        announce_dry_run_pre_commit();
         announce_dry_run_wiring(&settings_path, &bundle);
         return ExitCode::SUCCESS;
     }
     if let Err(err) = write_scripts(project_root, &scripts) {
         return report_failure(&err.to_string());
     }
+    if let Err(err) = write_script_to(&project_root.join(GIT_HOOKS_DEST_SUBDIR), &pre_commit) {
+        return report_failure(&err.to_string());
+    }
+    arm_git_hooks_path(project_root);
     match write_settings(&settings_path, &settings) {
         Ok(()) => {
             println!("wired {}", settings_path.display());
@@ -70,6 +87,37 @@ pub(crate) fn install(project_root: &Path, docs_dir: &Path, dry_run: bool) -> Ex
         }
         Err(err) => report_failure(&err.to_string()),
     }
+}
+
+/// Removes the artifacts [`install`] wrote — the two `.living-docs/hooks/`
+/// scripts, `.githooks/pre-commit`, and the living-docs entries in
+/// `<project_root>/.claude/settings.json` — leaving unrelated entries,
+/// unrelated top-level keys, and `core.hooksPath` untouched. A project
+/// carrying none of these artifacts is a clean no-op: exit 0, nothing
+/// created, nothing deleted. Under `dry_run`, reports the same removal plan
+/// and changes nothing on disk. An existing settings file that fails to
+/// parse as JSON is a hard error, never overwritten.
+pub(crate) fn uninstall(project_root: &Path, dry_run: bool) -> ExitCode {
+    let removable = removable_artifacts(project_root);
+    let settings_path = project_root.join(SETTINGS_REL_PATH);
+    let settings_update = match plan_settings_removal(&settings_path) {
+        Ok(update) => update,
+        Err(message) => return report_failure(&message),
+    };
+    if dry_run {
+        announce_uninstall_dry_run(&removable, settings_update.is_some(), &settings_path);
+        return ExitCode::SUCCESS;
+    }
+    if let Err(err) = remove_artifacts(&removable) {
+        return report_failure(&err.to_string());
+    }
+    if let Some(settings) = settings_update {
+        if let Err(err) = write_settings(&settings_path, &settings) {
+            return report_failure(&err.to_string());
+        }
+        println!("stripped {}", settings_path.display());
+    }
+    ExitCode::SUCCESS
 }
 
 fn validate_docs_dir(project_root: &Path, docs_dir: &Path) -> Result<(), String> {
@@ -105,6 +153,13 @@ fn announce_dry_run(scripts: &[HookScript]) {
     }
 }
 
+fn announce_dry_run_pre_commit() {
+    println!(
+        "[dry-run] would write {GIT_HOOKS_DEST_SUBDIR}/{}",
+        basename_of(PRE_COMMIT_ASSET_PATH)
+    );
+}
+
 fn announce_dry_run_wiring(settings_path: &Path, bundle: &str) {
     println!(
         "[dry-run] would wire {} (LIVING_DOCS_BUNDLE={bundle})",
@@ -118,18 +173,43 @@ fn dest_display(basename: &str) -> String {
 
 fn write_scripts(project_root: &Path, scripts: &[HookScript]) -> io::Result<()> {
     let dest_dir = project_root.join(HOOKS_DEST_SUBDIR);
-    fs::create_dir_all(&dest_dir)?;
     scripts
         .iter()
-        .try_for_each(|script| write_one(&dest_dir, script))
+        .try_for_each(|script| write_script_to(&dest_dir, script))
 }
 
-fn write_one(dest_dir: &Path, script: &HookScript) -> io::Result<()> {
+/// Writes `script` into `dest_dir` (creating it if needed) at [`SCRIPT_MODE`]
+/// — the one write path shared by [`write_scripts`] (`.living-docs/hooks/`)
+/// and [`install`]'s own pre-commit write (`.githooks/`).
+fn write_script_to(dest_dir: &Path, script: &HookScript) -> io::Result<()> {
+    fs::create_dir_all(dest_dir)?;
     let dest = dest_dir.join(script.basename);
     fs::write(&dest, script.bytes.as_ref())?;
     fs::set_permissions(&dest, fs::Permissions::from_mode(SCRIPT_MODE))?;
     println!("wrote {}", dest.display());
     Ok(())
+}
+
+/// Best-effort `git -C project_root config core.hooksPath .githooks`. Any
+/// failure — `project_root` is not a git repository, `git` is unavailable —
+/// is a stderr warning; the installer must still succeed outside a git repo.
+fn arm_git_hooks_path(project_root: &Path) {
+    let outcome = std::process::Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["config", "core.hooksPath", GIT_HOOKS_PATH_VALUE])
+        .output();
+    match outcome {
+        Ok(result) if result.status.success() => {}
+        Ok(result) => warn_hooks_path(String::from_utf8_lossy(&result.stderr).trim()),
+        Err(err) => warn_hooks_path(&err.to_string()),
+    }
+}
+
+fn warn_hooks_path(detail: &str) {
+    eprintln!(
+        "living-docs hooks install: could not set core.hooksPath ({detail}) — the pre-commit doc-gate will not run automatically outside a git repository"
+    );
 }
 
 fn hook_entry_specs() -> [HookEntrySpec; 2] {
@@ -240,8 +320,82 @@ fn write_settings(path: &Path, settings: &Value) -> io::Result<()> {
     fs::write(path, rendered)
 }
 
+fn removable_artifacts(project_root: &Path) -> Vec<PathBuf> {
+    let hooks_dir = project_root.join(HOOKS_DEST_SUBDIR);
+    let mut candidates: Vec<PathBuf> = HOOK_ASSET_PATHS
+        .iter()
+        .map(|asset_path| hooks_dir.join(basename_of(asset_path)))
+        .collect();
+    candidates.push(
+        project_root
+            .join(GIT_HOOKS_DEST_SUBDIR)
+            .join(basename_of(PRE_COMMIT_ASSET_PATH)),
+    );
+    candidates
+        .into_iter()
+        .filter(|path| path.is_file())
+        .collect()
+}
+
+/// `None` when `settings_path` does not exist (untouched, so uninstall stays
+/// a clean no-op) or carries no living-docs entry to strip; `Some` with the
+/// filtered value otherwise.
+fn plan_settings_removal(settings_path: &Path) -> Result<Option<Value>, String> {
+    if !settings_path.is_file() {
+        return Ok(None);
+    }
+    let mut settings = load_settings(settings_path)?;
+    if strip_hook_entries(&mut settings) {
+        Ok(Some(settings))
+    } else {
+        Ok(None)
+    }
+}
+
+fn strip_hook_entries(settings: &mut Value) -> bool {
+    let marker = living_docs_hook_marker();
+    let pre_tool_use_changed = strip_section_entries(settings, PRE_TOOL_USE_SECTION, &marker);
+    let session_start_changed = strip_section_entries(settings, SESSION_START_SECTION, &marker);
+    pre_tool_use_changed || session_start_changed
+}
+
+fn strip_section_entries(settings: &mut Value, section: &str, marker: &str) -> bool {
+    let Some(array) = settings
+        .get_mut("hooks")
+        .and_then(|hooks| hooks.get_mut(section))
+        .and_then(Value::as_array_mut)
+    else {
+        return false;
+    };
+    let before = array.len();
+    array.retain(|entry| !is_living_docs_entry(entry, marker));
+    array.len() != before
+}
+
+fn remove_artifacts(paths: &[PathBuf]) -> io::Result<()> {
+    paths.iter().try_for_each(|path| remove_one(path))
+}
+
+fn remove_one(path: &Path) -> io::Result<()> {
+    fs::remove_file(path)?;
+    println!("removed {}", path.display());
+    Ok(())
+}
+
+fn announce_uninstall_dry_run(removable: &[PathBuf], strips_settings: bool, settings_path: &Path) {
+    for path in removable {
+        println!("[dry-run] would remove {}", path.display());
+    }
+    if strips_settings {
+        println!(
+            "[dry-run] would strip living-docs entries from {}",
+            settings_path.display()
+        );
+    }
+}
+
 fn report_failure(message: &str) -> ExitCode {
-    eprintln!("living-docs hooks install: {message}");
+    eprintln!("living-docs hooks: {message}");
     ExitCode::from(2)
 }
 
@@ -295,5 +449,85 @@ mod tests {
         let mut settings = json!({ "hooks": "not-an-object" });
         let section = ensure_hooks_section(&mut settings, PRE_TOOL_USE_SECTION);
         assert!(section.is_empty());
+    }
+
+    #[test]
+    fn resolve_one_finds_the_embedded_pre_commit_asset() {
+        let script = resolve_one(PRE_COMMIT_ASSET_PATH).expect("pre-commit is embedded");
+        assert_eq!(script.basename, "pre-commit");
+        assert!(script.bytes.starts_with(b"#!"));
+    }
+
+    fn scratch_project(label: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("living-docs-hooks-unit-{label}-{nanos}"));
+        fs::create_dir_all(&dir).expect("create scratch project dir");
+        dir
+    }
+
+    #[test]
+    fn removable_artifacts_is_empty_for_a_project_with_nothing_installed() {
+        let project = scratch_project("removable-empty");
+        assert!(removable_artifacts(&project).is_empty());
+        let _ = fs::remove_dir_all(&project);
+    }
+
+    #[test]
+    fn removable_artifacts_lists_only_the_files_actually_present() {
+        let project = scratch_project("removable-partial");
+        let hooks_dir = project.join(HOOKS_DEST_SUBDIR);
+        fs::create_dir_all(&hooks_dir).unwrap();
+        fs::write(
+            hooks_dir.join("session-context.sh"),
+            b"#!/usr/bin/env bash\n",
+        )
+        .unwrap();
+
+        let artifacts = removable_artifacts(&project);
+
+        assert_eq!(artifacts, vec![hooks_dir.join("session-context.sh")]);
+        let _ = fs::remove_dir_all(&project);
+    }
+
+    #[test]
+    fn strip_hook_entries_removes_only_the_living_docs_entries() {
+        let mut settings = json!({
+            "hooks": {
+                "PreToolUse": [
+                    { "matcher": "Bash", "hooks": [ { "type": "command", "command": "echo custom" } ] },
+                    { "matcher": "Write|Edit|MultiEdit", "hooks": [ { "type": "command", "command": format!("\"$CLAUDE_PROJECT_DIR\"/{}block-docs-handwrite.sh", living_docs_hook_marker()) } ] }
+                ]
+            }
+        });
+
+        let changed = strip_hook_entries(&mut settings);
+
+        assert!(changed);
+        let remaining = settings["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0]["matcher"], "Bash");
+    }
+
+    #[test]
+    fn strip_hook_entries_reports_no_change_when_there_is_nothing_to_strip() {
+        let mut settings = json!({
+            "hooks": {
+                "PreToolUse": [
+                    { "matcher": "Bash", "hooks": [ { "type": "command", "command": "echo custom" } ] }
+                ]
+            }
+        });
+
+        assert!(!strip_hook_entries(&mut settings));
+        assert_eq!(settings["hooks"]["PreToolUse"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn strip_hook_entries_reports_no_change_when_the_hooks_key_is_absent() {
+        let mut settings = json!({ "unrelatedTopLevelKey": "keep-me" });
+        assert!(!strip_hook_entries(&mut settings));
     }
 }

--- a/cli/src/hooks.rs
+++ b/cli/src/hooks.rs
@@ -1,0 +1,102 @@
+use crate::skill;
+use std::borrow::Cow;
+use std::fs;
+use std::io;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::ExitCode;
+
+const HOOK_ASSET_PATHS: [&str; 2] = [
+    "living-docs/hooks/block-docs-handwrite.sh",
+    "living-docs/hooks/session-context.sh",
+];
+
+const HOOKS_DEST_SUBDIR: &str = ".living-docs/hooks";
+const SCRIPT_MODE: u32 = 0o755;
+
+struct HookScript {
+    basename: &'static str,
+    bytes: Cow<'static, [u8]>,
+}
+
+/// Materializes the corpus hook scripts into `<project_root>/.living-docs/hooks/`
+/// at mode 0755, idempotently. Under `dry_run`, reports the same plan on
+/// stdout and writes nothing. A missing embedded asset is a hard error —
+/// named on stderr, no file written, `ExitCode::from(2)`.
+pub(crate) fn install(project_root: &Path, dry_run: bool) -> ExitCode {
+    let scripts = match resolve_scripts() {
+        Ok(scripts) => scripts,
+        Err(message) => return report_failure(&message),
+    };
+    if dry_run {
+        announce_dry_run(&scripts);
+        return ExitCode::SUCCESS;
+    }
+    match write_scripts(project_root, &scripts) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => report_failure(&err.to_string()),
+    }
+}
+
+fn resolve_scripts() -> Result<Vec<HookScript>, String> {
+    HOOK_ASSET_PATHS.into_iter().map(resolve_one).collect()
+}
+
+fn resolve_one(path: &'static str) -> Result<HookScript, String> {
+    let bytes = skill::asset(path).ok_or_else(|| format!("missing embedded asset: {path}"))?;
+    Ok(HookScript {
+        basename: basename_of(path),
+        bytes,
+    })
+}
+
+fn basename_of(path: &'static str) -> &'static str {
+    path.rsplit('/').next().unwrap_or(path)
+}
+
+fn announce_dry_run(scripts: &[HookScript]) {
+    for script in scripts {
+        println!("[dry-run] would write {}", dest_display(script.basename));
+    }
+}
+
+fn dest_display(basename: &str) -> String {
+    format!("{HOOKS_DEST_SUBDIR}/{basename}")
+}
+
+fn write_scripts(project_root: &Path, scripts: &[HookScript]) -> io::Result<()> {
+    let dest_dir = project_root.join(HOOKS_DEST_SUBDIR);
+    fs::create_dir_all(&dest_dir)?;
+    scripts
+        .iter()
+        .try_for_each(|script| write_one(&dest_dir, script))
+}
+
+fn write_one(dest_dir: &Path, script: &HookScript) -> io::Result<()> {
+    let dest = dest_dir.join(script.basename);
+    fs::write(&dest, script.bytes.as_ref())?;
+    fs::set_permissions(&dest, fs::Permissions::from_mode(SCRIPT_MODE))?;
+    println!("wrote {}", dest.display());
+    Ok(())
+}
+
+fn report_failure(message: &str) -> ExitCode {
+    eprintln!("living-docs hooks install: {message}");
+    ExitCode::from(2)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_scripts_finds_both_corpus_assets() {
+        let scripts = resolve_scripts().expect("both hook scripts are embedded");
+        let basenames: Vec<&str> = scripts.iter().map(|script| script.basename).collect();
+        assert_eq!(
+            basenames,
+            vec!["block-docs-handwrite.sh", "session-context.sh"]
+        );
+        assert!(scripts.iter().all(|script| !script.bytes.is_empty()));
+    }
+}

--- a/cli/src/hooks.rs
+++ b/cli/src/hooks.rs
@@ -1,4 +1,5 @@
 use crate::skill;
+use serde_json::{json, Value};
 use std::borrow::Cow;
 use std::fs;
 use std::io;
@@ -13,29 +14,73 @@ const HOOK_ASSET_PATHS: [&str; 2] = [
 
 const HOOKS_DEST_SUBDIR: &str = ".living-docs/hooks";
 const SCRIPT_MODE: u32 = 0o755;
+const SETTINGS_REL_PATH: &str = ".claude/settings.json";
+const PRE_TOOL_USE_SECTION: &str = "PreToolUse";
+const SESSION_START_SECTION: &str = "SessionStart";
+const PRE_TOOL_USE_MATCHER: &str = "Write|Edit|MultiEdit";
 
 struct HookScript {
     basename: &'static str,
     bytes: Cow<'static, [u8]>,
 }
 
+struct HookEntrySpec {
+    script_basename: &'static str,
+    section: &'static str,
+    matcher: Option<&'static str>,
+}
+
 /// Materializes the corpus hook scripts into `<project_root>/.living-docs/hooks/`
-/// at mode 0755, idempotently. Under `dry_run`, reports the same plan on
-/// stdout and writes nothing. A missing embedded asset is a hard error —
-/// named on stderr, no file written, `ExitCode::from(2)`.
-pub(crate) fn install(project_root: &Path, dry_run: bool) -> ExitCode {
+/// at mode 0755, then wires them into `<project_root>/.claude/settings.json`
+/// via a `serde_json::Value` parse/mutate/serialize merge — idempotently,
+/// replacing any prior living-docs entry by identity rather than appending.
+/// The bundle pinned into each generated command's `LIVING_DOCS_BUNDLE=` is
+/// `docs_dir`, resolved against `project_root` and required to already
+/// exist. Under `dry_run`, reports the same plan on stdout and changes
+/// nothing on disk. A missing embedded asset, a non-existent `docs_dir`, or
+/// a settings file that fails to parse as JSON are hard errors — named on
+/// stderr, no file written, `ExitCode::from(2)`.
+pub(crate) fn install(project_root: &Path, docs_dir: &Path, dry_run: bool) -> ExitCode {
+    if let Err(message) = validate_docs_dir(project_root, docs_dir) {
+        return report_failure(&message);
+    }
     let scripts = match resolve_scripts() {
         Ok(scripts) => scripts,
         Err(message) => return report_failure(&message),
     };
+    let settings_path = project_root.join(SETTINGS_REL_PATH);
+    let mut settings = match load_settings(&settings_path) {
+        Ok(settings) => settings,
+        Err(message) => return report_failure(&message),
+    };
+    let bundle = docs_dir.to_string_lossy().into_owned();
+    apply_hook_entries(&mut settings, &bundle);
     if dry_run {
         announce_dry_run(&scripts);
+        announce_dry_run_wiring(&settings_path, &bundle);
         return ExitCode::SUCCESS;
     }
-    match write_scripts(project_root, &scripts) {
-        Ok(()) => ExitCode::SUCCESS,
+    if let Err(err) = write_scripts(project_root, &scripts) {
+        return report_failure(&err.to_string());
+    }
+    match write_settings(&settings_path, &settings) {
+        Ok(()) => {
+            println!("wired {}", settings_path.display());
+            ExitCode::SUCCESS
+        }
         Err(err) => report_failure(&err.to_string()),
     }
+}
+
+fn validate_docs_dir(project_root: &Path, docs_dir: &Path) -> Result<(), String> {
+    if project_root.join(docs_dir).is_dir() {
+        return Ok(());
+    }
+    Err(format!(
+        "--docs-dir {} does not name an existing directory under {}",
+        docs_dir.display(),
+        project_root.display()
+    ))
 }
 
 fn resolve_scripts() -> Result<Vec<HookScript>, String> {
@@ -60,6 +105,13 @@ fn announce_dry_run(scripts: &[HookScript]) {
     }
 }
 
+fn announce_dry_run_wiring(settings_path: &Path, bundle: &str) {
+    println!(
+        "[dry-run] would wire {} (LIVING_DOCS_BUNDLE={bundle})",
+        settings_path.display()
+    );
+}
+
 fn dest_display(basename: &str) -> String {
     format!("{HOOKS_DEST_SUBDIR}/{basename}")
 }
@@ -80,6 +132,114 @@ fn write_one(dest_dir: &Path, script: &HookScript) -> io::Result<()> {
     Ok(())
 }
 
+fn hook_entry_specs() -> [HookEntrySpec; 2] {
+    [
+        HookEntrySpec {
+            script_basename: basename_of(HOOK_ASSET_PATHS[0]),
+            section: PRE_TOOL_USE_SECTION,
+            matcher: Some(PRE_TOOL_USE_MATCHER),
+        },
+        HookEntrySpec {
+            script_basename: basename_of(HOOK_ASSET_PATHS[1]),
+            section: SESSION_START_SECTION,
+            matcher: None,
+        },
+    ]
+}
+
+fn living_docs_hook_marker() -> String {
+    format!("{HOOKS_DEST_SUBDIR}/")
+}
+
+fn build_entry(spec: &HookEntrySpec, bundle: &str) -> Value {
+    let command = format!(
+        "LIVING_DOCS_BUNDLE={bundle} \"$CLAUDE_PROJECT_DIR\"/{HOOKS_DEST_SUBDIR}/{}",
+        spec.script_basename
+    );
+    let mut entry = json!({ "hooks": [ { "type": "command", "command": command } ] });
+    if let Some(matcher) = spec.matcher {
+        entry["matcher"] = json!(matcher);
+    }
+    entry
+}
+
+fn apply_hook_entries(settings: &mut Value, bundle: &str) {
+    let marker = living_docs_hook_marker();
+    for spec in hook_entry_specs() {
+        let entry = build_entry(&spec, bundle);
+        let section = ensure_hooks_section(settings, spec.section);
+        section.retain(|existing| !is_living_docs_entry(existing, &marker));
+        section.push(entry);
+    }
+}
+
+fn load_settings(path: &Path) -> Result<Value, String> {
+    if !path.exists() {
+        return Ok(json!({}));
+    }
+    let raw = fs::read_to_string(path)
+        .map_err(|err| format!("failed to read {}: {err}", path.display()))?;
+    let value: Value = serde_json::from_str(&raw)
+        .map_err(|err| format!("{} is not valid JSON: {err}", path.display()))?;
+    if !value.is_object() {
+        return Err(format!("{} does not contain a JSON object", path.display()));
+    }
+    Ok(value)
+}
+
+fn ensure_hooks_section<'a>(settings: &'a mut Value, section: &str) -> &'a mut Vec<Value> {
+    let hooks = ensure_child_object(settings, "hooks");
+    ensure_child_array(hooks, section)
+}
+
+fn ensure_child_object<'a>(value: &'a mut Value, key: &str) -> &'a mut Value {
+    let object = value
+        .as_object_mut()
+        .expect("settings value is validated as an object before this call");
+    let child = object.entry(key).or_insert_with(|| json!({}));
+    if !child.is_object() {
+        *child = json!({});
+    }
+    object.get_mut(key).expect("key was just inserted")
+}
+
+fn ensure_child_array<'a>(value: &'a mut Value, key: &str) -> &'a mut Vec<Value> {
+    let object = value
+        .as_object_mut()
+        .expect("settings value is validated as an object before this call");
+    let child = object.entry(key).or_insert_with(|| json!([]));
+    if !child.is_array() {
+        *child = json!([]);
+    }
+    object
+        .get_mut(key)
+        .and_then(Value::as_array_mut)
+        .expect("key was just normalized to an array")
+}
+
+fn is_living_docs_entry(entry: &Value, marker: &str) -> bool {
+    entry
+        .get("hooks")
+        .and_then(Value::as_array)
+        .is_some_and(|hooks| hooks.iter().any(|hook| hook_command_contains(hook, marker)))
+}
+
+fn hook_command_contains(hook: &Value, marker: &str) -> bool {
+    hook.get("command")
+        .and_then(Value::as_str)
+        .is_some_and(|command| command.contains(marker))
+}
+
+fn write_settings(path: &Path, settings: &Value) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut rendered = serde_json::to_string_pretty(settings)
+        .expect("a settings value built from string literals always serializes");
+    rendered.push('\n');
+    fs::write(path, rendered)
+}
+
 fn report_failure(message: &str) -> ExitCode {
     eprintln!("living-docs hooks install: {message}");
     ExitCode::from(2)
@@ -98,5 +258,42 @@ mod tests {
             vec!["block-docs-handwrite.sh", "session-context.sh"]
         );
         assert!(scripts.iter().all(|script| !script.bytes.is_empty()));
+    }
+
+    #[test]
+    fn is_living_docs_entry_true_when_any_nested_command_contains_the_marker() {
+        let marker = living_docs_hook_marker();
+        let entry = json!({
+            "hooks": [
+                { "type": "command", "command": "echo unrelated" },
+                {
+                    "type": "command",
+                    "command": format!(
+                        "LIVING_DOCS_BUNDLE=docs \"$CLAUDE_PROJECT_DIR\"/{marker}session-context.sh"
+                    )
+                }
+            ]
+        });
+        assert!(is_living_docs_entry(&entry, &marker));
+    }
+
+    #[test]
+    fn is_living_docs_entry_false_when_no_command_mentions_the_marker() {
+        let marker = living_docs_hook_marker();
+        let entry = json!({ "hooks": [ { "type": "command", "command": "echo unrelated" } ] });
+        assert!(!is_living_docs_entry(&entry, &marker));
+    }
+
+    #[test]
+    fn is_living_docs_entry_false_when_the_entry_carries_no_hooks_array() {
+        let marker = living_docs_hook_marker();
+        assert!(!is_living_docs_entry(&json!({ "matcher": "X" }), &marker));
+    }
+
+    #[test]
+    fn ensure_child_array_normalizes_a_non_array_value_instead_of_panicking() {
+        let mut settings = json!({ "hooks": "not-an-object" });
+        let section = ensure_hooks_section(&mut settings, PRE_TOOL_USE_SECTION);
+        assert!(section.is_empty());
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -6,6 +6,7 @@ use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
+mod hooks;
 mod skill;
 
 #[derive(Parser)]
@@ -167,6 +168,26 @@ enum Command {
         #[arg(long, conflicts_with = "json")]
         plain: bool,
     },
+    /// Materializes the corpus hook scripts into a target project (ADR 0023).
+    Hooks {
+        #[command(subcommand)]
+        cmd: HooksCmd,
+    },
+}
+
+#[derive(Subcommand)]
+enum HooksCmd {
+    /// Writes the two corpus hook scripts into `<dir>/.living-docs/hooks/`
+    /// at mode 0755, idempotently. `--dry-run` reports the same plan without
+    /// writing anything.
+    Install {
+        /// Target project root; defaults to the current directory.
+        #[arg(long)]
+        dir: Option<PathBuf>,
+        /// Report the plan without writing any file or directory.
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -300,11 +321,21 @@ fn main() -> ExitCode {
             json,
             plain,
         } => run_skill(name, topic, list, json, plain),
+        Command::Hooks {
+            cmd: HooksCmd::Install { dir, dry_run },
+        } => run_hooks_install(dir, dry_run),
     }
 }
 
 fn run_next(docs_dir: &Path, doc_type: &str) -> ExitCode {
     commands::next::run(docs_dir, doc_type)
+}
+
+/// Defaults `--dir` to the current directory when omitted, matching every
+/// other subcommand's cwd-relative default.
+fn run_hooks_install(dir: Option<PathBuf>, dry_run: bool) -> ExitCode {
+    let project_root = dir.unwrap_or_else(|| PathBuf::from("."));
+    hooks::install(&project_root, dry_run)
 }
 
 fn run_new(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -178,8 +178,11 @@ enum Command {
 #[derive(Subcommand)]
 enum HooksCmd {
     /// Writes the two corpus hook scripts into `<dir>/.living-docs/hooks/`
-    /// at mode 0755, idempotently. `--dry-run` reports the same plan without
-    /// writing anything.
+    /// at mode 0755 and wires them into `<dir>/.claude/settings.json`,
+    /// idempotently — re-running replaces the living-docs entries by
+    /// identity rather than appending. The generated commands pin the
+    /// resolved `--docs-dir` bundle as a `LIVING_DOCS_BUNDLE=` prefix.
+    /// `--dry-run` reports the same plan without writing anything.
     Install {
         /// Target project root; defaults to the current directory.
         #[arg(long)]
@@ -323,7 +326,7 @@ fn main() -> ExitCode {
         } => run_skill(name, topic, list, json, plain),
         Command::Hooks {
             cmd: HooksCmd::Install { dir, dry_run },
-        } => run_hooks_install(dir, dry_run),
+        } => run_hooks_install(dir, dry_run, &cli.docs_dir),
     }
 }
 
@@ -332,10 +335,13 @@ fn run_next(docs_dir: &Path, doc_type: &str) -> ExitCode {
 }
 
 /// Defaults `--dir` to the current directory when omitted, matching every
-/// other subcommand's cwd-relative default.
-fn run_hooks_install(dir: Option<PathBuf>, dry_run: bool) -> ExitCode {
+/// other subcommand's cwd-relative default. `docs_dir` is the CLI's global
+/// `--docs-dir` flag, resolved at install time and pinned into the
+/// generated `LIVING_DOCS_BUNDLE=` commands (ADR 0020 scope, resolved once
+/// here rather than at hook run time).
+fn run_hooks_install(dir: Option<PathBuf>, dry_run: bool, docs_dir: &Path) -> ExitCode {
     let project_root = dir.unwrap_or_else(|| PathBuf::from("."));
-    hooks::install(&project_root, dry_run)
+    hooks::install(&project_root, docs_dir, dry_run)
 }
 
 fn run_new(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -178,7 +178,9 @@ enum Command {
 #[derive(Subcommand)]
 enum HooksCmd {
     /// Writes the two corpus hook scripts into `<dir>/.living-docs/hooks/`
-    /// at mode 0755 and wires them into `<dir>/.claude/settings.json`,
+    /// at mode 0755, materializes the pre-commit doc-gate to
+    /// `<dir>/.githooks/pre-commit` (pointing `core.hooksPath` at it), and
+    /// wires the Claude Code hooks into `<dir>/.claude/settings.json`,
     /// idempotently — re-running replaces the living-docs entries by
     /// identity rather than appending. The generated commands pin the
     /// resolved `--docs-dir` bundle as a `LIVING_DOCS_BUNDLE=` prefix.
@@ -188,6 +190,19 @@ enum HooksCmd {
         #[arg(long)]
         dir: Option<PathBuf>,
         /// Report the plan without writing any file or directory.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Removes the artifacts `install` wrote — the two `.living-docs/hooks/`
+    /// scripts, `.githooks/pre-commit`, and the living-docs entries in
+    /// `<dir>/.claude/settings.json` — leaving unrelated entries and
+    /// `core.hooksPath` untouched. A clean no-op when nothing was installed.
+    /// `--dry-run` reports the same removal plan without deleting anything.
+    Uninstall {
+        /// Target project root; defaults to the current directory.
+        #[arg(long)]
+        dir: Option<PathBuf>,
+        /// Report the plan without removing any file.
         #[arg(long)]
         dry_run: bool,
     },
@@ -327,6 +342,9 @@ fn main() -> ExitCode {
         Command::Hooks {
             cmd: HooksCmd::Install { dir, dry_run },
         } => run_hooks_install(dir, dry_run, &cli.docs_dir),
+        Command::Hooks {
+            cmd: HooksCmd::Uninstall { dir, dry_run },
+        } => run_hooks_uninstall(dir, dry_run),
     }
 }
 
@@ -342,6 +360,12 @@ fn run_next(docs_dir: &Path, doc_type: &str) -> ExitCode {
 fn run_hooks_install(dir: Option<PathBuf>, dry_run: bool, docs_dir: &Path) -> ExitCode {
     let project_root = dir.unwrap_or_else(|| PathBuf::from("."));
     hooks::install(&project_root, docs_dir, dry_run)
+}
+
+/// Defaults `--dir` to the current directory, mirroring [`run_hooks_install`].
+fn run_hooks_uninstall(dir: Option<PathBuf>, dry_run: bool) -> ExitCode {
+    let project_root = dir.unwrap_or_else(|| PathBuf::from("."));
+    hooks::uninstall(&project_root, dry_run)
 }
 
 fn run_new(

--- a/cli/src/skill.rs
+++ b/cli/src/skill.rs
@@ -1,5 +1,6 @@
 use rust_embed::RustEmbed;
 use serde::Serialize;
+use std::borrow::Cow;
 use std::collections::BTreeSet;
 
 /// The `skills/**` corpus embedded in the binary at compile time (ADR
@@ -151,6 +152,14 @@ fn to_minified_json<T: Serialize>(value: &T) -> Result<String, String> {
 fn read_asset(path: &str) -> Result<String, String> {
     let file = SkillAssets::get(path).ok_or_else(|| format!("missing embedded asset: {path}"))?;
     String::from_utf8(file.data.into_owned()).map_err(|_| format!("{path} is not valid UTF-8"))
+}
+
+/// Raw bytes of a `skills/**`-relative embedded asset (e.g.
+/// `living-docs/hooks/session-context.sh`), for consumers that need the
+/// asset's bytes as-is rather than [`read_asset`]'s UTF-8-decoded form. None
+/// when `path` has no embedded asset.
+pub(crate) fn asset(path: &str) -> Option<Cow<'static, [u8]>> {
+    SkillAssets::get(path).map(|file| file.data)
 }
 
 fn skill_names() -> BTreeSet<String> {
@@ -315,5 +324,17 @@ mod tests {
     #[test]
     fn topic_json_errors_for_an_unknown_topic() {
         assert!(topic_json("living-docs", "no-such-topic").is_err());
+    }
+
+    #[test]
+    fn asset_returns_the_raw_bytes_of_an_embedded_hook_script() {
+        let bytes =
+            asset("living-docs/hooks/session-context.sh").expect("session-context.sh is embedded");
+        assert!(bytes.starts_with(b"#!"));
+    }
+
+    #[test]
+    fn asset_returns_none_for_an_unknown_path() {
+        assert!(asset("living-docs/hooks/no-such-script.sh").is_none());
     }
 }

--- a/cli/tests/hooks_install.rs
+++ b/cli/tests/hooks_install.rs
@@ -1,0 +1,124 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const SCRIPT_BASENAMES: [&str; 2] = ["block-docs-handwrite.sh", "session-context.sh"];
+
+fn living_docs() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_living-docs"))
+}
+
+fn temp_dir(label: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("living-docs-hooks-install-test-{label}-{nanos}"));
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn corpus_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("skills/living-docs/hooks")
+}
+
+fn run_install(dir: &Path, dry_run: bool) -> Output {
+    let mut command = living_docs();
+    command.args(["hooks", "install", "--dir", dir.to_str().unwrap()]);
+    if dry_run {
+        command.arg("--dry-run");
+    }
+    command
+        .output()
+        .expect("failed to run living-docs hooks install")
+}
+
+#[test]
+fn install_materializes_both_scripts_byte_identical_at_mode_0755() {
+    let project = temp_dir("materialize");
+
+    let output = run_install(&project, false);
+
+    assert!(output.status.success());
+    let hooks_dir = project.join(".living-docs/hooks");
+    for basename in SCRIPT_BASENAMES {
+        let installed = hooks_dir.join(basename);
+        let expected = fs::read(corpus_root().join(basename))
+            .unwrap_or_else(|e| panic!("failed to read corpus {basename}: {e}"));
+        let actual = fs::read(&installed)
+            .unwrap_or_else(|e| panic!("failed to read installed {basename}: {e}"));
+        assert_eq!(actual, expected, "{basename} bytes differ from the corpus");
+
+        let mode = fs::metadata(&installed).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o755, "{basename} unexpected mode: {mode:o}");
+    }
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn install_is_idempotent_across_repeated_runs() {
+    let project = temp_dir("idempotent");
+    let hooks_dir = project.join(".living-docs/hooks");
+
+    let first = run_install(&project, false);
+    assert!(first.status.success());
+    let first_bytes: Vec<Vec<u8>> = SCRIPT_BASENAMES
+        .iter()
+        .map(|basename| fs::read(hooks_dir.join(basename)).unwrap())
+        .collect();
+
+    let second = run_install(&project, false);
+    assert!(second.status.success());
+    let second_bytes: Vec<Vec<u8>> = SCRIPT_BASENAMES
+        .iter()
+        .map(|basename| fs::read(hooks_dir.join(basename)).unwrap())
+        .collect();
+
+    assert_eq!(
+        first_bytes, second_bytes,
+        "repeated install must leave byte-identical files"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn dry_run_reports_the_plan_and_writes_nothing() {
+    let project = temp_dir("dry-run");
+
+    let output = run_install(&project, true);
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    for basename in SCRIPT_BASENAMES {
+        assert!(
+            stdout.contains(basename),
+            "stdout missing {basename}: {stdout}"
+        );
+    }
+    assert!(!project.join(".living-docs").exists());
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn install_defaults_dir_to_the_current_directory_when_omitted() {
+    let project = temp_dir("default-dir");
+
+    let output = living_docs()
+        .args(["hooks", "install", "--dry-run"])
+        .current_dir(&project)
+        .output()
+        .expect("failed to run living-docs hooks install");
+
+    assert!(output.status.success());
+    assert!(!project.join(".living-docs").exists());
+
+    let _ = fs::remove_dir_all(&project);
+}

--- a/cli/tests/hooks_install.rs
+++ b/cli/tests/hooks_install.rs
@@ -5,6 +5,7 @@ use std::process::{Command, Output};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const SCRIPT_BASENAMES: [&str; 2] = ["block-docs-handwrite.sh", "session-context.sh"];
+const LIVING_DOCS_MARKER: &str = ".living-docs/hooks/";
 
 fn living_docs() -> Command {
     Command::new(env!("CARGO_BIN_EXE_living-docs"))
@@ -20,6 +21,12 @@ fn temp_dir(label: &str) -> PathBuf {
     dir
 }
 
+fn project_with_bundle(label: &str, bundle: &str) -> PathBuf {
+    let project = temp_dir(label);
+    fs::create_dir_all(project.join(bundle)).unwrap();
+    project
+}
+
 fn corpus_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -27,20 +34,53 @@ fn corpus_root() -> PathBuf {
         .join("skills/living-docs/hooks")
 }
 
-fn run_install(dir: &Path, dry_run: bool) -> Output {
-    let mut command = living_docs();
-    command.args(["hooks", "install", "--dir", dir.to_str().unwrap()]);
-    if dry_run {
-        command.arg("--dry-run");
-    }
-    command
+fn run_hooks_install(args: &[&str]) -> Output {
+    living_docs()
+        .arg("hooks")
+        .arg("install")
+        .args(args)
         .output()
         .expect("failed to run living-docs hooks install")
 }
 
+fn run_install(dir: &Path, dry_run: bool) -> Output {
+    let dir_str = dir.to_str().unwrap();
+    if dry_run {
+        run_hooks_install(&["--dir", dir_str, "--dry-run"])
+    } else {
+        run_hooks_install(&["--dir", dir_str])
+    }
+}
+
+fn read_settings(project: &Path) -> serde_json::Value {
+    let raw = fs::read_to_string(project.join(".claude/settings.json"))
+        .expect("settings.json was written");
+    serde_json::from_str(&raw).expect("settings.json parses as JSON")
+}
+
+fn entries(settings: &serde_json::Value, section: &str) -> Vec<serde_json::Value> {
+    settings["hooks"][section]
+        .as_array()
+        .unwrap_or_else(|| panic!("hooks.{section} is an array"))
+        .clone()
+}
+
+fn living_docs_entries(settings: &serde_json::Value, section: &str) -> Vec<serde_json::Value> {
+    entries(settings, section)
+        .into_iter()
+        .filter(|entry| {
+            entry["hooks"].as_array().into_iter().flatten().any(|hook| {
+                hook["command"]
+                    .as_str()
+                    .is_some_and(|command| command.contains(LIVING_DOCS_MARKER))
+            })
+        })
+        .collect()
+}
+
 #[test]
 fn install_materializes_both_scripts_byte_identical_at_mode_0755() {
-    let project = temp_dir("materialize");
+    let project = project_with_bundle("materialize", "docs");
 
     let output = run_install(&project, false);
 
@@ -63,7 +103,7 @@ fn install_materializes_both_scripts_byte_identical_at_mode_0755() {
 
 #[test]
 fn install_is_idempotent_across_repeated_runs() {
-    let project = temp_dir("idempotent");
+    let project = project_with_bundle("idempotent", "docs");
     let hooks_dir = project.join(".living-docs/hooks");
 
     let first = run_install(&project, false);
@@ -90,7 +130,7 @@ fn install_is_idempotent_across_repeated_runs() {
 
 #[test]
 fn dry_run_reports_the_plan_and_writes_nothing() {
-    let project = temp_dir("dry-run");
+    let project = project_with_bundle("dry-run", "docs");
 
     let output = run_install(&project, true);
 
@@ -102,14 +142,16 @@ fn dry_run_reports_the_plan_and_writes_nothing() {
             "stdout missing {basename}: {stdout}"
         );
     }
+    assert!(stdout.contains(".claude/settings.json"), "got: {stdout}");
     assert!(!project.join(".living-docs").exists());
+    assert!(!project.join(".claude").exists());
 
     let _ = fs::remove_dir_all(&project);
 }
 
 #[test]
 fn install_defaults_dir_to_the_current_directory_when_omitted() {
-    let project = temp_dir("default-dir");
+    let project = project_with_bundle("default-dir", "docs");
 
     let output = living_docs()
         .args(["hooks", "install", "--dry-run"])
@@ -119,6 +161,163 @@ fn install_defaults_dir_to_the_current_directory_when_omitted() {
 
     assert!(output.status.success());
     assert!(!project.join(".living-docs").exists());
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn install_wires_a_fresh_settings_json_with_one_pretooluse_and_one_sessionstart_entry() {
+    let project = project_with_bundle("fresh-wire", "docs");
+
+    let output = run_install(&project, false);
+    assert!(output.status.success());
+
+    let settings = read_settings(&project);
+    let pre_tool_use = entries(&settings, "PreToolUse");
+    assert_eq!(pre_tool_use.len(), 1, "got: {pre_tool_use:?}");
+    assert_eq!(pre_tool_use[0]["matcher"], "Write|Edit|MultiEdit");
+    let pre_command = pre_tool_use[0]["hooks"][0]["command"]
+        .as_str()
+        .expect("PreToolUse entry carries a command string");
+    assert!(pre_command.contains(".living-docs/hooks/block-docs-handwrite.sh"));
+    assert!(pre_command.starts_with("LIVING_DOCS_BUNDLE=docs "));
+
+    let session_start = entries(&settings, "SessionStart");
+    assert_eq!(session_start.len(), 1, "got: {session_start:?}");
+    let session_command = session_start[0]["hooks"][0]["command"]
+        .as_str()
+        .expect("SessionStart entry carries a command string");
+    assert!(session_command.contains(".living-docs/hooks/session-context.sh"));
+    assert!(session_command.starts_with("LIVING_DOCS_BUNDLE=docs "));
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn install_preserves_unrelated_settings_entries_and_top_level_keys() {
+    let project = project_with_bundle("preserve", "docs");
+    fs::create_dir_all(project.join(".claude")).unwrap();
+    fs::write(
+        project.join(".claude/settings.json"),
+        serde_json::to_string_pretty(&serde_json::json!({
+            "unrelatedTopLevelKey": "keep-me",
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [ { "type": "command", "command": "echo custom-guard" } ]
+                    }
+                ]
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let output = run_install(&project, false);
+    assert!(output.status.success());
+
+    let settings = read_settings(&project);
+    assert_eq!(settings["unrelatedTopLevelKey"], "keep-me");
+
+    let pre_tool_use = entries(&settings, "PreToolUse");
+    assert_eq!(pre_tool_use.len(), 2, "got: {pre_tool_use:?}");
+    let unrelated_still_present = pre_tool_use.iter().any(|entry| {
+        entry["hooks"][0]["command"] == "echo custom-guard" && entry["matcher"] == "Bash"
+    });
+    assert!(unrelated_still_present, "got: {pre_tool_use:?}");
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn install_replaces_living_docs_entries_on_reinstall_without_duplicating() {
+    let project = project_with_bundle("reinstall", "docs");
+
+    let first = run_install(&project, false);
+    assert!(first.status.success());
+    let second = run_install(&project, false);
+    assert!(second.status.success());
+
+    let settings = read_settings(&project);
+    assert_eq!(
+        living_docs_entries(&settings, "PreToolUse").len(),
+        1,
+        "got: {settings:?}"
+    );
+    assert_eq!(
+        living_docs_entries(&settings, "SessionStart").len(),
+        1,
+        "got: {settings:?}"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn install_pins_a_custom_docs_dir_verbatim_into_the_generated_commands() {
+    let project = project_with_bundle("custom-bundle", "handbook");
+
+    let output = run_hooks_install(&["--docs-dir", "handbook", "--dir", project.to_str().unwrap()]);
+    assert!(output.status.success());
+
+    let settings = read_settings(&project);
+    let pre_command = entries(&settings, "PreToolUse")[0]["hooks"][0]["command"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let session_command = entries(&settings, "SessionStart")[0]["hooks"][0]["command"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert!(
+        pre_command.starts_with("LIVING_DOCS_BUNDLE=handbook "),
+        "got: {pre_command}"
+    );
+    assert!(
+        session_command.starts_with("LIVING_DOCS_BUNDLE=handbook "),
+        "got: {session_command}"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn install_fails_with_exit_2_when_docs_dir_does_not_exist_and_writes_nothing() {
+    let project = temp_dir("missing-bundle");
+
+    let output = run_hooks_install(&["--docs-dir", "nope", "--dir", project.to_str().unwrap()]);
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--docs-dir"), "got: {stderr}");
+    assert!(!project.join(".living-docs").exists());
+    assert!(!project.join(".claude").exists());
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn install_fails_with_exit_2_when_existing_settings_json_is_not_valid_json_and_never_overwrites_it()
+{
+    let project = project_with_bundle("invalid-json", "docs");
+    fs::create_dir_all(project.join(".claude")).unwrap();
+    let settings_path = project.join(".claude/settings.json");
+    fs::write(&settings_path, "{ not valid json").unwrap();
+
+    let output = run_install(&project, false);
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("settings.json"), "got: {stderr}");
+    let raw = fs::read_to_string(&settings_path).unwrap();
+    assert_eq!(
+        raw, "{ not valid json",
+        "settings.json must never be overwritten on parse failure"
+    );
+    assert!(!project
+        .join(".living-docs/hooks/block-docs-handwrite.sh")
+        .exists());
 
     let _ = fs::remove_dir_all(&project);
 }

--- a/cli/tests/hooks_install.rs
+++ b/cli/tests/hooks_install.rs
@@ -43,6 +43,46 @@ fn run_hooks_install(args: &[&str]) -> Output {
         .expect("failed to run living-docs hooks install")
 }
 
+fn run_hooks_uninstall(args: &[&str]) -> Output {
+    living_docs()
+        .arg("hooks")
+        .arg("uninstall")
+        .args(args)
+        .output()
+        .expect("failed to run living-docs hooks uninstall")
+}
+
+fn run_uninstall(dir: &Path, dry_run: bool) -> Output {
+    let dir_str = dir.to_str().unwrap();
+    if dry_run {
+        run_hooks_uninstall(&["--dir", dir_str, "--dry-run"])
+    } else {
+        run_hooks_uninstall(&["--dir", dir_str])
+    }
+}
+
+fn init_git_repo(dir: &Path) {
+    let output = Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(dir)
+        .output()
+        .expect("failed to run git init");
+    assert!(output.status.success(), "git init failed: {output:?}");
+}
+
+fn read_git_config(dir: &Path, key: &str) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["config", "--get", key])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).trim().to_owned())
+}
+
 fn run_install(dir: &Path, dry_run: bool) -> Output {
     let dir_str = dir.to_str().unwrap();
     if dry_run {
@@ -318,6 +358,321 @@ fn install_fails_with_exit_2_when_existing_settings_json_is_not_valid_json_and_n
     assert!(!project
         .join(".living-docs/hooks/block-docs-handwrite.sh")
         .exists());
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn install_materializes_pre_commit_byte_identical_at_mode_0755() {
+    let project = project_with_bundle("precommit-materialize", "docs");
+    init_git_repo(&project);
+
+    let output = run_install(&project, false);
+
+    assert!(output.status.success());
+    let installed = project.join(".githooks/pre-commit");
+    let expected =
+        fs::read(corpus_root().join("pre-commit")).expect("corpus pre-commit is readable");
+    let actual = fs::read(&installed).expect("pre-commit was installed");
+    assert_eq!(actual, expected, "pre-commit bytes differ from the corpus");
+    let mode = fs::metadata(&installed).unwrap().permissions().mode();
+    assert_eq!(mode & 0o777, 0o755, "unexpected mode: {mode:o}");
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn install_succeeds_outside_a_git_repository_and_warns_on_stderr() {
+    let project = project_with_bundle("precommit-no-git", "docs");
+
+    let output = run_install(&project, false);
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("core.hooksPath"), "got: {stderr}");
+    assert!(project.join(".githooks/pre-commit").exists());
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn install_dry_run_does_not_touch_githooks_or_git_config() {
+    let project = project_with_bundle("precommit-dry-run", "docs");
+    init_git_repo(&project);
+
+    let output = run_install(&project, true);
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("pre-commit"), "got: {stdout}");
+    assert!(!project.join(".githooks").exists());
+    assert_eq!(read_git_config(&project, "core.hooksPath"), None);
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn uninstall_removes_installed_artifacts_and_strips_settings_preserving_unrelated_entries() {
+    let project = project_with_bundle("uninstall-full", "docs");
+    init_git_repo(&project);
+    fs::create_dir_all(project.join(".claude")).unwrap();
+    fs::write(
+        project.join(".claude/settings.json"),
+        serde_json::to_string_pretty(&serde_json::json!({
+            "unrelatedTopLevelKey": "keep-me",
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [ { "type": "command", "command": "echo custom-guard" } ]
+                    }
+                ]
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let install_output = run_install(&project, false);
+    assert!(install_output.status.success());
+
+    let uninstall_output = run_uninstall(&project, false);
+    assert!(uninstall_output.status.success());
+
+    for basename in SCRIPT_BASENAMES {
+        assert!(!project.join(".living-docs/hooks").join(basename).exists());
+    }
+    assert!(!project.join(".githooks/pre-commit").exists());
+
+    let settings = read_settings(&project);
+    assert_eq!(settings["unrelatedTopLevelKey"], "keep-me");
+    assert!(living_docs_entries(&settings, "PreToolUse").is_empty());
+    assert!(living_docs_entries(&settings, "SessionStart").is_empty());
+    let pre_tool_use = entries(&settings, "PreToolUse");
+    assert!(
+        pre_tool_use.iter().any(|entry| entry["matcher"] == "Bash"
+            && entry["hooks"][0]["command"] == "echo custom-guard"),
+        "got: {pre_tool_use:?}"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn uninstall_on_a_project_with_nothing_installed_is_a_clean_no_op() {
+    let project = temp_dir("uninstall-clean");
+
+    let output = run_uninstall(&project, false);
+
+    assert!(output.status.success());
+    assert!(!project.join(".living-docs").exists());
+    assert!(!project.join(".githooks").exists());
+    assert!(!project.join(".claude").exists());
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn uninstall_dry_run_reports_the_plan_and_changes_nothing() {
+    let project = project_with_bundle("uninstall-dry-run", "docs");
+    init_git_repo(&project);
+    let install_output = run_install(&project, false);
+    assert!(install_output.status.success());
+
+    let before_settings = fs::read_to_string(project.join(".claude/settings.json")).unwrap();
+    let before_scripts: Vec<Vec<u8>> = SCRIPT_BASENAMES
+        .iter()
+        .map(|basename| fs::read(project.join(".living-docs/hooks").join(basename)).unwrap())
+        .collect();
+    let before_pre_commit = fs::read(project.join(".githooks/pre-commit")).unwrap();
+
+    let output = run_uninstall(&project, true);
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for basename in SCRIPT_BASENAMES {
+        assert!(stdout.contains(basename), "got: {stdout}");
+    }
+    assert!(stdout.contains("pre-commit"), "got: {stdout}");
+    assert!(stdout.contains(".claude/settings.json"), "got: {stdout}");
+
+    let after_settings = fs::read_to_string(project.join(".claude/settings.json")).unwrap();
+    assert_eq!(before_settings, after_settings);
+    for (basename, before_bytes) in SCRIPT_BASENAMES.iter().zip(before_scripts) {
+        let after_bytes = fs::read(project.join(".living-docs/hooks").join(basename)).unwrap();
+        assert_eq!(after_bytes, before_bytes);
+    }
+    let after_pre_commit = fs::read(project.join(".githooks/pre-commit")).unwrap();
+    assert_eq!(after_pre_commit, before_pre_commit);
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+fn binary_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_living-docs"))
+        .parent()
+        .expect("the compiled binary has a parent directory")
+        .to_path_buf()
+}
+
+fn path_with_binary_dir() -> std::ffi::OsString {
+    let mut dirs = vec![binary_dir()];
+    if let Some(current) = std::env::var_os("PATH") {
+        dirs.extend(std::env::split_paths(&current));
+    }
+    std::env::join_paths(dirs).expect("PATH components join cleanly")
+}
+
+/// The current `$PATH` with every directory carrying a `living-docs`
+/// executable filtered out, so the pre-commit script's `command -v
+/// living-docs` reliably fails regardless of what a developer's host or CI
+/// runner happens to have installed.
+fn path_without_living_docs() -> std::ffi::OsString {
+    let current = std::env::var_os("PATH").unwrap_or_default();
+    let filtered: Vec<PathBuf> = std::env::split_paths(&current)
+        .filter(|dir| !dir.join("living-docs").is_file())
+        .collect();
+    std::env::join_paths(filtered).expect("PATH components join cleanly")
+}
+
+fn run_pre_commit_script(
+    project: &Path,
+    bundle: &str,
+    path_override: Option<std::ffi::OsString>,
+) -> Output {
+    let script = corpus_root().join("pre-commit");
+    let path_value = path_override.unwrap_or_else(path_with_binary_dir);
+    Command::new("bash")
+        .arg(&script)
+        .current_dir(project)
+        .env("LIVING_DOCS_BUNDLE", bundle)
+        .env("PATH", path_value)
+        .output()
+        .expect("failed to run the pre-commit script")
+}
+
+fn only_record_path(adr_dir: &Path) -> PathBuf {
+    fs::read_dir(adr_dir)
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .find(|path| path.file_name().and_then(|name| name.to_str()) != Some("index.md"))
+        .expect("the scaffolded record exists")
+}
+
+const CLEAN_FIXTURE_BODY: &str = "# 0001. Pre Commit Fixture\n\n## Context\n\nFixture body with no links, kept clean for the pre-commit script test.\n\n## Decision\n\nWe will keep this fixture minimal.\n";
+
+/// Replaces `contents`' body (below the closing frontmatter fence) with
+/// [`CLEAN_FIXTURE_BODY`], keeping the frontmatter block byte-identical —
+/// `check_canonical_frontmatter` compares only the frontmatter block, so
+/// this never disturbs canonicality while dropping the ADR template's
+/// placeholder links that would otherwise fail the link-validity invariant.
+fn with_clean_body(contents: &str) -> String {
+    let fence_end = contents
+        .find("\n---\n")
+        .expect("a scaffolded record has a closing frontmatter fence");
+    let frontmatter = &contents[..fence_end + 5];
+    format!("{frontmatter}\n{CLEAN_FIXTURE_BODY}")
+}
+
+/// Scaffolds a single canonical ADR record plus a bundle root `index.md`
+/// under `<project>/<bundle>` via the real CLI (`new` + `index`), then
+/// swaps in a link-free body — the whole tree passes `living-docs check`
+/// unmodified, giving the pre-commit script fixture tests a bundle that is
+/// clean by construction rather than hand-assembled.
+fn scaffold_canonical_bundle(project: &Path, bundle: &str) {
+    let docs_dir = project.join(bundle);
+    let new_output = living_docs()
+        .arg("--docs-dir")
+        .arg(&docs_dir)
+        .args(["new", "adr", "Pre Commit Fixture"])
+        .output()
+        .expect("failed to scaffold a record");
+    assert!(new_output.status.success(), "new failed: {new_output:?}");
+
+    let index_output = living_docs()
+        .arg("--docs-dir")
+        .arg(&docs_dir)
+        .args(["index", "adr"])
+        .output()
+        .expect("failed to build the adr index");
+    assert!(
+        index_output.status.success(),
+        "index failed: {index_output:?}"
+    );
+
+    let record_path = only_record_path(&docs_dir.join("adr"));
+    let contents = fs::read_to_string(&record_path).unwrap();
+    fs::write(&record_path, with_clean_body(&contents)).unwrap();
+
+    fs::write(
+        docs_dir.join("index.md"),
+        "# Index\n\n- [ADRs](/adr/index.md)\n",
+    )
+    .unwrap();
+}
+
+/// Swaps the `type:`/`title:` frontmatter lines' order — a canonical record
+/// always emits `type` before `title`, so this reordering is exactly the
+/// hand-written drift `check_canonical_frontmatter` (ADR 0019) flags.
+fn corrupt_frontmatter_key_order(record_path: &Path) {
+    let contents = fs::read_to_string(record_path).unwrap();
+    let mut lines: Vec<&str> = contents.lines().collect();
+    let type_idx = lines
+        .iter()
+        .position(|line| line.starts_with("type:"))
+        .expect("record carries a type: line");
+    let title_idx = lines
+        .iter()
+        .position(|line| line.starts_with("title:"))
+        .expect("record carries a title: line");
+    lines.swap(type_idx, title_idx);
+    fs::write(record_path, lines.join("\n") + "\n").unwrap();
+}
+
+#[test]
+fn pre_commit_script_is_fail_open_when_no_binary_resolves() {
+    let project = temp_dir("precommit-fail-open");
+    init_git_repo(&project);
+
+    let output = run_pre_commit_script(&project, "docs", Some(path_without_living_docs()));
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("skipped"), "got: {stderr}");
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn pre_commit_script_exits_zero_against_a_clean_bundle() {
+    let project = temp_dir("precommit-clean");
+    init_git_repo(&project);
+    scaffold_canonical_bundle(&project, "bundle");
+
+    let output = run_pre_commit_script(&project, "bundle", None);
+
+    assert!(
+        output.status.success(),
+        "stdout: {} stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn pre_commit_script_exits_nonzero_for_a_hand_written_noncanonical_record() {
+    let project = temp_dir("precommit-noncanonical");
+    init_git_repo(&project);
+    scaffold_canonical_bundle(&project, "bundle");
+    let record_path = only_record_path(&project.join("bundle/adr"));
+    corrupt_frontmatter_key_order(&record_path);
+
+    let output = run_pre_commit_script(&project, "bundle", None);
+
+    assert!(!output.status.success());
 
     let _ = fs::remove_dir_all(&project);
 }

--- a/cli/tests/plugin_manifest.rs
+++ b/cli/tests/plugin_manifest.rs
@@ -1,0 +1,126 @@
+//! Guards the in-repo Claude Code plugin bundle (ADR 0023, decision 1):
+//! `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and
+//! `hooks/hooks.json` must keep parsing, stay plugin-rooted, and point only
+//! at hook scripts that exist and are executable.
+
+use serde_json::Value;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+const PLUGIN_ROOT_PREFIX: &str = "\"${CLAUDE_PLUGIN_ROOT}\"/";
+
+/// Resolves the repository root from the `cli` crate's manifest directory.
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("cli crate has a parent directory")
+        .to_path_buf()
+}
+
+/// Reads a repo-relative file and parses it as JSON, panicking with the
+/// offending path on any I/O or parse failure.
+fn read_json(relative_path: &str) -> Value {
+    let path = repo_root().join(relative_path);
+    let contents = fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+    serde_json::from_str(&contents)
+        .unwrap_or_else(|err| panic!("failed to parse {} as JSON: {err}", path.display()))
+}
+
+/// Flattens every nested `hooks[].command` string out of a parsed
+/// `hooks.json` document, across all event groups (`PreToolUse`,
+/// `SessionStart`, ...).
+fn collect_hook_commands(hooks_json: &Value) -> Vec<String> {
+    let mut commands = Vec::new();
+    let Some(groups) = hooks_json["hooks"].as_object() else {
+        return commands;
+    };
+    for entries in groups.values() {
+        let Some(entries) = entries.as_array() else {
+            continue;
+        };
+        for entry in entries {
+            let Some(nested) = entry["hooks"].as_array() else {
+                continue;
+            };
+            for hook in nested {
+                if let Some(command) = hook["command"].as_str() {
+                    commands.push(command.to_string());
+                }
+            }
+        }
+    }
+    commands
+}
+
+#[test]
+fn manifests_parse_and_plugin_identifies_itself() {
+    let plugin = read_json(".claude-plugin/plugin.json");
+    read_json(".claude-plugin/marketplace.json");
+    read_json("hooks/hooks.json");
+
+    assert_eq!(plugin["name"], Value::String("living-docs".to_string()));
+
+    let version = fs::read_to_string(repo_root().join("VERSION"))
+        .expect("VERSION file exists")
+        .trim()
+        .to_string();
+    assert_eq!(plugin["version"], Value::String(version));
+}
+
+#[test]
+fn hook_commands_are_plugin_rooted_and_point_at_executable_files() {
+    let hooks_json = read_json("hooks/hooks.json");
+    let commands = collect_hook_commands(&hooks_json);
+
+    assert!(
+        commands.len() >= 2,
+        "expected at least two hook commands, found {}",
+        commands.len()
+    );
+
+    for command in &commands {
+        assert!(
+            command.starts_with(PLUGIN_ROOT_PREFIX),
+            "command does not start with the plugin-root prefix: {command}"
+        );
+        let relative_path = command.trim_start_matches(PLUGIN_ROOT_PREFIX);
+        let script_path = repo_root().join(relative_path);
+        let metadata = fs::metadata(&script_path).unwrap_or_else(|err| {
+            panic!("hook script missing at {}: {err}", script_path.display())
+        });
+        assert!(
+            metadata.is_file(),
+            "{} is not a file",
+            script_path.display()
+        );
+        assert!(
+            metadata.permissions().mode() & 0o100 != 0,
+            "{} is not owner-executable",
+            script_path.display()
+        );
+    }
+}
+
+#[test]
+fn marketplace_lists_exactly_one_self_hosted_living_docs_plugin() {
+    let marketplace = read_json(".claude-plugin/marketplace.json");
+    let plugins = marketplace["plugins"]
+        .as_array()
+        .expect("marketplace.json plugins is an array");
+
+    assert_eq!(plugins.len(), 1, "expected exactly one plugin entry");
+
+    let plugin = &plugins[0];
+    assert_eq!(plugin["name"], Value::String("living-docs".to_string()));
+    let source = plugin["source"].as_str().expect("source is a string");
+    assert_eq!(source, "./");
+
+    let plugin_manifest = repo_root().join(source).join(".claude-plugin/plugin.json");
+    assert!(
+        plugin_manifest.is_file(),
+        "marketplace source does not resolve to a directory containing .claude-plugin/plugin.json: {}",
+        plugin_manifest.display()
+    );
+}

--- a/docs/adr/0023-hooks-ship-through-two-deterministic-channels-an-in-repo-claude-code-plugin-and-a-living-docs-hooks-install-verb.md
+++ b/docs/adr/0023-hooks-ship-through-two-deterministic-channels-an-in-repo-claude-code-plugin-and-a-living-docs-hooks-install-verb.md
@@ -70,7 +70,8 @@ plugin cache. Adoption is `/plugin marketplace add ejklock/living-docs-skill` th
 **2. A `living-docs hooks install` verb, for every other harness.** It materializes the hook
 scripts from the embedded corpus into `<project>/.living-docs/hooks/` (mode `0755`), emits
 the harness wiring, and installs the pre-commit doc-gate. It is idempotent — re-running
-converges on the same bytes — and supports `--dry-run` and `--uninstall`. It never merges
+converges on the same bytes — and supports `--dry-run`. Removal is the sibling subcommand
+`living-docs hooks uninstall`, not a flag on `install`. It never merges
 JSON by hand-rolled string surgery: an existing settings file is parsed, the living-docs hook
 entries are replaced by identity, and unrelated entries are preserved verbatim.
 
@@ -132,7 +133,8 @@ outside the deterministic layer that owns them.
   verbatim and the resulting file parses as JSON.
 - The generated wiring pins `LIVING_DOCS_BUNDLE` to the resolved bundle; with no resolvable
   bundle the verb exits non-zero naming the flag to pass.
-- `--uninstall` removes the living-docs entries and leaves unrelated entries intact.
+- `living-docs hooks uninstall` removes the living-docs entries and leaves unrelated entries
+  intact.
 - Every `command` in `hooks/hooks.json` is prefixed by `${CLAUDE_PLUGIN_ROOT}`, and every
   path it names exists in the plugin bundle.
 - Fitness function: `cli/tests/hooks_install.rs` covers the criteria above and a manifest

--- a/docs/adr/0023-hooks-ship-through-two-deterministic-channels-an-in-repo-claude-code-plugin-and-a-living-docs-hooks-install-verb.md
+++ b/docs/adr/0023-hooks-ship-through-two-deterministic-channels-an-in-repo-claude-code-plugin-and-a-living-docs-hooks-install-verb.md
@@ -1,0 +1,140 @@
+---
+type: ADR
+title: "Hooks ship through two deterministic channels: an in-repo Claude Code plugin and a living-docs hooks install verb"
+description: Distribute the ADR 0021 enforcement layers to consumer projects through two deterministic channels — an in-repo Claude Code plugin whose hooks resolve via CLAUDE_PLUGIN_ROOT, and a `living-docs hooks install` verb that materializes the same scripts from the embedded corpus for every other harness — leaving install.sh a skill-stub copier.
+status: Accepted
+tags: [cli, distribution, enforcement, hooks, plugin]
+timestamp: 2026-07-29T12:43:28Z
+---
+
+# 0023. Hooks ship through two deterministic channels: an in-repo Claude Code plugin and a living-docs hooks install verb
+
+## Context
+
+[ADR 0021](/adr/0021-enforcement-layers-ship-with-the-repo-write-gate-hook-session-teaching-and-pre-commit-doc-gate.md)
+made *this* repository self-enforcing: `block-docs-handwrite.sh` and `session-context.sh`
+live in `skills/living-docs/hooks/`, `.claude/settings.json` wires them, and
+`.githooks/pre-commit` runs the doc-gate. It closed the gap for contributors to the bundle
+and explicitly deferred the gap for everyone else — its own follow-up asks for
+"a `living-docs hooks install` verb so consumer projects wire the same layers through the
+CLI instead of copying files by hand".
+
+That gap is now measured. `install.sh` — the only supported way to adopt the bundle — copies
+`SKILL.md` stubs (plus `okf-knowledge-format`'s `reference/`) into a harness skills directory
+and generates the Cursor and Copilot pointer files. It never copies `hooks/`, and it never
+touches any harness settings file. A consumer project therefore adopts the *instructions*
+and none of the *gates*, which inverts the ADR 0019 constraint the whole enforcement design
+rests on: instructions never block; only gates block.
+
+Copying the scripts is not sufficient on its own. The wiring committed here is
+`"$CLAUDE_PROJECT_DIR"/skills/living-docs/hooks/block-docs-handwrite.sh` — a path that
+resolves only inside a checkout of this bundle. Any distribution has to relocate the scripts
+*and* rewrite the command that points at them, which is exactly the class of mechanical,
+single-correct-output work that [ADR 0001](/adr/0001-living-docs-cli.md) assigns to the CLI
+rather than to a shell installer merging JSON with `jq`.
+
+Two properties of the existing implementation bound the solution and keep it small. The
+`rust-embed` corpus in `cli/src/skill.rs` is declared `#[folder = "../skills/"]` with no
+include/exclude filter, so `skills/living-docs/hooks/*.sh` are **already** compiled into the
+binary — materializing them needs no new embedding. And the write-gate already reads
+`LIVING_DOCS_BUNDLE` (default `docs`) for its ADR 0020 directory scope, so pinning the scope
+in a consumer project is a matter of emitting one environment variable, not of teaching the
+shell script to discover anything.
+
+The residual force is harness asymmetry. Claude Code has a first-class plugin format that
+bundles skills, hooks, and commands together and resolves paths through
+`${CLAUDE_PLUGIN_ROOT}`; the block rules already exist there as the external
+`living-docs-enforcer` plugin in the `ai-configs` repository — the duplication ADR 0021
+accepted as a trade-off. OpenCode, Codex, Cursor and Copilot have no equivalent, and Cursor
+and Copilot have no write-time hook surface at all.
+
+## Decision
+
+We will distribute the enforcement layers through **two channels, both deterministic and
+both owned by this repository**, and leave `install.sh` a skill-stub copier.
+
+**1. A Claude Code plugin, vendored in this repo, with the repo root as its source.**
+`.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` declare a `living-docs`
+plugin whose marketplace entry is `"source": "./"`. The repo root is already the plugin
+layout Claude Code expects — `skills/<name>/SKILL.md` is auto-discovered, so the existing
+`skills/` tree needs no duplication — and it costs no extra copy, because the marketplace
+repository is cloned regardless and `"./"` reuses that clone. `hooks/hooks.json` at the repo
+root (auto-discovered; no `plugin.json` key needed) registers `block-docs-handwrite.sh` on
+`PreToolUse` (`Write|Edit|MultiEdit`) and `session-context.sh` on `SessionStart`, addressing
+both as `"${CLAUDE_PLUGIN_ROOT}"/skills/living-docs/hooks/<script>` so they resolve from the
+plugin cache. Adoption is `/plugin marketplace add ejklock/living-docs-skill` then
+`/plugin install living-docs@living-docs` (`--scope project` to commit the choice). This
+**absorbs the external `living-docs-enforcer`**: the block rules get one home, retiring the
+"block rules exist in two places" trade-off ADR 0021 accepted.
+
+**2. A `living-docs hooks install` verb, for every other harness.** It materializes the hook
+scripts from the embedded corpus into `<project>/.living-docs/hooks/` (mode `0755`), emits
+the harness wiring, and installs the pre-commit doc-gate. It is idempotent — re-running
+converges on the same bytes — and supports `--dry-run` and `--uninstall`. It never merges
+JSON by hand-rolled string surgery: an existing settings file is parsed, the living-docs hook
+entries are replaced by identity, and unrelated entries are preserved verbatim.
+
+**3. The write-gate scope is resolved at install time, not at hook time.** The verb resolves
+the project's docs bundle with the same resolver the CLI already uses for `--docs-dir`, and
+pins the result into the generated wiring as `LIVING_DOCS_BUNDLE`. The shell script keeps its
+existing env-var contract and gains no discovery logic. When no bundle resolves, the verb
+fails with the flag to pass rather than silently defaulting to `docs`.
+
+**4. `install.sh` grows no hook logic.** It keeps copying skill stubs and generating pointer
+files, and gains one line naming the correct channel per harness. Rationale: JSON merging in
+`bash` is fragile, and duplicating the wiring in a shell installer would put the mechanics
+outside the deterministic layer that owns them.
+
+## Consequences
+
+**Easier / gained:**
+- A consumer project gets write-time enforcement, not just instructions — one command on
+  Claude Code, one CLI verb elsewhere.
+- The `${CLAUDE_PLUGIN_ROOT}` indirection removes the broken-path failure mode: no consumer
+  needs a checkout of this bundle for the hooks to resolve.
+- The block rules collapse to a single home, closing the duplication ADR 0021 accepted.
+- Hook distribution becomes testable in this repo's CI like any other CLI verb, instead of
+  being verified only by a human following README prose.
+
+**Harder / accepted trade-offs:**
+- Two channels mean two adoption paths to document and keep in sync. Accepted: they share
+  one source of truth — the scripts in `skills/living-docs/hooks/` — and differ only in
+  how the wiring addresses them.
+- Cursor and Copilot still get no write-time gate; they retain the pre-commit and CI gates
+  only. Accepted: fail-open by design, unchanged from ADR 0021.
+- Plugin hooks and `.claude/settings.json` hooks fire independently, so a contributor to
+  *this* repo who also installs the plugin runs both — a duplicated SessionStart notice and
+  a doubled (still correct) block. Accepted rather than removing this repo's committed
+  wiring, which is what guarantees enforcement for contributors who install nothing.
+- Materialized scripts in a consumer project can drift from the binary that wrote them.
+  Mitigated by idempotent re-install, not by a runtime version check.
+- Retiring the external `living-docs-enforcer` requires a deprecation pass in the `ai-configs`
+  repository, which is outside this repo's CI.
+
+**Follow-ups:**
+- Deprecate `living-docs-enforcer` in `ai-configs` and point its README at the plugin here.
+- Consider a `living-docs hooks check` verb reporting drift between materialized scripts and
+  the embedded corpus.
+
+## Verification
+
+**Implementation impact:** `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`,
+`hooks/hooks.json`, `cli/src/main.rs` (subcommand + dispatch), a new `hooks` command module,
+`cli/tests/hooks_install.rs`, `install.sh` (pointer line), `README.md`, `CONTRIBUTING.md`,
+`skills/living-docs/templates/claude-hard-rules.md` (rule 10).
+
+**Verification criteria:**
+- `living-docs hooks install --dir <tmp>` writes both hook scripts mode `0755` under
+  `<tmp>/.living-docs/hooks/`, and their bytes equal the embedded corpus entries.
+- Running the verb twice leaves the target tree byte-identical to the first run
+  (idempotence), and `--dry-run` writes nothing while reporting the same plan.
+- Against a settings file carrying an unrelated hook entry, the verb preserves that entry
+  verbatim and the resulting file parses as JSON.
+- The generated wiring pins `LIVING_DOCS_BUNDLE` to the resolved bundle; with no resolvable
+  bundle the verb exits non-zero naming the flag to pass.
+- `--uninstall` removes the living-docs entries and leaves unrelated entries intact.
+- Every `command` in `hooks/hooks.json` is prefixed by `${CLAUDE_PLUGIN_ROOT}`, and every
+  path it names exists in the plugin bundle.
+- Fitness function: `cli/tests/hooks_install.rs` covers the criteria above and a manifest
+  test asserts `.claude-plugin/*.json` parse and reference only existing files; both run in
+  `make check`.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -29,6 +29,7 @@ repo teaches. The decision *log* is this listing plus each record's `status` /
 * [0020 — Hand-write hook is scoped to CLI-owned type directories, not the whole bundle](0020-hand-write-hook-is-scoped-to-cli-owned-type-directories-not-the-whole-bundle.md) - Accepted
 * [0021 — Enforcement layers ship with the repo: write-gate hook, session teaching, and pre-commit doc-gate](0021-enforcement-layers-ship-with-the-repo-write-gate-hook-session-teaching-and-pre-commit-doc-gate.md) - Accepted
 * [0022 — Canonical frontmatter check is scoped to CLI-owned type directories](0022-canonical-frontmatter-check-is-scoped-to-cli-owned-type-directories.md) - Accepted
+* [0023 — Hooks ship through two deterministic channels: an in-repo Claude Code plugin and a living-docs hooks install verb](0023-hooks-ship-through-two-deterministic-channels-an-in-repo-claude-code-plugin-and-a-living-docs-hooks-install-verb.md) - Accepted
 
 ## Superseded
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,25 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/skills/living-docs/hooks/block-docs-handwrite.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/skills/living-docs/hooks/session-context.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,12 @@
 # the `living-docs skill` CLI command, not copied to disk — and, for tools
 # that need it, generating a small rule/instruction pointer file.
 #
+# Enforcement (write-gate, session teaching, pre-commit doc-gate) is NOT part
+# of this script — it ships through two separate channels: the Claude Code
+# plugin (/plugin marketplace add ejklock/living-docs-skill && /plugin install
+# living-docs@living-docs) or `living-docs hooks install` for every harness.
+# See README.md → Enforcement.
+#
 # Usage:
 #   ./install.sh [harness] [options]
 #
@@ -62,7 +68,7 @@ run()  { if [[ $DRYRUN -eq 1 ]]; then log "  [dry-run] $*"; else eval "$*"; fi; 
 note() { if [[ $DRYRUN -eq 1 ]]; then log "  [dry-run] would install: $*"; else log "installed: $*"; fi; }
 die()  { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
-usage() { sed -n '2,42p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+usage() { sed -n '2,50p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
 
 # --- parse args ---
 while [[ $# -gt 0 ]]; do
@@ -271,3 +277,6 @@ if [[ "$HARNESS" == "all" ]]; then
 else
   do_harness "$HARNESS"
 fi
+
+log ""
+log "Reminder: this script ships skills only. Enforcement (write-gate, session teaching, pre-commit) installs separately — Claude Code plugin (/plugin marketplace add ejklock/living-docs-skill && /plugin install living-docs@living-docs) or 'living-docs hooks install' for every harness."

--- a/skills/living-docs/hooks/pre-commit
+++ b/skills/living-docs/hooks/pre-commit
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# pre-commit — living-docs doc-gate, distributed copy (ADR 0021 layer 3,
+# ADR 0023 distribution channel 2). `living-docs hooks install` materializes
+# this file to <project>/.githooks/pre-commit and points core.hooksPath at
+# .githooks; skills/living-docs/hooks/ stays the single source of truth.
+#
+# Runs `living-docs check` over the docs bundle so a hand-written or drifted
+# record fails in the authoring session, not at CI. Fail-open when no binary
+# is resolvable (CI still gates); never bypass a real failure with --no-verify.
+
+set -u
+
+ROOT="$(git rev-parse --show-toplevel)"
+BUNDLE="${LIVING_DOCS_BUNDLE:-docs}"
+
+resolve_bin() {
+  if command -v living-docs >/dev/null 2>&1; then
+    command -v living-docs
+  elif [ -x "$ROOT/target/release/living-docs" ]; then
+    printf '%s' "$ROOT/target/release/living-docs"
+  fi
+}
+
+BIN="$(resolve_bin)"
+if [ -z "$BIN" ]; then
+  echo "living-docs pre-commit: no binary found (PATH or target/release) — doc-gate skipped, CI will enforce it. Build with \`make build\`." >&2
+  exit 0
+fi
+
+exec "$BIN" check "$ROOT/$BUNDLE"

--- a/skills/living-docs/templates/claude-hard-rules.md
+++ b/skills/living-docs/templates/claude-hard-rules.md
@@ -97,8 +97,8 @@ The dividing line is determinism: any documentation step with a single correct o
 
 **Write ONLY the body below the closing `---`.** Numbering, frontmatter (`type`, `title`, `status`, `supersedes`, `superseded_by`, `timestamp`), and index rows are CLI-owned; `description` and `tags` are yours.
 
-This rule is enforced by gates, not prose (instructions never block; only gates block). Wire them once per project:
+This rule is enforced by gates, not prose (instructions never block; only gates block). Wire them once per project through either of two deterministic channels (ADR 0023):
 
-- **Write-time gate (Claude Code):** copy `skills/living-docs/hooks/block-docs-handwrite.sh` from the living-docs repo into the project and register it in `.claude/settings.json` as a `PreToolUse` hook on `Write|Edit|MultiEdit`. It blocks hand-writes to CLI-owned frontmatter keys, new `NNNN-*.md` records, and type `index.md` files, naming the correct verb. Knobs: `LIVING_DOCS_ENFORCE=block|warn`, `LIVING_DOCS_BUNDLE=<dir>`.
-- **Session teaching:** register `skills/living-docs/hooks/session-context.sh` as a `SessionStart` hook so every session receives this rule and the resolved CLI path at start.
-- **Commit-time gate:** a `pre-commit` hook running `living-docs check <bundle>` (see `.githooks/pre-commit` in the living-docs repo), so a hand-written record fails in the session that authored it, not at CI.
+- **Claude Code plugin:** `/plugin marketplace add ejklock/living-docs-skill` then `/plugin install living-docs@living-docs` (`--scope project` to commit the choice). Installs the write-time gate (`PreToolUse` on `Write|Edit|MultiEdit`, blocking hand-writes to CLI-owned frontmatter keys, new `NNNN-*.md` records, and type `index.md` files, naming the correct verb) and the session-teaching hook (`SessionStart`, so every session receives this rule and the resolved CLI path at start).
+- **`living-docs hooks install [--dir <path>] [--docs-dir <bundle>] [--dry-run]`** (every harness): materializes the same write-gate and session-teaching scripts, wires them into `.claude/settings.json`, and installs a `pre-commit` hook running `living-docs check <bundle>` so a hand-written record fails in the session that authored it, not at CI. Remove everything it wrote with the sibling `living-docs hooks uninstall [--dir <path>] [--dry-run]`.
+- **Knobs:** `LIVING_DOCS_ENFORCE=block|warn` (write-gate strictness), `LIVING_DOCS_BUNDLE=<dir>` (docs bundle scope), documented and honored by either channel.


### PR DESCRIPTION
Implements [ADR 0023](docs/adr/0023-hooks-ship-through-two-deterministic-channels-an-in-repo-claude-code-plugin-and-a-living-docs-hooks-install-verb.md).

## Problem

`install.sh` shipped instructions and zero gates. It copied `SKILL.md` + `reference/` and generated pointer files, but never installed a hook — so a consumer project got the *rules* for CLI-first doc authoring with nothing enforcing them. This inverts the ADR 0019 principle that instructions never block and only gates block.

Worse, the committed wiring in this repo's `.claude/settings.json` points at `"$CLAUDE_PROJECT_DIR"/skills/living-docs/hooks/...`, a path that can only resolve inside a checkout of this bundle. Copying the scripts alone would not have fixed it.

## Solution — two deterministic channels, one source of truth

Both channels wire the same scripts in `skills/living-docs/hooks/`.

**1. Claude Code plugin (repo root is the plugin bundle).** `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `hooks/hooks.json` addressing scripts through `${CLAUDE_PLUGIN_ROOT}`, which removes the broken-path failure mode. Adoption:

```
/plugin marketplace add ejklock/living-docs-skill
/plugin install living-docs@living-docs
```

Self-hosted marketplace (`"source": "./"`), so there is no extra copy — the marketplace clones the repo regardless. This absorbs the external `living-docs-enforcer`, collapsing the "block rules exist in two places" duplication ADR 0021 accepted.

**2. `living-docs hooks install`, for every other harness.** Materializes the embedded scripts into `<project>/.living-docs/hooks/` at mode `0755`, merges the Claude Code wiring, and installs the `.githooks/pre-commit` doc-gate with `core.hooksPath`.

```
living-docs hooks install [--dir <path>] [--docs-dir <bundle>] [--dry-run]
living-docs hooks uninstall [--dir <path>] [--dry-run]
```

Sibling subcommands — there is no `--uninstall` flag.

Notable properties:
- **Idempotent.** Re-running converges on the same bytes; entries are replaced by the `.living-docs/hooks/` identity, not appended.
- **JSON is parsed, never spliced.** An existing `settings.json` round-trips through `serde_json`; unrelated entries and unrelated top-level keys survive verbatim.
- **Bundle resolved at install time**, pinned into the generated wiring as `LIVING_DOCS_BUNDLE`. The shell script keeps its existing env-var contract and gains no discovery logic. No resolvable bundle → exit 2 naming the flag to pass.
- **Fail-open pre-commit.** No resolvable binary → stderr notice, exit 0. Outside a git repo, `core.hooksPath` warns but the verb still succeeds.
- **`--dry-run` writes nothing** while reporting the same plan, for both verbs.

**3. `install.sh` grows no hook logic** (ADR 0023 decision 4). Only a header pointer and one `log` line naming the correct channel per harness. JSON merging in bash is fragile, and duplicating the wiring there would put the mechanics outside the deterministic layer that owns them.

## Scope note

Cursor and Copilot still get no write-time gate — neither exposes a pre-write hook. They retain the pre-commit and CI gates. Unchanged from ADR 0021, documented explicitly in the README.

## Verification

Delivered in 5 vertical slices, each individually reviewed, plus a cross-slice pass.

- `cli/tests/hooks_install.rs` — materialization + mode, idempotence, dry-run, unrelated-entry preservation, bundle pinning, exit 2 on unresolvable bundle, uninstall (including the no-op case), pre-commit fail-open.
- `cli/tests/plugin_manifest.rs` — manifests parse and the version matches `VERSION`; every `hooks[].command` is `${CLAUDE_PLUGIN_ROOT}`-prefixed and resolves to an existing executable file; the marketplace lists exactly one self-hosted plugin.
- Both run under `make check`, verified by execution, not by inspection.

`make check` → exit 0 (44 unit tests, 14 integration binaries, 11/11 doc fixtures, all hook fixtures, shellcheck + `bash -n` clean).

## Follow-ups (not in this PR)

- Release pipeline: the v0.7.0 release job died at `make check` before `release-binaries` ran, so that tag carries zero assets, and v0.8.0 was never tagged. Needs an asset-verification gate so a zero-binary release fails loudly.
- Deprecate `living-docs-enforcer` in `ai-configs` and point its README here.
- Consider `living-docs hooks check` to report drift between materialized scripts and the embedded corpus.

🤖 Co-authored with Claude Code

Evaldo Klock <neto.nemesis@gmail.com>
