### PR TITLE
feat(ci): fail the release when an expected binary asset is missing or corrupt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,9 @@ name: Release
 # into a versioned zip, and publishes a GitHub Release with auto-generated notes. A second
 # job then cross-compiles the `living-docs` binary for each supported target and uploads
 # `living-docs-<target-triple>` + its `.sha256` to the same release — install.sh downloads
-# these by that exact name (asset-naming contract).
+# these by that exact name (asset-naming contract). A third job, `verify-release-assets`,
+# runs `if: always()` after the first two and demotes the release to a draft if any expected
+# asset is missing or checksum-invalid (ADR 0024).
 
 on:
   push:
@@ -106,3 +108,15 @@ jobs:
           files: |
             living-docs-${{ matrix.target }}
             living-docs-${{ matrix.target }}.sha256
+
+  verify-release-assets:
+    needs: [release, release-binaries]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify every expected release asset is published and checksum-valid
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./scripts/verify-release-assets.sh "${GITHUB_REF_NAME}"

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ LIVING_DOCS_BIN := target/release/living-docs
 .PHONY: help install install-claude install-cursor install-copilot \
         install-opencode install-codex install-pi install-all install-pocock \
         project-claude project-opencode project-codex project-pi \
-        uninstall uninstall-all check lint test-fixtures test-hooks version \
+        uninstall uninstall-all check lint test-fixtures test-hooks \
+        test-release-gate version \
         cli-dev-image cli-build cli-test cli-fmt cli-clippy build cli-install \
         up down db-up db-psql db-logs db-test
 
@@ -83,9 +84,10 @@ uninstall: ## Remove the global Claude Code install
 uninstall-all: ## Remove the install for every supported harness
 	$(INSTALL) all --uninstall
 
-check: version build test-fixtures test-hooks ## Check version sync, validate install.sh, run Rust tests, living-docs check + mermaid, hook fixtures, dry-run harnesses
+check: version build test-fixtures test-hooks test-release-gate ## Check version sync, validate install.sh, run Rust tests, living-docs check + mermaid, hook fixtures, release-asset gate fixtures, dry-run harnesses
 	bash -n install.sh
 	bash -n scripts/check-version.sh
+	bash -n scripts/verify-release-assets.sh
 	cargo test --manifest-path cli/Cargo.toml
 	$(LIVING_DOCS_BIN) check examples/linkly/docs
 	$(LIVING_DOCS_BIN) check --mermaid-only
@@ -96,6 +98,9 @@ test-fixtures: build ## Run the hostile/negative fixtures that guard the check p
 
 test-hooks: ## Run the write-gate hook fixtures (ADR 0021)
 	./skills/living-docs/tests/hooks/run.sh
+
+test-release-gate: ## Run the verify-release-assets.sh fixtures (ADR 0024), stubbed gh
+	./scripts/tests/verify-release-assets/run.sh
 
 version: ## Assert the release version is consistent across VERSION and every SKILL.md
 	./scripts/check-version.sh

--- a/docs/adr/0024-a-release-is-atomic-a-missing-binary-asset-fails-the-workflow-and-demotes-the-release-to-a-draft.md
+++ b/docs/adr/0024-a-release-is-atomic-a-missing-binary-asset-fails-the-workflow-and-demotes-the-release-to-a-draft.md
@@ -1,0 +1,115 @@
+---
+type: ADR
+title: "A release is atomic: a missing binary asset fails the workflow and demotes the release to a draft"
+description: A release job that publishes an incomplete asset set fails loudly and demotes the release to a draft, so install.sh never sees a half-published tag.
+status: Accepted
+timestamp: 2026-07-29T16:08:56Z
+---
+
+# 0024. A release is atomic: a missing binary asset fails the workflow and demotes the release to a draft
+
+## Context
+
+`install.sh` already downloads a prebuilt `living-docs-<target-triple>` binary from the
+GitHub Release matching `VERSION`, verifies its `.sha256`, and only builds from source when
+that download fails. The `Release` workflow already cross-compiles four targets and uploads
+each binary plus its checksum. On paper the "no Makefile needed" path is complete.
+
+In practice it has never worked. The `v0.7.0` release run failed at `make check` —
+`make test-fixtures` rejected two of the repo's own frontmatter fixtures (the bug ADR 0022
+later fixed). The `release` job died, `release-binaries` `needs: release` and was therefore
+skipped, and the tag was published carrying **zero assets**. `v0.8.0` was never tagged at all.
+
+Nothing detected this. The failure surfaced only as a red run nobody read, while
+`install.sh` degraded exactly as designed: `release asset unavailable for <triple>; falling
+back to build from source`. The consumer experience — "it still needs the Makefile" — is the
+*symptom*; the cause is a release that publishes successfully while being incomplete.
+
+Two structural gaps make a partial release possible and silent:
+
+1. `release-binaries` uses `fail-fast: false`, so one broken target does not stop the other
+   three from uploading. That is the right build policy — we want to learn which targets
+   broke — but it means a green-ish run can still leave a release short of assets.
+2. No step ever asserts the *published* result. Each job verifies its own step; nothing
+   verifies the release as a whole.
+
+The asset names are a contract: `install.sh` constructs the download URL from
+`living-docs-$triple` and `$asset.sha256`. A rename on either side breaks adoption silently,
+and no test covers that agreement.
+
+## Decision
+
+We will treat a release as **atomic**: it is complete or it is not a release.
+
+**1. A `verify-release-assets` job asserts the published asset set.** It runs after
+`release-binaries` with `if: always()`, so it executes precisely in the cases worth catching
+— a skipped or partially failed matrix. It reads the published assets with
+`gh release view "$GITHUB_REF_NAME"` and compares them against a hard-coded expected list:
+the skills zip and its `.sha256`, plus `living-docs-<triple>` and `living-docs-<triple>.sha256`
+for each of the four supported targets. Any missing name fails the job, naming every absent
+asset.
+
+**2. An incomplete release is demoted to a draft, not left published.** Before failing, the
+job runs `gh release edit --draft`. A draft is invisible to `install.sh` (its download 404s
+the same way an absent asset does) and, unlike deletion, preserves the run for diagnosis and
+lets a re-run promote it. Rationale: the window between "assets partially uploaded" and "a
+human notices the red run" is exactly when a consumer installs a broken version.
+
+**3. The gate lives in `scripts/verify-release-assets.sh`, not inline in the YAML.** Inline
+`run:` blocks are invisible to every linter this repo owns — `make check` shell-checks
+`install.sh` and `scripts/check-version.sh` and never parses workflow YAML. A real script
+file is syntax-checked by `make check`, runnable locally against any existing tag, and
+reviewable like any other code. The workflow job becomes a one-line invocation.
+
+**4. The gate verifies integrity, not just presence.** For each expected binary it downloads
+the asset and its `.sha256` and verifies the checksum with the same comparison `install.sh`
+performs. Presence catches the skipped-job failure; the checksum catches a truncated or
+mismatched upload. This is the only place the asset-naming contract is executed end-to-end
+rather than asserted in a comment.
+
+We will not change `install.sh`. Its fallback-to-source behavior is correct and already
+announces itself; the defect is on the publishing side.
+
+## Consequences
+
+**Easier / gained:**
+- A tag either yields four verified binaries or does not yield a usable release at all.
+- The asset-naming contract between the workflow and `install.sh` becomes executable instead
+  of a comment in the workflow header.
+- `install.sh` stops being a de-facto source builder for users on supported platforms, which
+  is the outcome originally intended when the download path was added.
+- The gate can be run by hand against any past tag to audit what that release actually
+  shipped, which is how `v0.7.0`'s emptiness would have been found.
+
+**Harder / accepted trade-offs:**
+- Releasing gets slower: the gate downloads every binary before the release is trusted.
+  Accepted — it runs once per tag and the assets are small.
+- A transient GitHub API or download failure can demote an otherwise good release to a draft.
+  Accepted: a draft is recoverable by re-running the job, whereas a silently broken published
+  release is not recoverable at all once someone has installed from it.
+- The gate needs `contents: write` to demote, which the workflow already grants.
+- The supported target triples are now named in two places — the build matrix and the gate's
+  expected list. Accepted rather than deriving one from the other: parsing the matrix out of
+  the YAML at runtime trades a visible, greppable list for fragile introspection. The gate
+  fails loudly if they disagree, which is the behavior that matters.
+
+**Follow-ups:**
+- Consider having the gate promote a verified draft to published, inverting the default so a
+  release is born draft and earns publication.
+
+## Verification
+
+**Implementation impact:** `scripts/verify-release-assets.sh` (new), `.github/workflows/release.yml`
+(one new job invoking it), `Makefile` (`bash -n` coverage for the new script).
+
+**Verification criteria:**
+- `scripts/verify-release-assets.sh <tag>` exits 0 against a release carrying all ten expected
+  assets, and exits non-zero naming every absent asset when any is missing.
+- On failure the script demotes the release with `gh release edit <tag> --draft` before
+  exiting non-zero; on success it leaves the release published and untouched.
+- For every expected binary the script recomputes the SHA-256 of the downloaded asset and
+  compares it to the published `.sha256`; a mismatch fails the script.
+- `verify-release-assets` runs with `if: always()` after `release-binaries`, so a skipped or
+  partially failed matrix still reaches the gate.
+- Fitness function: `make check` runs `bash -n scripts/verify-release-assets.sh`, so the gate
+  cannot be merged unparseable — the same coverage `install.sh` and `check-version.sh` get.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -30,6 +30,7 @@ repo teaches. The decision *log* is this listing plus each record's `status` /
 * [0021 — Enforcement layers ship with the repo: write-gate hook, session teaching, and pre-commit doc-gate](0021-enforcement-layers-ship-with-the-repo-write-gate-hook-session-teaching-and-pre-commit-doc-gate.md) - Accepted
 * [0022 — Canonical frontmatter check is scoped to CLI-owned type directories](0022-canonical-frontmatter-check-is-scoped-to-cli-owned-type-directories.md) - Accepted
 * [0023 — Hooks ship through two deterministic channels: an in-repo Claude Code plugin and a living-docs hooks install verb](0023-hooks-ship-through-two-deterministic-channels-an-in-repo-claude-code-plugin-and-a-living-docs-hooks-install-verb.md) - Accepted
+* [0024 — A release is atomic: a missing binary asset fails the workflow and demotes the release to a draft](0024-a-release-is-atomic-a-missing-binary-asset-fails-the-workflow-and-demotes-the-release-to-a-draft.md) - Accepted
 
 ## Superseded
 

--- a/docs/issues/index.md
+++ b/docs/issues/index.md
@@ -14,10 +14,6 @@ one slice per fresh context, starting from the skeleton.
 
 ## Closed
 
-* [0008 — Three-pane web shell with metadata panel and Cmd+K palette](0008-three-pane-web-shell-with-metadata-panel-and-cmd-k-palette.md) - done
-* [0008 — living-docs brief — deterministic pre-filled scaffold, judgment slots left empty](0008-brief-scaffold.md) - done
-* [0009 — Per-type doc size targets (skill corpus + advisory check warning) + the same-change economic rationale](0009-doc-size-targets.md) - done
-
 * [0001 — Walking skeleton — Cargo workspace + living-docs-core + fs-store + thin cli](0001-workspace-core-skeleton.md) - done
 * [0002 — Findability — db sync builds a SQLite/FTS5 read-model and living-docs search queries it](0002-findability-search.md) - done
 * [0003 — Read-only web view — axum search + record page over the read-model](0003-web-read-only.md) - done
@@ -25,3 +21,6 @@ one slice per fresh context, starting from the skeleton.
 * [0005 — projects root + multi-project ingestion and cross-project search](0005-projects-multi-project.md) - done
 * [0006 — db-mode authoritative authoring — new/index/supersede/check on db-store, lossless .md export](0006-db-mode-authoring.md) - done
 * [0007 — Dev environment — docker-compose (ParadeDB) + Makefile targets over the workspace](0007-docker-compose-dev-env.md) - done
+* [0008 — living-docs brief — deterministic pre-filled scaffold that leaves only the judgment slots for the authoring model](0008-brief-scaffold.md) - done
+* [0008 — Three-pane web shell with metadata panel and Cmd+K palette](0008-three-pane-web-shell-with-metadata-panel-and-cmd-k-palette.md) - done
+* [0009 — Per-type doc size targets — authoring convention in the skill corpus + advisory warning in check, plus the same-change economic rationale](0009-doc-size-targets.md) - done

--- a/scripts/tests/verify-release-assets/run.sh
+++ b/scripts/tests/verify-release-assets/run.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+#
+# run.sh — fixture tests for scripts/verify-release-assets.sh (ADR 0024 verification
+# criteria), driven entirely by a stub `gh` placed first on PATH. No network access and no
+# real GitHub release are involved.
+#
+# The stub logs every invocation to $GH_LOG, serves `release view` from a per-case fixture
+# list of asset names (or fails when the case declares the release absent), serves
+# `release download` by writing a payload file plus a matching or deliberately mismatching
+# .sha256, and serves `release edit` by only logging the call.
+#
+# Exit: 0 = all cases pass, 1 = at least one failed.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/../../verify-release-assets.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+TAG="v9.9.9"
+GH_LOG="$TMP/gh.log"
+STUB_BIN="$TMP/bin"
+mkdir -p "$STUB_BIN"
+
+cat >"$STUB_BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_call() { printf '%s\n' "$*" >>"$GH_LOG"; }
+
+sha256_of_stdin() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{print $1}'
+  else
+    shasum -a 256 | awk '{print $1}'
+  fi
+}
+
+release_view() {
+  local tag="$1"
+  log_call release view "$tag" --json assets --jq .assets[].name
+  [[ "${GH_RELEASE_ABSENT:-0}" == "1" ]] && exit 1
+  cat "$GH_ASSETS_FILE"
+}
+
+release_download() {
+  local tag="$1" pattern="" dir=""
+  shift
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --pattern) pattern="$2"; shift 2 ;;
+      --dir) dir="$2"; shift 2 ;;
+      --clobber) shift ;;
+      *) shift ;;
+    esac
+  done
+  log_call release download "$tag" --pattern "$pattern" --dir "$dir" --clobber
+  if [[ "$pattern" == *.sha256 ]]; then
+    local base="${pattern%.sha256}" hash mismatch_list=",${GH_MISMATCH_ASSETS:-},"
+    hash="$(printf 'payload:%s' "$base" | sha256_of_stdin)"
+    [[ "$mismatch_list" == *",$base,"* ]] && hash="$(printf '%064d' 0)"
+    printf '%s  %s\n' "$hash" "$base" >"$dir/$pattern"
+  else
+    printf 'payload:%s' "$pattern" >"$dir/$pattern"
+  fi
+}
+
+release_edit() {
+  local tag="$1"
+  log_call release edit "$tag" --draft
+}
+
+case "$1 $2" in
+  "release view") shift 2; release_view "$@" ;;
+  "release download") shift 2; release_download "$@" ;;
+  "release edit") shift 2; release_edit "$@" ;;
+  *) exit 1 ;;
+esac
+STUB
+chmod +x "$STUB_BIN/gh"
+
+ALL_ASSETS=(
+  "living-docs-skill-${TAG}.zip"
+  "living-docs-skill-${TAG}.zip.sha256"
+  "living-docs-aarch64-apple-darwin"
+  "living-docs-aarch64-apple-darwin.sha256"
+  "living-docs-x86_64-apple-darwin"
+  "living-docs-x86_64-apple-darwin.sha256"
+  "living-docs-x86_64-unknown-linux-gnu"
+  "living-docs-x86_64-unknown-linux-gnu.sha256"
+  "living-docs-aarch64-unknown-linux-gnu"
+  "living-docs-aarch64-unknown-linux-gnu.sha256"
+)
+
+write_assets_file() { # write_assets_file <file> <names...>
+  local file="$1"
+  shift
+  printf '%s\n' "$@" >"$file"
+}
+
+ASSETS_ALL="$TMP/assets-all.txt"
+write_assets_file "$ASSETS_ALL" "${ALL_ASSETS[@]}"
+
+ASSETS_MISSING_ONE="$TMP/assets-missing-one.txt"
+write_assets_file "$ASSETS_MISSING_ONE" \
+  "living-docs-skill-${TAG}.zip" \
+  "living-docs-skill-${TAG}.zip.sha256" \
+  "living-docs-x86_64-apple-darwin" \
+  "living-docs-x86_64-apple-darwin.sha256" \
+  "living-docs-x86_64-unknown-linux-gnu" \
+  "living-docs-x86_64-unknown-linux-gnu.sha256" \
+  "living-docs-aarch64-unknown-linux-gnu" \
+  "living-docs-aarch64-unknown-linux-gnu.sha256"
+
+ASSETS_ZIP_ONLY="$TMP/assets-zip-only.txt"
+write_assets_file "$ASSETS_ZIP_ONLY" "${ALL_ASSETS[@]:0:2}"
+
+fail=0
+
+reset_gh_state() { : >"$GH_LOG"; }
+
+invoke() { # invoke <ENV=val>... -- <script args...>
+  local envs=()
+  while [[ "$1" != "--" ]]; do
+    envs+=("$1")
+    shift
+  done
+  shift
+  reset_gh_state
+  OUT="$(env "${envs[@]}" PATH="$STUB_BIN:$PATH" GH_LOG="$GH_LOG" bash "$SCRIPT" "$@" 2>&1)"
+  RC=$?
+  LOG=""
+  [[ -f "$GH_LOG" ]] && LOG="$(cat "$GH_LOG")"
+}
+
+check() { # check <name> <ok:0|1>
+  if [[ "$2" == 1 ]]; then
+    printf '  ok    %s\n' "$1"
+  else
+    printf '  FAIL  %s\n' "$1"
+    printf '        exit=%s\n%s\n' "$RC" "$OUT" | sed 's/^/        out | /'
+    printf '%s\n' "$LOG" | sed 's/^/        log | /'
+    fail=1
+  fi
+}
+
+assert_exit() { # assert_exit <name> <expected>
+  local ok=0
+  [[ "$RC" == "$2" ]] && ok=1
+  check "$1" "$ok"
+}
+
+assert_out_has() { # assert_out_has <name> <substring>
+  local ok=0
+  grep -qF -- "$2" <<<"$OUT" && ok=1
+  check "$1" "$ok"
+}
+
+assert_out_line() { # assert_out_line <name> <exact-line>
+  local ok=0
+  grep -qxF -- "$2" <<<"$OUT" && ok=1
+  check "$1" "$ok"
+}
+
+assert_out_line_count() { # assert_out_line_count <name> <expected-count>
+  local ok=0 actual
+  actual="$(wc -l <<<"$OUT" | tr -d ' ')"
+  [[ "$actual" == "$2" ]] && ok=1
+  check "$1" "$ok"
+}
+
+assert_log_has() { # assert_log_has <name> <substring>
+  local ok=0
+  grep -qF -- "$2" <<<"$LOG" && ok=1
+  check "$1" "$ok"
+}
+
+assert_log_lacks() { # assert_log_lacks <name> <substring>
+  local ok=1
+  grep -qF -- "$2" <<<"$LOG" && ok=0
+  check "$1" "$ok"
+}
+
+echo "verify-release-assets fixtures"
+echo
+
+echo "case 1: all ten assets present, checksums valid"
+invoke "GH_ASSETS_FILE=$ASSETS_ALL" -- "$TAG"
+assert_exit  "1-exit-0"                 0
+assert_out_has "1-names-verified-count" "10"
+assert_log_lacks "1-no-demote"          "release edit"
+
+echo "case 2: one binary asset missing"
+invoke "GH_ASSETS_FILE=$ASSETS_MISSING_ONE" -- "$TAG"
+assert_exit    "2-exit-1"          1
+assert_out_has "2-names-missing"   "living-docs-aarch64-apple-darwin"
+assert_log_has "2-demotes"         "release edit $TAG --draft"
+
+echo "case 3: matrix skipped, only zip assets present"
+invoke "GH_ASSETS_FILE=$ASSETS_ZIP_ONLY" -- "$TAG"
+assert_exit "3-exit-1" 1
+assert_out_line_count "3-names-missing-count" 8
+for triple in aarch64-apple-darwin x86_64-apple-darwin x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu; do
+  assert_out_line "3-names-missing-living-docs-$triple"          "living-docs-$triple"
+  assert_out_line "3-names-missing-living-docs-$triple-checksum" "living-docs-$triple.sha256"
+done
+assert_log_has "3-demotes" "release edit $TAG --draft"
+
+echo "case 4: all present, one checksum mismatched"
+invoke "GH_ASSETS_FILE=$ASSETS_ALL" "GH_MISMATCH_ASSETS=living-docs-x86_64-unknown-linux-gnu" -- "$TAG"
+assert_exit    "4-exit-1"        1
+assert_out_line "4-names-mismatch" "living-docs-x86_64-unknown-linux-gnu"
+assert_log_has "4-demotes"        "release edit $TAG --draft"
+
+echo "case 5: release not found"
+invoke "GH_RELEASE_ABSENT=1" -- "$TAG"
+assert_exit      "5-exit-1"       1
+assert_out_has   "5-names-tag"    "$TAG"
+assert_log_lacks "5-no-demote"    "release edit"
+
+echo "case 6: --no-demote with a missing asset"
+invoke "GH_ASSETS_FILE=$ASSETS_MISSING_ONE" -- --no-demote "$TAG"
+assert_exit       "6-exit-1"    1
+assert_log_lacks  "6-no-demote" "release edit"
+
+echo "case 7: no tag argument"
+invoke --
+assert_exit    "7-exit-2"   2
+assert_out_has "7-usage"    "Usage:"
+
+echo
+if ((fail == 0)); then
+  echo "All verify-release-assets fixtures passed."
+  exit 0
+else
+  echo "verify-release-assets fixture failures."
+  exit 1
+fi

--- a/scripts/verify-release-assets.sh
+++ b/scripts/verify-release-assets.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# verify-release-assets.sh — assert a GitHub Release carries every expected asset with a
+# valid SHA-256 checksum (ADR 0024). A missing or mismatched asset demotes the release to a
+# draft with `gh release edit --draft` before failing, so install.sh never sees a
+# half-published tag. Checksum comparison mirrors install.sh's cli_verify_sha256
+# sha256sum-or-shasum portability handling.
+#
+# Usage:  verify-release-assets.sh [--no-demote] <tag>
+# Exit:   0 = every expected asset is present and checksum-valid
+#         1 = an asset is missing or checksum-mismatched (release demoted unless
+#             --no-demote), or the release itself could not be read (no demotion attempted)
+#         2 = usage error (missing tag argument)
+
+set -euo pipefail
+
+readonly TARGET_TRIPLES=(
+  aarch64-apple-darwin
+  x86_64-apple-darwin
+  x86_64-unknown-linux-gnu
+  aarch64-unknown-linux-gnu
+)
+
+usage() {
+  printf 'Usage: %s [--no-demote] <tag>\n' "$(basename "$0")" >&2
+}
+
+parse_args() {
+  DEMOTE=1
+  TAG=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --no-demote) DEMOTE=0 ;;
+      -h|--help) usage; exit 0 ;;
+      *) TAG="$1" ;;
+    esac
+    shift
+  done
+  [[ -n "$TAG" ]] || { usage; exit 2; }
+}
+
+expected_assets() {
+  local tag="$1" triple
+  printf '%s\n' "living-docs-skill-${tag}.zip"
+  printf '%s\n' "living-docs-skill-${tag}.zip.sha256"
+  for triple in "${TARGET_TRIPLES[@]}"; do
+    printf '%s\n' "living-docs-${triple}"
+    printf '%s\n' "living-docs-${triple}.sha256"
+  done
+}
+
+published_assets() {
+  local tag="$1"
+  gh release view "$tag" --json assets --jq '.assets[].name'
+}
+
+missing_assets() {
+  local published="$1" name
+  while IFS= read -r name; do
+    grep -qxF -- "$name" <<<"$published" || printf '%s\n' "$name"
+  done < <(expected_assets "$TAG")
+}
+
+sha256_of() {
+  local file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+  else
+    shasum -a 256 "$file" | awk '{print $1}'
+  fi
+}
+
+checksum_valid() {
+  local file="$1" sumfile="$2" expected actual
+  expected="$(awk '{print $1}' "$sumfile")"
+  actual="$(sha256_of "$file")"
+  [[ -n "$expected" && "$expected" == "$actual" ]]
+}
+
+download_binary_assets() {
+  local dir="$1" triple asset
+  for triple in "${TARGET_TRIPLES[@]}"; do
+    asset="living-docs-${triple}"
+    gh release download "$TAG" --pattern "$asset" --dir "$dir" --clobber
+    gh release download "$TAG" --pattern "${asset}.sha256" --dir "$dir" --clobber
+  done
+}
+
+mismatched_assets() {
+  local dir="$1" triple asset
+  download_binary_assets "$dir"
+  for triple in "${TARGET_TRIPLES[@]}"; do
+    asset="living-docs-${triple}"
+    checksum_valid "$dir/$asset" "$dir/${asset}.sha256" || printf '%s\n' "$asset"
+  done
+}
+
+demote_release() {
+  gh release edit "$TAG" --draft >/dev/null
+}
+
+fail_with() {
+  printf '%s\n' "$@"
+  [[ $DEMOTE -eq 1 ]] && { demote_release || true; }
+  exit 1
+}
+
+main() {
+  parse_args "$@"
+
+  local published missing mismatched count
+  WORKDIR="$(mktemp -d)"
+  trap 'rm -rf "$WORKDIR"' EXIT
+
+  if ! published="$(published_assets "$TAG" 2>/dev/null)"; then
+    printf 'release %s not found or unreadable\n' "$TAG" >&2
+    exit 1
+  fi
+
+  missing="$(missing_assets "$published")"
+  [[ -z "$missing" ]] || fail_with "$missing"
+
+  mismatched="$(mismatched_assets "$WORKDIR")"
+  [[ -z "$mismatched" ]] || fail_with "$mismatched"
+
+  count="$(expected_assets "$TAG" | wc -l | tr -d ' ')"
+  printf 'verified %s release assets for %s\n' "$count" "$TAG"
+}
+
+main "$@"


### PR DESCRIPTION
Implements [ADR 0024](docs/adr/0024-a-release-is-atomic-a-missing-binary-asset-fails-the-workflow-and-demotes-the-release-to-a-draft.md).

> Stacked on #25. Base will auto-retarget to `main` once #25 merges.

## Problem

`install.sh` already downloads a prebuilt `living-docs-<triple>` from the GitHub Release matching `VERSION`, verifies its `.sha256`, and only builds from source when that fails. The workflow already cross-compiles four targets and uploads each binary plus its checksum. On paper, "no Makefile needed" is done.

It has never actually worked. The `v0.7.0` release run failed at `make check` — `make test-fixtures` rejected two of the repo's own frontmatter fixtures (the bug ADR 0022 later fixed). The `release` job died, `release-binaries` `needs: release` and was therefore **skipped**, and the tag published carrying **zero assets**. `v0.8.0` was never tagged at all.

Nothing detected it. The only signal was a red run nobody read, while `install.sh` degraded exactly as designed:

```
release asset unavailable for aarch64-apple-darwin; falling back to build from source
```

"It still needs the Makefile" is the symptom. The cause is a release that publishes successfully while being incomplete.

Two structural gaps made that possible and silent:

1. `fail-fast: false` on the matrix means one broken target does not stop the other three from uploading. That is the right *build* policy — we want to learn which targets broke — but it lets a green-ish run leave the release short.
2. Nothing ever asserted the *published* result. Each job verified its own step; no job verified the release.

## Solution — a release is atomic

New `scripts/verify-release-assets.sh`, invoked by a new `verify-release-assets` job:

```yaml
needs: [release, release-binaries]
if: always()
```

`if: always()` is the point — the job runs *precisely* in the cases worth catching, when the matrix was skipped or partially failed.

The script:

- Builds the expected set from the four supported triples: the skills zip + `.sha256`, plus `living-docs-<triple>` and `living-docs-<triple>.sha256` for each target. **Ten assets.**
- **Collects every failure**, never short-circuits. A fully skipped matrix reports all eight missing binaries, not the first one.
- **Verifies integrity, not just presence.** Each binary is downloaded and its SHA-256 recomputed against the published `.sha256`, mirroring `install.sh`'s `cli_verify_sha256` portability handling (`sha256sum` or `shasum -a 256`). This is the only place the asset-naming contract is executed end-to-end rather than asserted in a comment.
- **Demotes an incomplete release to a draft** with `gh release edit --draft` before failing. A draft is invisible to `install.sh` and, unlike deletion, preserves the run for diagnosis and allows a re-run to promote it. The window between "assets partially uploaded" and "a human notices the red run" is exactly when a consumer installs a broken version.
- **Never demotes what it cannot verify.** An absent or unreadable release exits 1 without touching anything — there is nothing to demote. `--no-demote` supports auditing a past tag by hand without mutating it.

It lives in `scripts/`, not inline in the YAML, because inline `run:` blocks are invisible to every linter this repo owns. `make check` now runs `bash -n scripts/verify-release-assets.sh` alongside `install.sh` and `check-version.sh`.

## Verification

`scripts/tests/verify-release-assets/run.sh` — 7 cases against a stubbed `gh` on `PATH` that logs every invocation. No network, no real `gh`.

| Case | Asserts |
|---|---|
| all ten present, valid | exit 0, no `release edit` logged |
| one binary missing | exit 1, names it, demotes |
| matrix skipped (zip only) | exit 1, names **all eight** missing binaries, demotes |
| checksum mismatch | exit 1, names it, demotes |
| release absent | exit 1, names the tag, **no** demote attempted |
| `--no-demote` + missing | exit 1, **no** demote |
| no tag argument | exit 2, usage on stderr |

Assertions are whole-line (`grep -qxF`) plus an exact line count, not substring — `living-docs-<triple>` is a prefix of `living-docs-<triple>.sha256`, so substring matching would let a regression that dropped the bare binary names survive. That mutation was applied and confirmed to fail the suite before being reverted.

`make check` → exit 0. `shellcheck`, `bash -n`, and `actionlint` all clean.

## Not in scope

`install.sh` is untouched. Its fallback-to-source is correct and already announces itself; the defect was on the publishing side. `fail-fast: false` stays — it is deliberate.

After this and #25 merge, `v0.8.0` gets tagged and the gate proves the binaries actually shipped.

🤖 Co-authored with Claude Code

Evaldo Klock <neto.nemesis@gmail.com>
