### PR TITLE
feat(core): make a DocTypeSpec registry the sole doc-type enumeration

### DIFF
--- a/cli/tests/brief.rs
+++ b/cli/tests/brief.rs
@@ -1,3 +1,4 @@
+use living_docs_core::doc_type::{self, Identity};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
@@ -48,22 +49,28 @@ fn brief_scaffolds_a_numbered_record_with_filled_title_and_byte_identical_judgme
     let _ = fs::remove_dir_all(&docs);
 }
 
+fn numbered_type_tokens_and_dirs() -> Vec<(&'static str, &'static str)> {
+    doc_type::DOC_TYPES
+        .iter()
+        .filter_map(|spec| match spec.identity {
+            Identity::Numbered { dir } => Some((spec.token, dir)),
+            Identity::Singleton { .. } => None,
+        })
+        .collect()
+}
+
 #[test]
 fn brief_output_passes_check_for_every_supported_doc_type() {
     let docs = temp_dir("passes-check");
-    for (doc_type, title) in [
-        ("adr", "A Decision"),
-        ("bdr", "A Behavior"),
-        ("prd", "A Feature"),
-        ("issue", "A Slice"),
-    ] {
-        assert!(run_brief(&docs, doc_type, title).status.success());
+    let types = numbered_type_tokens_and_dirs();
+    for (doc_type, _) in &types {
+        assert!(run_brief(&docs, doc_type, "A Record").status.success());
     }
-    fs::write(
-        docs.join("index.md"),
-        "# Docs\n\n- [ADRs](/adr/index.md)\n- [BDRs](/bdr/index.md)\n- [PRDs](/prd/index.md)\n- [Issues](/issues/index.md)\n",
-    )
-    .unwrap();
+    let index_links: String = types
+        .iter()
+        .map(|(_, dir)| format!("- [{dir}](/{dir}/index.md)\n"))
+        .collect();
+    fs::write(docs.join("index.md"), format!("# Docs\n\n{index_links}")).unwrap();
     let indexed = living_docs()
         .args(["--docs-dir", docs.to_str().unwrap(), "index"])
         .output()
@@ -179,8 +186,13 @@ fn an_invalid_from_diff_range_fails_with_a_clear_error_and_writes_no_file() {
 #[test]
 fn brief_rejects_an_unsupported_doc_type() {
     let docs = temp_dir("unsupported");
+    let unsupported = "glossary";
+    assert!(
+        doc_type::spec_for(unsupported).is_none(),
+        "fixture premise broken: `{unsupported}` is now a registry token — pick another",
+    );
 
-    let output = run_brief(&docs, "constitution", "Root Rules");
+    let output = run_brief(&docs, unsupported, "Root Rules");
 
     assert!(!output.status.success());
     assert!(String::from_utf8_lossy(&output.stderr).contains("unsupported doc type"));

--- a/cli/tests/check_core.rs
+++ b/cli/tests/check_core.rs
@@ -1,3 +1,4 @@
+use living_docs_core::doc_type::{self, Identity};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
@@ -64,6 +65,27 @@ fn run_new(docs_dir: &Path, doc_type: &str, title: &str) -> Output {
         ])
         .output()
         .expect("failed to run living-docs new")
+}
+
+fn run_brief(docs_dir: &Path, doc_type: &str, title: &str) -> Output {
+    living_docs()
+        .args([
+            "--docs-dir",
+            docs_dir.to_str().unwrap(),
+            "brief",
+            doc_type,
+            title,
+        ])
+        .output()
+        .expect("failed to run living-docs brief")
+}
+
+fn singleton_token() -> &'static str {
+    doc_type::DOC_TYPES
+        .iter()
+        .find(|spec| matches!(spec.identity, Identity::Singleton { .. }))
+        .expect("registry must carry at least one singleton row")
+        .token
 }
 
 /// The fixture's `type` value is spread across three files as a double-quoted,
@@ -336,7 +358,11 @@ fn hand_written_frontmatter_fails_check_and_passes_after_fmt() {
 /// canonical violation on it, with no `fmt` pass required.
 #[test]
 fn fresh_new_scaffold_is_a_canonical_round_trip_fixed_point_for_every_doc_type() {
-    for doc_type in ["adr", "bdr", "prd", "issue"] {
+    let numbered_types = doc_type::DOC_TYPES
+        .iter()
+        .filter(|spec| matches!(spec.identity, Identity::Numbered { .. }))
+        .map(|spec| spec.token);
+    for doc_type in numbered_types {
         let docs = temp_bundle(&format!("fresh-scaffold-{doc_type}"));
 
         let new_output = run_new(&docs, doc_type, "Fixed Point");
@@ -355,4 +381,78 @@ fn fresh_new_scaffold_is_a_canonical_round_trip_fixed_point_for_every_doc_type()
 
         let _ = fs::remove_dir_all(&docs);
     }
+}
+
+/// ADR 0026 decision point 7: a briefed bundle-root singleton
+/// (`constitution.md`) is CLI-owned for the canonical-frontmatter invariant
+/// and exempt from directory-index membership — `check` reports neither a
+/// dangling markdown link left over from an unfilled slot nor a
+/// non-canonical frontmatter block.
+#[test]
+fn briefed_singleton_scaffold_passes_check_over_its_own_bundle() {
+    let docs = temp_bundle("briefed-singleton");
+    write(&docs, "index.md", "# Index\n");
+
+    let brief_output = run_brief(&docs, singleton_token(), "Acme Constitution");
+    assert!(
+        brief_output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&brief_output.stderr)
+    );
+
+    let singleton_file = doc_type::DOC_TYPES
+        .iter()
+        .find_map(|spec| match spec.identity {
+            Identity::Singleton { file } => Some(file),
+            Identity::Numbered { .. } => None,
+        })
+        .expect("registry must carry at least one singleton row");
+    assert!(
+        docs.join(singleton_file).is_file(),
+        "brief did not scaffold {singleton_file} at the bundle root"
+    );
+
+    let output = run_check(&docs);
+    let stdout = stdout_of(&output);
+    assert_eq!(output.status.code(), Some(0), "got:\n{stdout}");
+    assert!(stdout.contains("no invariant violations"), "got:\n{stdout}");
+
+    let _ = fs::remove_dir_all(&docs);
+}
+
+/// The other half of decision point 7's canonical-frontmatter ownership: a
+/// hand-written bundle-root singleton with non-canonical frontmatter is
+/// caught by `check`, not silently accepted because it sits outside every
+/// CLI-owned type directory. `constitution.md` is hardcoded, matching
+/// `constitution_md_is_exempt_from_the_directory_index_listing_requirement`
+/// above, with the same registry premise guarded explicitly so a renamed
+/// singleton row fails this assertion instead of silently testing the
+/// wrong path.
+#[test]
+fn hand_written_bundle_root_singleton_fails_check_with_the_fmt_remediation() {
+    let spec = doc_type::spec_for("constitution")
+        .expect("fixture premise broken: `constitution` is no longer a registered token");
+    assert_eq!(
+        spec.identity,
+        Identity::Singleton {
+            file: "constitution.md"
+        },
+        "fixture premise broken: the constitution row no longer names constitution.md — update this fixture",
+    );
+
+    let bundle = temp_bundle("hand-written-singleton");
+    write(&bundle, "index.md", "# Index\n");
+    write(
+        &bundle,
+        "constitution.md",
+        "---\ntitle: Acme  # a comment\ntype: Constitution\n---\n\n# Acme\n",
+    );
+
+    let output = run_check(&bundle);
+    let stdout = stdout_of(&output);
+
+    assert_eq!(output.status.code(), Some(1), "got:\n{stdout}");
+    assert!(stdout.contains("living-docs fmt"), "got:\n{stdout}");
+
+    let _ = fs::remove_dir_all(&bundle);
 }

--- a/cli/tests/index_supersede.rs
+++ b/cli/tests/index_supersede.rs
@@ -40,6 +40,34 @@ fn run_index_with_visibility(
         .expect("failed to run living-docs index")
 }
 
+fn run_check(docs: &Path) -> Output {
+    living_docs()
+        .args(["check", docs.to_str().unwrap()])
+        .output()
+        .expect("failed to run living-docs check")
+}
+
+/// `examples/linkly/docs` anchored at compile time via `CARGO_MANIFEST_DIR`,
+/// independent of the working directory `cargo test` is invoked from — a
+/// real bundle that passes `check` today and, notably, carries no
+/// `research/` directory (the type-registry token this round adds).
+fn linkly_fixture_dir() -> PathBuf {
+    PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/..")).join("examples/linkly/docs")
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).unwrap();
+    for entry in fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let dst_path = dst.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir_recursive(&entry.path(), &dst_path);
+        } else {
+            fs::copy(entry.path(), &dst_path).unwrap();
+        }
+    }
+}
+
 fn run_supersede(docs: &Path, old: &str, new: &str) -> Output {
     living_docs()
         .args(["--docs-dir", docs.to_str().unwrap(), "supersede", old, new])
@@ -401,6 +429,46 @@ fn index_without_a_type_regenerates_every_supported_type_present() {
 
     assert!(docs.join("adr/index.md").exists());
     assert!(docs.join("prd/index.md").exists());
+
+    let _ = fs::remove_dir_all(&docs);
+}
+
+/// The regression this round fixes (ADR 0026 decision point 7): a bundle
+/// that passes `check` must still pass `check` after a bare `index` run,
+/// for every registry token — not just the ones the bundle happens to use.
+/// `regenerate` used to call `fs::create_dir_all` unconditionally, so a bare
+/// sweep materialized an empty `index.md` (and its directory) for every
+/// registry token regardless of whether the bundle carried that type,
+/// producing a directory index unreachable from the bundle root (invariant
+/// 3). This is registry-blind by construction — it exercises every token in
+/// `all_type_tokens()` through the real bare-`index` sweep against a
+/// fixture that only uses a subset of them, so it keeps holding without
+/// editing as new types are registered.
+#[test]
+fn index_without_a_type_leaves_a_check_clean_bundle_check_clean() {
+    let docs = temp_dir("linkly-check-clean");
+    copy_dir_recursive(&linkly_fixture_dir(), &docs);
+
+    let before = run_check(&docs);
+    assert!(
+        before.status.success(),
+        "fixture must be check-clean before index: stdout: {}",
+        String::from_utf8_lossy(&before.stdout)
+    );
+
+    let index_output = run_index(&docs, None);
+    assert!(
+        index_output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&index_output.stderr)
+    );
+
+    let after = run_check(&docs);
+    assert!(
+        after.status.success(),
+        "bundle regressed from check-clean to failing after a bare index run: stdout: {}",
+        String::from_utf8_lossy(&after.stdout)
+    );
 
     let _ = fs::remove_dir_all(&docs);
 }

--- a/cli/tests/new.rs
+++ b/cli/tests/new.rs
@@ -1,3 +1,4 @@
+use living_docs_core::doc_type;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
@@ -130,13 +131,18 @@ fn new_preserves_body_placeholders_and_guidance_comments_verbatim() {
 #[test]
 fn new_rejects_an_unsupported_doc_type() {
     let docs = temp_dir("unsupported");
+    let unsupported = "glossary";
+    assert!(
+        doc_type::spec_for(unsupported).is_none(),
+        "fixture premise broken: `{unsupported}` is now a registry token — pick another",
+    );
 
-    let output = run_new(&docs, "constitution", "Root Rules");
+    let output = run_new(&docs, unsupported, "Root Rules");
 
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("unsupported doc type"));
-    assert!(!docs.join("constitution").exists());
+    assert!(!docs.join(unsupported).exists());
 
     let _ = fs::remove_dir_all(&docs);
 }

--- a/docs/adr/0026-a-single-doctype-registry-replaces-nine-hand-synced-enumerations-and-research-and-constitution-enter-as-rows.md
+++ b/docs/adr/0026-a-single-doctype-registry-replaces-nine-hand-synced-enumerations-and-research-and-constitution-enter-as-rows.md
@@ -1,0 +1,350 @@
+---
+type: ADR
+title: A single DocType registry replaces nine hand-synced enumerations, and research and constitution enter as rows
+description: One compile-time DocTypeSpec table becomes the sole enumeration of the doc-type taxonomy, so the nine sites that hand-synced it derive instead, and `research` and `constitution` are added as rows.
+status: Accepted
+timestamp: 2026-07-29T23:49:51Z
+---
+
+# 0026. A single DocType registry replaces nine hand-synced enumerations, and research and constitution enter as rows
+
+## Context
+
+The doc-type taxonomy is four tokens — `adr`, `bdr`, `prd`, `issue` — and it is
+written out by hand in **nine** places:
+
+| Site | Shape |
+|---|---|
+| `paths::dir_for` | token → directory |
+| `paths::doc_type_for_dir` | directory → token |
+| `paths::frontmatter_type_for` | token → frontmatter `type:` value |
+| `templates::template_for` | token → `include_str!` template |
+| `record::NUMBERED_DOC_TYPES` | which tokens carry number identity |
+| `index::SUPPORTED_TYPES` | which tokens `index` regenerates |
+| `commands::new::unsupported_type_message` | the list quoted at the user |
+| `commands::index::unsupported_type_message` | a byte-identical second copy |
+| `web::views::CREATABLE_DOC_TYPES` | which tokens the web create form offers |
+
+Nothing makes those nine agree. `new::plan_at` *asserts* the agreement at
+runtime:
+
+```rust
+let dir_name = paths::dir_for(doc_type).ok_or_else(|| unsupported_type_message(doc_type))?;
+let frontmatter_type = paths::frontmatter_type_for(doc_type)
+    .expect("dir_for and frontmatter_type_for cover the same doc types");
+let template = templates::template_for(doc_type)
+    .expect("dir_for and template_for cover the same doc types");
+```
+
+Adding a token to `dir_for` and forgetting `template_for` does not fail to
+compile and does not return an error. It **panics**, in a release binary, on a
+user's `new` invocation.
+
+Everywhere else the failure is quieter still. Unknown types degrade to defaults
+by design: `index::render_body` falls back to a flat listing, `heading_title_for`
+to the generic `"Index"`, `brief::slots_for` to an empty slot array. Each
+fallback is individually reasonable. Together they mean a **half-added type
+looks like a working type** — it creates records, it indexes, it just quietly
+lacks a partition axis, a heading and judgment slots.
+
+This is not hypothetical. It already happened:
+
+- `skills/living-docs/templates/constitution.md` exists, is fully authored, and
+  states its own semantics in a body comment: *"This file is singular — no NNNN
+  prefix, and it is NOT listed as a concept in any index.md."* It is wired into
+  nothing.
+- `templates::template_for` carries a test that **asserts** the gap:
+  `assert_eq!(template_for("constitution"), None)`.
+- `paths.rs` has two tests asserting `dir_for("constitution")` and
+  `dir_for("glossary")` are `None`.
+- `skills/living-docs/SKILL.md`'s tags already advertise `constitution` and
+  `research` as doc types the skill handles.
+
+So the taxonomy is advertised in the skill manifest, specified in a template,
+pinned as absent by three tests, and implemented for four of six types. The
+duplication did not merely risk drift — it produced it, and then the tests
+froze the drift in place.
+
+Two new types are wanted: `research` (this repo's own ADR template already links
+to `[research](/research/NNNN-<slug>.md)`, and consuming bundles carry
+`docs/research/NNNN-slug.md` records the CLI cannot create or index) and
+`constitution`. Adding them the current way costs eighteen edits across nine
+sites, with a silent-fallback failure mode on any one omission.
+
+## Decision
+
+We will make one compile-time table the sole enumeration of the taxonomy, have
+every existing site derive from it, and then add the two types as rows.
+
+**1. A registry module, `living-docs-core/src/doc_type.rs`.**
+
+```rust
+pub enum Identity {
+    /// `<dir>/NNNN-<slug>.md`; the number is allocated by `next`.
+    Numbered { dir: &'static str },
+    /// A single `<file>` relative to the bundle root; a second one is refused.
+    Singleton { file: &'static str },
+}
+
+pub struct DocTypeSpec {
+    pub token: &'static str,
+    pub identity: Identity,
+    pub frontmatter: &'static str,
+    pub template: &'static str,
+    pub index_heading: &'static str,
+    pub index_partition: IndexPartition,
+    pub web_creatable: bool,
+}
+
+pub const DOC_TYPES: &[DocTypeSpec] = &[ADR, BDR, PRD, ISSUE, RESEARCH, CONSTITUTION];
+
+pub fn spec_for(token: &str) -> Option<&'static DocTypeSpec>;
+pub fn spec_for_dir(dir: &str) -> Option<&'static DocTypeSpec>;
+```
+
+**Identity carries the path shape, so an inconsistent type is unrepresentable.**
+A directory is a field of the `Numbered` variant, not of the struct, so a
+singleton cannot have a stale directory and `dir_for` cannot return one for it.
+This is the load-bearing choice: the invariant `plan_at` asserts at runtime
+becomes a property of the type system.
+
+**2. Every one of the nine sites becomes a lookup.** `paths::dir_for`,
+`doc_type_for_dir` and `frontmatter_type_for` delegate to the registry;
+`templates::template_for` returns `spec.template`; `record::NUMBERED_DOC_TYPES`
+and `index::SUPPORTED_TYPES` are derived from `DOC_TYPES`;
+`web::CREATABLE_DOC_TYPES` filters on `web_creatable`. The public signatures of
+`paths::*` and `templates::template_for` do not change, so no caller outside
+these modules is touched.
+
+**3. All four `.expect()` calls are deleted.** The fragile three-line resolution
+appears **twice**, byte-identically: in `commands::new::plan_at` and in
+`commands::brief::scaffold_brief`. Each carries its own copy of both panics, so
+there are four, not two. One `spec_for(token)?` in each site yields the
+directory, the frontmatter value and the template together. Partial agreement is
+no longer expressible, so there is nothing left to assert.
+
+`brief.rs`'s per-type `slots_for` and `trail_comment_for` match arms are a
+different thing and stay: they enumerate *judgment-slot content*, not the
+taxonomy's identity, and are recorded as a follow-up below.
+
+**4. The unsupported-type message is generated from the registry** and the
+second copy is removed. A stale list at the user is no longer possible.
+
+**5. `research` enters as a `Numbered` row:** directory `research`, frontmatter
+`Research`, index heading `Research`, flat partition (a research record is a
+point-in-time audit; it has no Active/Superseded or Open/Closed lifecycle),
+`web_creatable: true`, and a new `skills/living-docs/templates/research.md`.
+
+**6. `constitution` enters as a `Singleton` row:** file `constitution.md` at the
+bundle root, frontmatter `Constitution`, `web_creatable: true`. Its existing
+template is wired with **one correction**: `status: Draft               # Draft |
+Ratified | Amended` carries the status domain as a trailing YAML comment, which
+no other template does and which a canonical frontmatter round-trip would flag.
+The domain moves into the HTML comment below the frontmatter, where `adr.md` and
+`bdr.md` already keep theirs. `living-docs new constitution "<title>"` writes
+`docs/constitution.md`; a second invocation is refused by the clobber guard
+`plan_at` already applies (`store.read(&target_path).is_ok()`), so the refusal
+needs no new code.
+
+**`index` sweeps Numbered rows only.** A singleton has no directory and therefore
+no directory index, so the bare `index` sweep iterates the `Identity::Numbered`
+tokens rather than every token — otherwise `compute` would resolve no directory
+for `constitution` and the sweep would exit non-zero. An explicit `index
+constitution` is an error with its own message: the type is supported, it simply
+has no index to regenerate, and reusing the unsupported-type message would lie.
+This narrows fitness function B accordingly: the token set `index` regenerates
+equals the registry's **Numbered** token set.
+
+**7. `check` honors the singleton contract.** `docs/constitution.md` is
+CLI-owned for the canonical-frontmatter invariant, and is **exempt from index
+membership** (invariant 3) — exactly as its template states. Both types are
+optional: a bundle with no `research/` directory and no `constitution.md` stays
+conformant, and `index` skips a type whose directory does not exist rather than
+creating it.
+
+**That last clause described an intention, not the code.** `commands::index::regenerate`
+called `fs::create_dir_all` unconditionally, so a bare `living-docs index` created
+an empty `index.md` for *every* registry token. With four rows this was invisible
+pollution — a bundle that uses the CLI has all four directories anyway. The fifth
+row turned it into a **check-breaking regression**: `examples/linkly/docs` passes
+`check`, and after one bare `index` run it fails with
+`research/index.md directory index not reachable from index.md (invariant 3)`,
+because the new directory index is not linked from the bundle root. So this
+decision now carries a code change it did not anticipate: `regenerate` is a no-op
+for a type whose directory does not exist. Directories come into existence when
+`new` writes the first record, never from `index`. The fitness function is the
+property, not the symptom: **a bundle that passes `check` still passes `check`
+after a bare `index` run.**
+
+**8. The one enumeration the registry cannot reach stays hardcoded, and is
+pinned by a cross-language fitness test.** `skills/living-docs/hooks/block-docs-handwrite.sh`
+is bash and matches CLI-owned directories with a literal alternation
+(`(adr|bdr|prd|issues)`, ADR 0020's scope). It cannot read a Rust `const`, and we
+will not make a PreToolUse gate shell out to the binary on every write — the hook
+must stay fast and fail-open, and the binary may be absent. So the bash copy
+remains a copy, and a Rust test reads the script, extracts the alternation group,
+and asserts it equals the registry's `Identity::Numbered` directories. The
+duplication survives; the *drift* does not.
+
+## Consequences
+
+**Easier / gained:**
+- Adding a doc type is one registry row plus one template file.
+- Two runtime panics on taxonomy inconsistency are removed, replaced by a
+  compile-time impossibility.
+- Three tests that pinned `constitution` and `glossary` as unsupported are
+  replaced by tests that hold the registry to its contract.
+- The error message the user reads can never disagree with what the tool
+  accepts.
+
+**Harder / accepted trade-offs:**
+- The registry is compile-time, so a doc type cannot be added by configuration.
+  This is deliberate: templates are `include_str!`-embedded to keep the binary
+  self-contained (ADR 0001), so a configured type could name a template that
+  does not exist — the config would be able to express a broken state that the
+  table cannot.
+- `Identity` becoming an enum makes `dir_for` fallible for a reason other than
+  "unknown type": a singleton has no directory. Callers that assumed a
+  directory for every known type must handle that, which is the point.
+
+**Follow-ups:**
+- ~~Whether `research` and `constitution` get `brief::slots_for` definitions is a
+  separate decision.~~ **Corrected during implementation: it is not separate, and
+  it is not optional.** `slots_for` returning `&[]` does not merely produce a
+  slot-less scaffold — it produces a **broken** one. Every judgment section a
+  slot collapses takes its placeholder links with it, which is precisely why
+  `trail_comment_for` wraps its stubs in an HTML comment ("so an unfilled
+  scaffold carries no dangling markdown links — `check` stays green on the raw
+  `brief` output"). A type with no slots keeps its template's
+  `[ADR](/adr/NNNN-<slug>.md)` placeholders as live links, and `check` reports
+  them. So the real invariant is: **a registry row the CLI will `brief` must
+  carry slot definitions**, and the registry-driven
+  `brief_output_passes_check_for_every_supported_doc_type` test is the fitness
+  function that enforces it — it caught this the first time a row was added
+  without them. `slots_for` and `trail_comment_for` stay outside the registry
+  (they are judgment-slot *content*, not identity), but they are no longer
+  optional per row.
+- `scaffold_brief` builds a numbered path unconditionally, so the identity branch
+  decision 6 adds to `new` must land in `brief` too. Until it does, `brief
+  constitution` would report the type as unsupported while `new constitution`
+  succeeds — a contradiction the singleton slice must close, not defer.
+- `check::size::has_size_target` matches on frontmatter values
+  (`"ADR" | "BDR" | "PRD" | "Issue"`) to decide which types carry the ~100-line
+  advisory. It is not one of the nine and does not drift when a row is added —
+  both new types correctly fall through to exempt, and a test already pins that.
+  Whether the advisory becomes a registry field is a separate decision; it
+  encodes an *epistemic category* (decision/execution record vs. long-form
+  evidence), not identity.
+- `check::canonical::in_cli_owned_dir` resolves ownership through
+  `paths::doc_type_for_dir`, so adding the `research` row silently makes
+  `docs/research/` CLI-owned for the canonical-frontmatter invariant in every
+  consuming bundle. That is the intended semantics — a type the CLI can create
+  is a type the CLI owns — but it means a bundle carrying hand-written research
+  records will start reporting them. This is a `check` behavior change delivered
+  by a registry row, and it belongs in the release notes.
+- `glossary` is the remaining authored-but-unwired template. It is now a
+  one-row addition whenever it is wanted.
+- **`is_bundle_singleton` is form-sensitive, and that is safe for a reason worth
+  writing down.** It decides ownership with `path == bundle.join(file)`, where
+  its sibling `in_cli_owned_dir` compares only a parent directory's `file_name`
+  and is therefore form-*insensitive*. Review raised the obvious worry: on macOS
+  `/tmp` symlinks to `/private/tmp`, so a bundle expressed one way and walked the
+  other would not compare equal, silently un-exempting the singleton and
+  reporting it as an orphan — a false positive in the gate. **It does not
+  reproduce**, and the reason is structural rather than lucky: `collect_md_files`
+  builds every path by joining onto the bundle root it was handed, and
+  `read_dir` does not resolve symlinks, so both sides of the comparison derive
+  from the same root by construction. A bundle reached through a symlink checks
+  identically to the same bundle reached directly.
+  The correctness therefore rests on an invariant that was unstated: **the paths
+  a `DocStore` enumerates under a bundle are rooted at the bundle it was given.**
+  That is the thing to pin with a test, not to paper over with a
+  `canonicalize` call — which would make a pure predicate touch the filesystem
+  and would break every in-memory-store unit test, whose fixture paths do not
+  exist on disk. A real regression traded for an imaginary one.
+- **The singleton's canonical contract now gates the db-mode write path.**
+  `check_violations` shares `run_all_checks`, so `db_store::write_checked`
+  rejects a `constitution.md` whose frontmatter is not canonical. That is the
+  intended direction — ADR 0016's write gate is "the same invariants `check`
+  enforces" — but it is a behavior change the web surface inherits without a
+  code change of its own.
+- **`docs/research/index.md` in this repository predates its own registry row.**
+  It was hand-written in a format the renderer no longer produces, so
+  `living-docs index research` will diff it. Regenerating it is mechanical and
+  deliberately deferred so it does not bury this ADR's implementation diff.
+
+## Verification
+
+**Implementation impact:** `living-docs-core/src/doc_type.rs` (new),
+`living-docs-core/src/paths.rs`, `living-docs-core/src/templates.rs`,
+`living-docs-core/src/record.rs`, `living-docs-core/src/commands/new.rs`,
+`living-docs-core/src/commands/brief.rs` (its `scaffold_brief` resolution, plus a
+`slots_for`/`trail_comment_for`/`context_marker_for` arm per new row — see the
+corrected follow-up), `living-docs-core/src/commands/index.rs`,
+`living-docs-core/src/check/canonical.rs`, `living-docs-core/src/check/mod.rs`,
+`living-docs-core/src/check/graph.rs`, `web/src/views.rs`,
+`living-docs-core/tests/hook_registry_parity.rs` (new),
+`skills/living-docs/hooks/block-docs-handwrite.sh`,
+`skills/living-docs/tests/hooks/run.sh`,
+`skills/living-docs/templates/research.md` (new),
+`skills/living-docs/templates/constitution.md`.
+
+`skills/living-docs/SKILL.md` was expected to need an edit and did not: it and
+every other prose surface spell the verb `living-docs new <type> "<title>"` with
+a placeholder rather than an enumeration, so a new row is documented the moment
+it exists. That is the shape the rest of this ADR is trying to reach.
+
+**Verification criteria:**
+- `living-docs new research "..."` creates `docs/research/0001-....md` with
+  `type: Research`, and `living-docs index research` renders a `Research`
+  heading listing it.
+- `living-docs new constitution "..."` creates `docs/constitution.md` with no
+  number; a second invocation exits non-zero saying it already exists, and
+  creates nothing.
+- `living-docs check` passes on a bundle containing both, and also on a bundle
+  containing neither — both types are optional.
+- `living-docs check` reports `docs/constitution.md` for non-canonical
+  frontmatter (it is CLI-owned) but never as an index orphan (it is exempt).
+- **Fitness function A:** a test iterating `DOC_TYPES` asserts every spec
+  resolves a non-empty template whose first line matches its `frontmatter`
+  value, and that `spec_for(spec.token)` round-trips. A row added with a
+  mismatched template fails it.
+- **Fitness function B:** a test asserts the number of `web_creatable` specs
+  equals the number of options the web create form renders, and that the
+  set of tokens `index` regenerates equals the `DOC_TYPES` **`Identity::Numbered`**
+  tokens (see decision 6: a singleton has no directory index). The three
+  surfaces cannot drift apart.
+- **Fitness function C:** a test asserts the unsupported-type error message
+  contains every token in `DOC_TYPES`, so the message cannot go stale.
+- **Fitness function D:** `grep` finds no literal `"bdr"` string list outside
+  `doc_type.rs` and `#[cfg(test)]` modules, *except* `brief::slots_for` and
+  `brief::trail_comment_for` — the nine taxonomy-identity enumerations are gone,
+  not merely supplemented. The two exempt sites match on type token to select
+  **judgment-slot content**, which is per-type prose, not identity; they are a
+  named follow-up below, not a leak. This is a prose check, not a test: a test
+  asserting the absence of a string in sibling source files would couple the
+  registry's tests to file layout, which is a worse invariant than the one it
+  guards.
+
+## Alternatives rejected
+
+**Add the two types to all nine sites and move on.** Rejected: that is the exact
+mechanism that produced the half-wired `constitution`, and it would leave the
+next type facing the same eighteen edits and the same two `.expect()` panics.
+Cheaper as a diff, more expensive as a repository.
+
+**A trait with one impl per doc type.** Rejected: the variation between types is
+*data* (a directory, a string, a partition axis), not behavior. Six near-identical
+impls is more code than six table rows, and iterating them still requires an
+enumeration — so the duplication would survive in the very place the trait was
+meant to remove it.
+
+**Runtime-configurable types from a TOML file.** Rejected: templates are
+compile-time embedded per ADR 0001. A configured type whose template is not in
+the binary cannot be created, so configuration would be able to express states
+the tool cannot honor. The table cannot.
+
+**Make `constitution` a numbered series** so it reuses the existing path
+entirely. Rejected: its own template already specifies singular semantics, and
+"constitution 0003" misrepresents the artifact — a project has one constitution,
+amended (there is an Amendment Log section for exactly that), not a series.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -31,6 +31,7 @@ repo teaches. The decision *log* is this listing plus each record's `status` /
 * [0022 — Canonical frontmatter check is scoped to CLI-owned type directories](0022-canonical-frontmatter-check-is-scoped-to-cli-owned-type-directories.md) - Accepted
 * [0023 — Hooks ship through two deterministic channels: an in-repo Claude Code plugin and a living-docs hooks install verb](0023-hooks-ship-through-two-deterministic-channels-an-in-repo-claude-code-plugin-and-a-living-docs-hooks-install-verb.md) - Accepted
 * [0024 — A release is atomic: a missing binary asset fails the workflow and demotes the release to a draft](0024-a-release-is-atomic-a-missing-binary-asset-fails-the-workflow-and-demotes-the-release-to-a-draft.md) - Accepted
+* [0026 — A single DocType registry replaces nine hand-synced enumerations, and research and constitution enter as rows](0026-a-single-doctype-registry-replaces-nine-hand-synced-enumerations-and-research-and-constitution-enter-as-rows.md) - Accepted
 
 ## Superseded
 

--- a/docs/issues/0014-docs-dir-is-silently-accepted-but-ignored-by-fmt-and-check-which-operate-on-the-cwd-bundle.md
+++ b/docs/issues/0014-docs-dir-is-silently-accepted-but-ignored-by-fmt-and-check-which-operate-on-the-cwd-bundle.md
@@ -1,0 +1,31 @@
+---
+type: Issue
+title: "--docs-dir is silently accepted but ignored by fmt and check, which operate on the cwd bundle"
+description: Make fmt and check either honor --docs-dir or hard-error on it, so the flag can never silently rewrite a different tree than the one the user pointed at.
+status: Proposed
+timestamp: 2026-07-30T18:58:08Z
+---
+
+## Problem
+
+`fmt` and `check` accept `--docs-dir` in both global and subcommand position without error, but ignore it and operate on the `docs/` bundle of the CURRENT WORKING DIRECTORY. Their `--help` does document that they match `[BUNDLE_ROOT]` positionally "rather than the global `--docs-dir`" — but accepting the flag silently and mutating a different tree than the one the user pointed at turns a documented quirk into a footgun. The other authoring verbs (`new`, `status`, `index`, `supersede`) honor the flag, so the same spelling changes meaning per verb.
+
+## Repro (v0.8.0 release binary, macOS arm64)
+
+```
+mkdir -p repro/cwd/docs/adr repro/target/adr
+cp <some-non-canonical-record>.md repro/cwd/docs/adr/
+cp <same-record>.md repro/target/adr/
+cd repro/cwd
+living-docs --docs-dir "$PWD/../target" fmt   # exit 0, "1 record(s) rewritten"
+```
+
+Result: `repro/cwd/docs/adr/<record>.md` REWRITTEN (sha256 changed), `repro/target/adr/<record>.md` UNTOUCHED (sha256 identical). Same outcome with the flag in subcommand position (`living-docs fmt --docs-dir ../target` → "0 record(s) rewritten" because the cwd copy was already canonical). The positional form `living-docs fmt ../target` works as designed.
+
+## Impact
+
+In a downstream repo (ai-configs, 2026-07-30) an agent session ran `living-docs --docs-dir <scratch-copy> fmt` intending an isolated experiment; the CLI rewrote 145 records of the LIVE tree with exit 0, and the mutation was only caught later by `git status`. Recovery required restoring 137 files from HEAD.
+
+## Proposal
+
+Either honor `--docs-dir` in `fmt`/`check` as the bundle root, or hard-error when the flag is combined with these verbs ("fmt/check take a positional bundle root; --docs-dir is not honored"). At minimum, print the RESOLVED bundle root before rewriting. Silent acceptance + cwd fallback is the one behavior that should be impossible.

--- a/docs/issues/0015-status-with-a-bare-record-number-resolves-across-type-directories-adrs-first.md
+++ b/docs/issues/0015-status-with-a-bare-record-number-resolves-across-type-directories-adrs-first.md
@@ -1,0 +1,23 @@
+---
+type: Issue
+title: status with a bare record number resolves across type directories, ADRs first
+description: Accept a type qualifier on status and hard-error on an ambiguous bare record number, so a number shared across type directories can no longer mutate the wrong record.
+status: Proposed
+timestamp: 2026-07-30T18:58:44Z
+---
+
+## Problem
+
+`living-docs status <N> <Status>` resolves a bare record number against every type directory, ADRs first. When a number exists in more than one type (adr/0016 and issues/0016), the verb mutates the ADR even when the user means the issue — there is no type disambiguator in the invocation.
+
+## Repro (v0.8.0)
+
+In a bundle containing both `adr/0016-*.md` and `issues/0016-*.md`: `living-docs status 16 Deprecated` → rewrites the ADR's `status:` frontmatter. Observed live in a downstream repo (ai-configs, 2026-07-30); the accidental ADR status change had to be reverted from HEAD.
+
+## Workaround
+
+Scope the search with the honored flag: `living-docs --docs-dir docs/issues status 16 Deprecated`.
+
+## Proposal
+
+Accept a type qualifier — `living-docs status issue 16 Deprecated` or `--type issue` — and hard-error on an ambiguous bare number instead of picking the first directory scanned.

--- a/docs/issues/0016-check-needs-a-ratchet-or-changed-files-mode-so-brownfield-repos-can-arm-the-pre-commit-channel.md
+++ b/docs/issues/0016-check-needs-a-ratchet-or-changed-files-mode-so-brownfield-repos-can-arm-the-pre-commit-channel.md
@@ -1,0 +1,19 @@
+---
+type: Issue
+title: check needs a ratchet or changed-files mode so brownfield repos can arm the pre-commit channel
+description: Give check a baseline or changed-files mode so a brownfield bundle can arm the pre-commit channel against new debt while legacy debt is paid down incrementally.
+status: Proposed
+timestamp: 2026-07-30T18:58:58Z
+---
+
+## Problem
+
+The `hooks install` pre-commit channel (ADR 0023) execs a FULL-bundle `living-docs check`. In a brownfield bundle with pre-existing debt, one legacy violation fails every future commit regardless of what the commit touches — so the channel cannot be armed at all until the entire bundle is clean.
+
+## Evidence
+
+Downstream adoption attempt (ai-configs, 2026-07-30, v0.8.0): `living-docs check docs` → FAIL, 180 violations across 177 docs (hand-written frontmatter, orphans, broken links, size advisories). `fmt` did not reduce the residue (145 records rewritten, violations 180 -> 185). The repo adopted the channel DISARMED — artifacts committed, `core.hooksPath` left unset — with arming blocked on this gap (its ADR 0072 / issue 0017).
+
+## Proposal
+
+Any of: (a) `check --baseline <ref>` — fail only on violations not present at the ref (diff-aware ratchet, the quality-gate pattern); (b) `check --changed-files <list>` — scope invariants to the files in the commit; (c) an accepted-debt manifest (`.living-docs/check-baseline`) that `check` subtracts and `fmt`/authoring can shrink but never grow. The pre-commit hook then gates NEW debt while legacy debt is paid down incrementally.

--- a/docs/issues/0017-bundle-vocabulary-gaps-no-research-doc-type-in-index-and-no-terminal-closed-status-for-issues.md
+++ b/docs/issues/0017-bundle-vocabulary-gaps-no-research-doc-type-in-index-and-no-terminal-closed-status-for-issues.md
@@ -1,0 +1,29 @@
+---
+type: Issue
+title: "bundle vocabulary gaps: no research doc type in index and no terminal closed status for issues"
+description: Close the two bundle vocabulary gaps — a research type the index cannot generate, and issues with no terminal closed status.
+status: Proposed
+timestamp: 2026-07-30T18:59:13Z
+---
+
+## Problem
+
+Two vocabulary gaps surfaced by a downstream bundle (ai-configs) that this repo's own bundle shares:
+
+- `index` supports only `adr|bdr|prd|issue`. Bundles carrying a `research/` directory (including THIS repo's `docs/research/`) cannot generate `research/index.md` via the CLI, so every research note is a permanent invariant-3 orphan that `check` flags and nothing can fix.
+- `status` accepts only `Proposed|Accepted|Deprecated` (plus `supersede`). Issues have no terminal `closed`/`resolved` state: a downstream repo had to close a FIXED bug report as `Deprecated`, which misstates the outcome.
+
+## Status of each half
+
+The first half is **done**: ADR 0026 made `research` a row in the `DocTypeSpec`
+registry, so `living-docs new research` and `living-docs index research` both
+work and a research note is no longer a permanent invariant-3 orphan. It was not
+added to a type set — the type set was replaced by the registry, which is why the
+fix generalizes to the next type instead of repeating this issue.
+
+The second half is **open**: `status` still has no terminal state for an issue.
+
+## Proposal
+
+- ~~Add `research` to the `index` type set (same list format; title/status columns as for issues), or make the type set bundle-configurable.~~ Delivered by ADR 0026.
+- Add issue-appropriate terminal statuses (`Resolved`, `Closed`, or a `resolution:` field) to the `status` verb's vocabulary, keeping the ADR lifecycle untouched.

--- a/docs/issues/index.md
+++ b/docs/issues/index.md
@@ -11,6 +11,10 @@ one slice per fresh context, starting from the skeleton.
 * [0011 — Atlas edit — optimistic concurrency via a revision precondition](0011-atlas-edit-optimistic-concurrency-via-revision-precondition.md) - open
 * [0012 — Atlas supersede — browser parity with the CLI supersede verb](0012-atlas-supersede-browser-parity-with-the-cli-supersede-verb.md) - open
 * [0013 — Atlas delete — a new verb with no CLI precedent](0013-atlas-delete-a-new-verb-with-no-cli-precedent.md) - open
+* [0014 — --docs-dir is silently accepted but ignored by fmt and check, which operate on the cwd bundle](0014-docs-dir-is-silently-accepted-but-ignored-by-fmt-and-check-which-operate-on-the-cwd-bundle.md) - Proposed
+* [0015 — status with a bare record number resolves across type directories, ADRs first](0015-status-with-a-bare-record-number-resolves-across-type-directories-adrs-first.md) - Proposed
+* [0016 — check needs a ratchet or changed-files mode so brownfield repos can arm the pre-commit channel](0016-check-needs-a-ratchet-or-changed-files-mode-so-brownfield-repos-can-arm-the-pre-commit-channel.md) - Proposed
+* [0017 — bundle vocabulary gaps: no research doc type in index and no terminal closed status for issues](0017-bundle-vocabulary-gaps-no-research-doc-type-in-index-and-no-terminal-closed-status-for-issues.md) - Proposed
 
 ## Closed
 

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -4,5 +4,5 @@ External evidence and technology evaluation backing the decisions in this repo. 
 append-only (evidence is dated) and sourced; an accepted recommendation becomes an ADR/BDR that
 spawns implementation slices.
 
-* [Worldwide PII detection catalog — deterministic regex + checksum reference](0001-worldwide-pii-detection-catalog.md)
-* [Ontology tooling and the code-to-docs bridge — Rust-native options for a living-docs knowledge layer](0002-ontology-tooling-codegraph-docs-bridge.md)
+* [0001 — Worldwide PII detection catalog — deterministic regex + checksum reference](0001-worldwide-pii-detection-catalog.md) - Accepted
+* [0002 — Ontology tooling and the code-to-docs bridge — Rust-native options for a living-docs knowledge layer](0002-ontology-tooling-codegraph-docs-bridge.md) - Accepted

--- a/living-docs-core/src/check/canonical.rs
+++ b/living-docs-core/src/check/canonical.rs
@@ -11,7 +11,7 @@
 //! untouched as long as its formatting was already canonical.
 
 use super::records::is_reserved;
-use super::{file_name_str, Reporter};
+use super::{file_name_str, is_bundle_singleton, Reporter};
 use crate::frontmatter::frontmatter_block;
 use crate::paths::doc_type_for_dir;
 use crate::record::{extract_record, to_canonical_markdown};
@@ -33,18 +33,24 @@ fn in_cli_owned_dir(path: &Path) -> bool {
         .is_some()
 }
 
-/// Flags every non-reserved record inside a CLI-owned type directory whose
-/// on-disk frontmatter block differs from its canonical re-serialization.
-/// Hand-authored records (research, bundle-root notes) are out of scope, and
-/// a record carrying no frontmatter block at all is the existing untyped-doc
-/// check's concern — both are skipped here.
+/// Flags every non-reserved record the CLI can produce byte-for-byte whose
+/// on-disk frontmatter block differs from its canonical re-serialization: a
+/// record inside a CLI-owned type directory (`new`'s numbered types,
+/// including `research` since ADR 0026), and a bundle-root registry
+/// [`crate::doc_type::Identity::Singleton`] file such as `constitution.md`
+/// (ADR 0026 decision point 7). A record outside both — a hand-authored
+/// bundle-root note, or the same filename nested in a subdirectory — is out
+/// of scope, and a record carrying no frontmatter block at all is the
+/// existing untyped-doc check's concern; both are skipped here.
 pub(crate) fn check_canonical_frontmatter(
     store: &dyn DocStore,
+    bundle: &Path,
     all_md: &[PathBuf],
     reporter: &mut Reporter,
 ) {
     for path in all_md {
-        if is_reserved(&file_name_str(path)) || !in_cli_owned_dir(path) {
+        let owned = in_cli_owned_dir(path) || is_bundle_singleton(bundle, path);
+        if is_reserved(&file_name_str(path)) || !owned {
             continue;
         }
         let Ok(contents) = store.read(path) else {
@@ -94,7 +100,7 @@ mod tests {
         let (store, all_md) = store_with("/bundle/adr/0001-doc.md", canonical);
         let mut reporter = Reporter::new();
 
-        check_canonical_frontmatter(&store, &all_md, &mut reporter);
+        check_canonical_frontmatter(&store, Path::new("/bundle"), &all_md, &mut reporter);
 
         assert!(reporter.into_violations().is_empty());
     }
@@ -105,7 +111,7 @@ mod tests {
         let (store, all_md) = store_with("/bundle/adr/0001-doc.md", commented);
         let mut reporter = Reporter::new();
 
-        check_canonical_frontmatter(&store, &all_md, &mut reporter);
+        check_canonical_frontmatter(&store, Path::new("/bundle"), &all_md, &mut reporter);
 
         let violations = reporter.into_violations();
         assert_eq!(violations.len(), 1);
@@ -118,7 +124,7 @@ mod tests {
         let (store, all_md) = store_with("/bundle/adr/0001-doc.md", reordered);
         let mut reporter = Reporter::new();
 
-        check_canonical_frontmatter(&store, &all_md, &mut reporter);
+        check_canonical_frontmatter(&store, Path::new("/bundle"), &all_md, &mut reporter);
 
         assert_eq!(reporter.into_violations().len(), 1);
     }
@@ -129,19 +135,28 @@ mod tests {
         let (store, all_md) = store_with("/bundle/adr/0001-doc.md", spaced);
         let mut reporter = Reporter::new();
 
-        check_canonical_frontmatter(&store, &all_md, &mut reporter);
+        check_canonical_frontmatter(&store, Path::new("/bundle"), &all_md, &mut reporter);
 
         assert_eq!(reporter.into_violations().len(), 1);
     }
 
     #[test]
     fn check_canonical_frontmatter_skips_records_outside_cli_owned_directories() {
+        let outside_dir = "reference";
+        assert!(
+            crate::doc_type::spec_for_dir(outside_dir).is_none(),
+            "fixture premise broken: `{outside_dir}` is now a registry-owned directory — pick another",
+        );
+
         let commented = "---\ntype: Research\ntitle: Field Notes  # a comment\n---\n\nBody.\n";
-        for path in ["/bundle/research/0001-notes.md", "/bundle/0001-notes.md"] {
-            let (store, all_md) = store_with(path, commented);
+        for path in [
+            format!("/bundle/{outside_dir}/0001-notes.md"),
+            "/bundle/0001-notes.md".to_string(),
+        ] {
+            let (store, all_md) = store_with(&path, commented);
             let mut reporter = Reporter::new();
 
-            check_canonical_frontmatter(&store, &all_md, &mut reporter);
+            check_canonical_frontmatter(&store, Path::new("/bundle"), &all_md, &mut reporter);
 
             assert!(reporter.into_violations().is_empty());
         }
@@ -150,15 +165,75 @@ mod tests {
     #[test]
     fn check_canonical_frontmatter_flags_every_cli_owned_directory() {
         let commented = "---\ntype: ADR\ntitle: X  # comment\n---\n\nBody.\n";
-        for dir in ["adr", "bdr", "prd", "issues"] {
+        for spec in crate::doc_type::DOC_TYPES {
+            let crate::doc_type::Identity::Numbered { dir } = spec.identity else {
+                continue;
+            };
             let path = format!("/bundle/{dir}/0001-doc.md");
             let (store, all_md) = store_with(&path, commented);
             let mut reporter = Reporter::new();
 
-            check_canonical_frontmatter(&store, &all_md, &mut reporter);
+            check_canonical_frontmatter(&store, Path::new("/bundle"), &all_md, &mut reporter);
 
             assert_eq!(reporter.into_violations().len(), 1);
         }
+    }
+
+    /// Guards the fixture premise the same way
+    /// `check_canonical_frontmatter_skips_records_outside_cli_owned_directories`
+    /// guards its own: the singleton filename these tests hardcode is driven
+    /// off `doc_type::DOC_TYPES`, so a renamed row fails this assertion
+    /// loudly instead of the fixture silently exercising the wrong path.
+    fn assert_constitution_md_is_still_the_registered_singleton() {
+        let spec = crate::doc_type::spec_for("constitution")
+            .expect("fixture premise broken: `constitution` is no longer a registered token");
+        assert_eq!(
+            spec.identity,
+            crate::doc_type::Identity::Singleton {
+                file: "constitution.md"
+            },
+            "fixture premise broken: the constitution row no longer names constitution.md — update this fixture",
+        );
+    }
+
+    #[test]
+    fn check_canonical_frontmatter_flags_a_hand_written_bundle_root_singleton() {
+        assert_constitution_md_is_still_the_registered_singleton();
+        let commented = "---\ntype: Constitution\ntitle: X  # comment\n---\n\nBody.\n".to_string();
+        let (store, all_md) = store_with("/bundle/constitution.md", &commented);
+        let mut reporter = Reporter::new();
+
+        check_canonical_frontmatter(&store, Path::new("/bundle"), &all_md, &mut reporter);
+
+        let violations = reporter.into_violations();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].1.contains("living-docs fmt"));
+    }
+
+    #[test]
+    fn check_canonical_frontmatter_does_not_flag_the_singleton_filename_nested_in_a_subdirectory() {
+        assert_constitution_md_is_still_the_registered_singleton();
+        let commented = "---\ntype: Constitution\ntitle: X  # comment\n---\n\nBody.\n".to_string();
+        let (store, all_md) = store_with("/bundle/reference/constitution.md", &commented);
+        let mut reporter = Reporter::new();
+
+        check_canonical_frontmatter(&store, Path::new("/bundle"), &all_md, &mut reporter);
+
+        assert!(reporter.into_violations().is_empty());
+    }
+
+    #[test]
+    fn check_canonical_frontmatter_accepts_the_canonical_bundle_root_singleton() {
+        assert_constitution_md_is_still_the_registered_singleton();
+        let path = Path::new("/bundle/constitution.md");
+        let hand_written = "---\ntype: Constitution\ntitle: X\n---\n\nBody.\n";
+        let canonical = to_canonical_markdown(&extract_record(path, hand_written));
+        let (store, all_md) = store_with("/bundle/constitution.md", &canonical);
+        let mut reporter = Reporter::new();
+
+        check_canonical_frontmatter(&store, Path::new("/bundle"), &all_md, &mut reporter);
+
+        assert!(reporter.into_violations().is_empty());
     }
 
     #[test]
@@ -166,7 +241,7 @@ mod tests {
         let (store, all_md) = store_with("/bundle/adr/notes.md", "# Just a heading\n\nBody.\n");
         let mut reporter = Reporter::new();
 
-        check_canonical_frontmatter(&store, &all_md, &mut reporter);
+        check_canonical_frontmatter(&store, Path::new("/bundle"), &all_md, &mut reporter);
 
         assert!(reporter.into_violations().is_empty());
     }
@@ -177,7 +252,7 @@ mod tests {
         let (store, all_md) = store_with("/bundle/adr/index.md", commented);
         let mut reporter = Reporter::new();
 
-        check_canonical_frontmatter(&store, &all_md, &mut reporter);
+        check_canonical_frontmatter(&store, Path::new("/bundle"), &all_md, &mut reporter);
 
         assert!(reporter.into_violations().is_empty());
     }
@@ -190,7 +265,7 @@ mod tests {
         let (store, all_md) = store_with("/bundle/adr/0001-doc.md", &fmt_pass);
         let mut reporter = Reporter::new();
 
-        check_canonical_frontmatter(&store, &all_md, &mut reporter);
+        check_canonical_frontmatter(&store, Path::new("/bundle"), &all_md, &mut reporter);
 
         assert!(reporter.into_violations().is_empty());
     }

--- a/living-docs-core/src/check/graph.rs
+++ b/living-docs-core/src/check/graph.rs
@@ -2,22 +2,22 @@
 //! reachability, built from the inline links in `index.md` files. Mirrors
 //! `strip_fences`/`links_in`/`resolve_link`/`normpath` from `lint-docs.sh`.
 
-use super::{file_name_str, records, Reporter};
+use super::{file_name_str, is_bundle_singleton, records, Reporter};
 use std::collections::{HashSet, VecDeque};
 use std::fs;
 use std::path::{Path, PathBuf};
 
 /// Every non-reserved concept file must be linked from its own directory's
-/// `index.md`. The bundle-root `constitution.md` is the root of trace and is
-/// deliberately exempt.
+/// `index.md`. A registry [`crate::doc_type::Identity::Singleton`] file at
+/// the bundle root (e.g. `constitution.md`) is deliberately exempt: it is the
+/// bundle's own root of trace, and has no directory index to be listed in.
 pub(crate) fn check_directory_membership(
     bundle: &Path,
     all_md: &[PathBuf],
     reporter: &mut Reporter,
 ) {
-    let constitution = bundle.join("constitution.md");
     for f in all_md {
-        if records::is_reserved(&file_name_str(f)) || f == &constitution {
+        if records::is_reserved(&file_name_str(f)) || is_bundle_singleton(bundle, f) {
             continue;
         }
         check_file_is_indexed(bundle, f, reporter);

--- a/living-docs-core/src/check/mod.rs
+++ b/living-docs-core/src/check/mod.rs
@@ -19,6 +19,7 @@ mod mermaid;
 mod records;
 mod size;
 
+use crate::doc_type::{self, Identity};
 use crate::store::DocStore;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -70,7 +71,7 @@ fn run_all_checks(store: &dyn DocStore, bundle: &Path, reporter: &mut Reporter) 
     graph::check_reachability(bundle, &root_index, &all_md, reporter);
     links::check_links(store, bundle, &all_md, reporter);
     records::check_supersede_chain(store, &all_md, reporter);
-    canonical::check_canonical_frontmatter(store, &all_md, reporter);
+    canonical::check_canonical_frontmatter(store, bundle, &all_md, reporter);
 
     mermaid::check_bundle(&all_md, reporter);
     size::check_body_size(store, &all_md, reporter);
@@ -114,6 +115,25 @@ fn walk_md_files(dir: &Path, out: &mut Vec<PathBuf>) {
             out.push(path);
         }
     }
+}
+
+/// True when `path` is exactly the bundle-root file of some registry
+/// [`Identity::Singleton`] row — the single place the check layer learns
+/// what a singleton is, so a second singleton row is handled without an
+/// edit here.
+///
+/// The comparison is a plain path equality, not a filesystem lookup, so it
+/// only stays correct because every [`DocStore`] enumerates a bundle's paths
+/// rooted at the same `bundle` it was given (see [`collect_md_files`]) —
+/// `read_dir` never resolves symlinks, so this holds even when the caller
+/// reaches the bundle through one. Reach for `canonicalize` here instead and
+/// this pure predicate starts touching disk, breaking every `MapStore`
+/// fixture whose paths never exist on disk.
+pub(crate) fn is_bundle_singleton(bundle: &Path, path: &Path) -> bool {
+    doc_type::DOC_TYPES.iter().any(|spec| match spec.identity {
+        Identity::Singleton { file } => path == bundle.join(file),
+        Identity::Numbered { .. } => false,
+    })
 }
 
 /// Collects violations and renders the final report + exit code, mirroring
@@ -173,6 +193,7 @@ impl Reporter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::record::{extract_record, to_canonical_markdown};
     use crate::test_support::MapStore;
     use std::collections::BTreeMap;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -219,6 +240,111 @@ mod tests {
         fn drop(&mut self) {
             let _ = fs::remove_dir_all(&self.root);
         }
+    }
+
+    /// A `DocStore` that reads and enumerates real files on disk, mirroring
+    /// `fs-store`'s adapter closely enough to exercise `is_bundle_singleton`'s
+    /// rooting invariant against a genuine filesystem rather than `MapStore`'s
+    /// in-memory fixture.
+    struct RealFsStore;
+
+    impl DocStore for RealFsStore {
+        fn list(&self, root: &Path) -> std::io::Result<Vec<PathBuf>> {
+            Ok(collect_md_files(root))
+        }
+
+        fn read(&self, path: &Path) -> std::io::Result<String> {
+            fs::read_to_string(path)
+        }
+
+        fn write(&self, path: &Path, contents: &str) -> std::io::Result<()> {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::write(path, contents)
+        }
+    }
+
+    /// Pins the invariant `is_bundle_singleton`'s docblock names: an unlisted
+    /// bundle-root singleton stays exempt from every `check` invariant
+    /// whether the caller passes the bundle directly or reaches the same
+    /// directory through a symlink, because both `store.list` and
+    /// `is_bundle_singleton` build their paths from whatever root they were
+    /// handed rather than a resolved one.
+    #[cfg(unix)]
+    #[test]
+    fn is_bundle_singleton_stays_exempt_regardless_of_the_path_form_the_caller_used() {
+        let bundle = ScratchBundle::new("singleton-symlink-invariant");
+        fs::write(bundle.root.join("adr").join("index.md"), "# ADR Index\n")
+            .expect("clear scratch adr index of phantom links");
+
+        let singleton_path = bundle.root.join("constitution.md");
+        let hand_written = "---\ntype: Constitution\ntitle: Root of Trust\n---\n\nBody.\n";
+        let canonical = to_canonical_markdown(&extract_record(&singleton_path, hand_written));
+        fs::write(&singleton_path, &canonical).expect("write scratch constitution.md");
+
+        let direct_violations = check_violations(&RealFsStore, &bundle.root);
+        assert!(
+            direct_violations.is_empty(),
+            "direct violations: {direct_violations:?}"
+        );
+
+        let symlink_root = std::env::temp_dir().join(format!(
+            "living-docs-check-mod-singleton-symlink-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock before unix epoch")
+                .as_nanos()
+        ));
+        std::os::unix::fs::symlink(&bundle.root, &symlink_root)
+            .expect("create symlink to scratch bundle");
+
+        let via_symlink_violations = check_violations(&RealFsStore, &symlink_root);
+        let _ = fs::remove_file(&symlink_root);
+
+        assert!(
+            via_symlink_violations.is_empty(),
+            "via-symlink violations: {via_symlink_violations:?}"
+        );
+    }
+
+    /// The positive direction `check_canonical_frontmatter_flags_every_cli_owned_directory`
+    /// and its `canonical.rs` siblings cannot instrument: since their fixture
+    /// paths are built from `spec` too, a premise guard is the only thing
+    /// that would fail after a registry rename, not the behavioral
+    /// assertion. Building both the matching and non-matching paths from
+    /// `spec` here means a rename keeps this test green for the *new* name,
+    /// proving `is_bundle_singleton` follows the registry rather than a
+    /// literal filename.
+    #[test]
+    fn is_bundle_singleton_follows_the_registry_not_a_literal_filename() {
+        let bundle = Path::new("/bundle");
+        let mut exercised = 0;
+
+        for spec in doc_type::DOC_TYPES {
+            let Identity::Singleton { file } = spec.identity else {
+                continue;
+            };
+            exercised += 1;
+
+            assert!(
+                is_bundle_singleton(bundle, &bundle.join(file)),
+                "{file} at the bundle root must be its own singleton"
+            );
+            assert!(
+                !is_bundle_singleton(bundle, &bundle.join("not-a-singleton.md")),
+                "a sibling filename must never match {file}'s singleton slot"
+            );
+            assert!(
+                !is_bundle_singleton(bundle, &bundle.join("reference").join(file)),
+                "{file} nested one level down must not match the bundle-root singleton"
+            );
+        }
+
+        assert!(
+            exercised > 0,
+            "no Identity::Singleton row in DOC_TYPES — this test would pass vacuously"
+        );
     }
 
     /// A record served only by the store (never written to disk) must still

--- a/living-docs-core/src/commands/brief.rs
+++ b/living-docs-core/src/commands/brief.rs
@@ -9,9 +9,9 @@ use crate::commands::new::{
     fill_frontmatter, fill_frontmatter_title, now_iso8601, unsupported_type_message,
 };
 use crate::commands::next::next_number_from_store;
+use crate::doc_type::{self, Identity};
 use crate::paths;
 use crate::store::DocStore;
-use crate::templates;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
@@ -49,25 +49,17 @@ fn scaffold_brief(
     timestamp: &str,
     diff: Option<&DiffContext>,
 ) -> Result<PathBuf, String> {
-    let dir_name = paths::dir_for(doc_type).ok_or_else(|| unsupported_type_message(doc_type))?;
-    let frontmatter_type = paths::frontmatter_type_for(doc_type)
-        .expect("dir_for and frontmatter_type_for cover the same doc types");
-    let template = templates::template_for(doc_type)
-        .expect("dir_for and template_for cover the same doc types");
-
-    let number = next_number_from_store(store, docs_dir, dir_name).map_err(|e| e.to_string())?;
-    let target_path = docs_dir
-        .join(dir_name)
-        .join(format!("{number:04}-{}.md", paths::slugify(title)));
+    let spec = doc_type::spec_for(doc_type).ok_or_else(|| unsupported_type_message(doc_type))?;
+    let (target_path, number) = brief_target_for(store, docs_dir, spec, title)?;
 
     if store.read(&target_path).is_ok() {
         return Err(format!("{} already exists", target_path.display()));
     }
 
     let content = brief_content(
-        template,
+        spec.template,
         doc_type,
-        frontmatter_type,
+        spec.frontmatter,
         timestamp,
         number,
         title,
@@ -77,6 +69,33 @@ fn scaffold_brief(
         .write(&target_path, &content)
         .map_err(|e| e.to_string())?;
     Ok(target_path)
+}
+
+/// Resolves `brief`'s target path and heading number for `spec`'s identity
+/// shape, mirroring [`crate::commands::new::target_path_for`]: a
+/// [`Identity::Numbered`] type allocates the next number and slugifies
+/// `title`; a [`Identity::Singleton`] type resolves straight to
+/// `docs_dir.join(file)` with no number allocated. The returned `0` for a
+/// singleton is never rendered — [`is_title_heading_placeholder`] only
+/// recognizes a `# NNNN. <...>` heading, which a singleton template (e.g.
+/// `constitution.md`'s plain `# Product Constitution`) does not carry.
+fn brief_target_for(
+    store: &dyn DocStore,
+    docs_dir: &Path,
+    spec: &doc_type::DocTypeSpec,
+    title: &str,
+) -> Result<(PathBuf, u32), String> {
+    match spec.identity {
+        Identity::Numbered { dir: dir_name } => {
+            let number =
+                next_number_from_store(store, docs_dir, dir_name).map_err(|e| e.to_string())?;
+            let target_path = docs_dir
+                .join(dir_name)
+                .join(format!("{number:04}-{}.md", paths::slugify(title)));
+            Ok((target_path, number))
+        }
+        Identity::Singleton { file } => Ok((docs_dir.join(file), 0)),
+    }
 }
 
 fn brief_content(
@@ -136,6 +155,18 @@ fn slots_for(doc_type: &str) -> &'static [(&'static str, &'static str)] {
             ("### Acceptance", "acceptance"),
             ("### Plan", "plan"),
         ],
+        "research" => &[
+            ("## Question", "question"),
+            ("## Method", "method"),
+            ("## Implications", "implications"),
+            ("## Open Questions", "open-questions"),
+            ("# References", "references"),
+        ],
+        "constitution" => &[
+            ("## Product", "product"),
+            ("## Scope Boundaries", "scope-boundaries"),
+            ("## Non-negotiables", "non-negotiables"),
+        ],
         _ => &[],
     }
 }
@@ -143,6 +174,8 @@ fn slots_for(doc_type: &str) -> &'static [(&'static str, &'static str)] {
 fn context_marker_for(doc_type: &str) -> &'static str {
     match doc_type {
         "prd" => "problem-motivation",
+        "research" => "question",
+        "constitution" => "product",
         _ => "context",
     }
 }
@@ -155,6 +188,7 @@ fn trail_comment_for(doc_type: &str) -> &'static str {
         "bdr" => "<!-- trail: spawned-by /prd/NNNN-<slug>.md · /adr/NNNN-<slug>.md · tracked-by /issues/NNNN-<slug>.md -->",
         "prd" => "<!-- trail: constitution /constitution.md · behavior /bdr/NNNN-<slug>.md · tracked-by /issues/NNNN-<slug>.md -->",
         "issue" => "<!-- trail: implements /adr/NNNN-<slug>.md · part-of /prd/NNNN-<slug>.md -->",
+        "research" => "<!-- trail: motivates /adr/NNNN-<slug>.md · /prd/NNNN-<slug>.md · tracked-by /issues/NNNN-<slug>.md -->",
         _ => "",
     }
 }
@@ -242,6 +276,9 @@ fn insert_touched_files(content: &str, context_marker: &str, diff: &DiffContext)
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::RefCell;
+    use std::collections::BTreeMap;
+    use std::io;
 
     const TEMPLATE: &str = "---\ntype: ADR\ntitle: <Short decision title>\nstatus: Proposed\ntimestamp: <ISO 8601 datetime>\n---\n\n# NNNN. <Short decision title>\n\n## Context\n\n<guidance with a [link](/research/NNNN-<slug>.md)>\n\n## Decision\n\nWe will <the choice>.\n\n## Consequences\n\n- <what this unlocks>\n\n# References\n\n[1] [<source>](<url>)\n";
 
@@ -341,5 +378,145 @@ mod tests {
         assert!(content.contains("<!-- judgment: context -->"));
         assert!(content.contains("### Scope\n\n<!-- judgment: scope -->"));
         assert!(!content.contains("intro guidance"));
+    }
+
+    #[test]
+    fn constitution_judgment_sections_collapse_while_structural_sections_stay_intact() {
+        let template = doc_type::spec_for("constitution")
+            .expect("constitution must be registered")
+            .template;
+        let content = brief_content(
+            template,
+            "constitution",
+            "Constitution",
+            "2026-07-19T00:00:00Z",
+            0,
+            "Acme Constitution",
+            None,
+        );
+
+        assert!(content.contains("## Product\n\n<!-- judgment: product -->\n"));
+        assert!(content.contains("## Scope Boundaries\n\n<!-- judgment: scope-boundaries -->\n"));
+        assert!(content.contains("## Non-negotiables\n\n<!-- judgment: non-negotiables -->\n"));
+        assert!(content.contains("erDiagram"));
+        assert!(content.contains("ENTITY_A ||--o{ ENTITY_B"));
+        assert!(content.contains("<!-- Append amendments here"));
+        assert!(!content.contains("<What the product is"));
+        assert!(!content.contains("<Capability or domain"));
+        assert!(!content.contains("<Non-negotiable 1>"));
+    }
+
+    #[test]
+    fn constitution_has_no_trail_comment_and_the_empty_trail_does_not_break_the_output() {
+        let template = doc_type::spec_for("constitution")
+            .expect("constitution must be registered")
+            .template;
+        let content = brief_content(
+            template,
+            "constitution",
+            "Constitution",
+            "2026-07-19T00:00:00Z",
+            0,
+            "Acme Constitution",
+            None,
+        );
+
+        assert!(!content.contains("<!-- trail:"));
+        assert!(content.contains("# Product Constitution\n"));
+    }
+
+    /// A minimal in-memory [`DocStore`] test double, mirroring the one in
+    /// `commands::new`'s tests, so `scaffold_brief`'s singleton branch needs
+    /// no filesystem.
+    struct MapStore {
+        files: RefCell<BTreeMap<PathBuf, String>>,
+    }
+
+    impl MapStore {
+        fn new() -> Self {
+            Self {
+                files: RefCell::new(BTreeMap::new()),
+            }
+        }
+
+        fn seeded(seed: &[(&str, &str)]) -> Self {
+            let files = seed
+                .iter()
+                .map(|(path, contents)| (PathBuf::from(path), (*contents).to_string()))
+                .collect();
+            Self {
+                files: RefCell::new(files),
+            }
+        }
+    }
+
+    impl DocStore for MapStore {
+        fn list(&self, root: &Path) -> io::Result<Vec<PathBuf>> {
+            Ok(self
+                .files
+                .borrow()
+                .keys()
+                .filter(|path| path.starts_with(root))
+                .cloned()
+                .collect())
+        }
+
+        fn read(&self, path: &Path) -> io::Result<String> {
+            self.files
+                .borrow()
+                .get(path)
+                .cloned()
+                .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "not found"))
+        }
+
+        fn write(&self, path: &Path, contents: &str) -> io::Result<()> {
+            self.files
+                .borrow_mut()
+                .insert(path.to_path_buf(), contents.to_string());
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn scaffold_brief_writes_a_singleton_constitution_with_no_number_or_slug() {
+        let store = MapStore::new();
+
+        let target = scaffold_brief(
+            &store,
+            Path::new("/bundle"),
+            "constitution",
+            "Acme Constitution",
+            "2026-07-19T00:00:00Z",
+            None,
+        )
+        .expect("scaffold_brief should succeed");
+
+        assert_eq!(target, PathBuf::from("/bundle/constitution.md"));
+        let persisted = store
+            .read(&target)
+            .expect("scaffold_brief must persist through DocStore::write");
+        assert!(persisted.contains("type: Constitution"));
+        assert!(persisted.contains("<!-- judgment: product -->"));
+    }
+
+    #[test]
+    fn scaffold_brief_refuses_a_second_constitution() {
+        let store = MapStore::seeded(&[("/bundle/constitution.md", "existing content")]);
+
+        let err = scaffold_brief(
+            &store,
+            Path::new("/bundle"),
+            "constitution",
+            "Acme Constitution",
+            "2026-07-19T00:00:00Z",
+            None,
+        )
+        .expect_err("a second constitution must be refused");
+
+        assert!(err.contains("already exists"), "got: {err}");
+        assert_eq!(
+            store.read(Path::new("/bundle/constitution.md")).unwrap(),
+            "existing content"
+        );
     }
 }

--- a/living-docs-core/src/commands/index.rs
+++ b/living-docs-core/src/commands/index.rs
@@ -1,11 +1,23 @@
+use crate::commands::new::unsupported_type_message;
+use crate::doc_type::{self, Identity, IndexPartition};
 use crate::frontmatter;
-use crate::paths;
 use crate::store::DocStore;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
-const SUPPORTED_TYPES: [&str; 4] = ["adr", "bdr", "prd", "issue"];
+/// Every Numbered-identity registry token, in [`doc_type::DOC_TYPES`] order —
+/// the set `index` regenerates when invoked with no explicit type (ADR 0026).
+/// A [`Identity::Singleton`] type has no directory to index, so the bare
+/// sweep excludes it — regenerating it would need a directory that `new`
+/// never creates for a singleton.
+fn all_type_tokens() -> Vec<String> {
+    doc_type::DOC_TYPES
+        .iter()
+        .filter(|spec| matches!(spec.identity, Identity::Numbered { .. }))
+        .map(|spec| spec.token.to_string())
+        .collect()
+}
 
 pub fn run(
     store: &dyn DocStore,
@@ -15,7 +27,7 @@ pub fn run(
 ) -> ExitCode {
     let types: Vec<String> = match doc_type {
         Some(t) => vec![t],
-        None => SUPPORTED_TYPES.iter().map(|t| t.to_string()).collect(),
+        None => all_type_tokens(),
     };
 
     for doc_type in &types {
@@ -34,6 +46,14 @@ pub fn run(
 /// the records feeding its body are read through `store`, meaning a db-mode
 /// run regenerates the filesystem `index.md` from the records in the
 /// database.
+///
+/// `doc_type`'s directory coming into existence is `new`'s job, never
+/// `index`'s (ADR 0026): a type with no directory yet is a successful no-op
+/// here, both for the bare `index` sweep and for an explicit `index
+/// <type>` naming a type the bundle doesn't use — otherwise a bare sweep
+/// would materialize an empty `index.md` per registry token regardless of
+/// whether the bundle carries that type, breaking invariant 3 (an
+/// unreachable directory index) for every type the bundle never populated.
 fn regenerate(
     store: &dyn DocStore,
     docs_dir: &Path,
@@ -42,7 +62,9 @@ fn regenerate(
 ) -> Result<(), String> {
     let (index_path, content) = compute(store, docs_dir, doc_type, visibility_filter)?;
     let type_dir = index_path.parent().unwrap_or(docs_dir);
-    fs::create_dir_all(type_dir).map_err(|e| e.to_string())?;
+    if !type_dir.is_dir() {
+        return Ok(());
+    }
     fs::write(&index_path, content).map_err(|e| e.to_string())
 }
 
@@ -58,7 +80,7 @@ pub fn compute(
     doc_type: &str,
     visibility_filter: Option<&[String]>,
 ) -> Result<(PathBuf, String), String> {
-    let dir_name = paths::dir_for(doc_type).ok_or_else(|| unsupported_type_message(doc_type))?;
+    let dir_name = numbered_dir_for(doc_type)?;
     let type_dir = docs_dir.join(dir_name);
     let records: Vec<Record> = collect_records(store, docs_dir, &type_dir)?
         .into_iter()
@@ -73,8 +95,26 @@ pub fn compute(
     Ok((index_path, format!("{preamble}{body}")))
 }
 
-fn unsupported_type_message(doc_type: &str) -> String {
-    format!("unsupported doc type '{doc_type}' (expected one of adr, bdr, prd, issue)")
+/// Resolves the numbered-series directory `index` regenerates for
+/// `doc_type`: an unknown token gets [`unsupported_type_message`], but a
+/// registered [`Identity::Singleton`] token gets its own message instead —
+/// it IS supported, it simply has no directory index, and reusing the
+/// unsupported-type message would list `doc_type` itself among the tokens
+/// the caller is told to pick from.
+fn numbered_dir_for(doc_type: &str) -> Result<&'static str, String> {
+    let spec = doc_type::spec_for(doc_type).ok_or_else(|| unsupported_type_message(doc_type))?;
+    match spec.identity {
+        Identity::Numbered { dir } => Ok(dir),
+        Identity::Singleton { file } => {
+            Err(singleton_has_no_directory_index_message(doc_type, file))
+        }
+    }
+}
+
+fn singleton_has_no_directory_index_message(doc_type: &str, file: &str) -> String {
+    format!(
+        "'{doc_type}' has no directory index — it writes a single {file} at the bundle root, not a numbered series"
+    )
 }
 
 struct Record {
@@ -205,17 +245,21 @@ fn numbered_prefix(filename: &str) -> Option<u32> {
     prefix.parse().ok()
 }
 
-/// Dispatches each supported type to the partition axis its lifecycle uses:
-/// issues track work-in-progress (Open/Closed), decisions track what is in
-/// force (Active/Superseded). A future/unknown type falls back to a flat
-/// listing until its own axis is chosen — see `render_flat_body`.
+/// Renders `records` along the partition axis `doc_type`'s registry spec
+/// declares (ADR 0026): [`IndexPartition::OpenClosed`] for work-in-progress
+/// types, [`IndexPartition::ActiveSuperseded`] for types that track what is
+/// in force, and [`IndexPartition::Flat`] — also the fallback for an
+/// unrecognized `doc_type`, unreachable in practice since every caller
+/// already validated it — as a single flat listing (`render_flat_body`).
 fn render_body(doc_type: &str, records: &[Record]) -> String {
-    match doc_type {
-        "issue" => render_partitioned(records, "Open", "Closed", is_open_status),
-        "adr" | "bdr" | "prd" => {
+    match doc_type::spec_for(doc_type).map(|spec| &spec.index_partition) {
+        Some(IndexPartition::OpenClosed) => {
+            render_partitioned(records, "Open", "Closed", is_open_status)
+        }
+        Some(IndexPartition::ActiveSuperseded) => {
             render_partitioned(records, "Active", "Superseded", is_active_status)
         }
-        _ => render_flat_body(records),
+        Some(IndexPartition::Flat) | None => render_flat_body(records),
     }
 }
 
@@ -371,18 +415,32 @@ fn fallback_preamble(existing: &str, doc_type: &str) -> String {
 }
 
 fn heading_title_for(doc_type: &str) -> &'static str {
-    match doc_type {
-        "adr" => "ADRs",
-        "bdr" => "BDRs",
-        "prd" => "PRDs",
-        "issue" => "Issues",
-        _ => "Index",
-    }
+    doc_type::spec_for(doc_type)
+        .map(|spec| spec.index_heading)
+        .unwrap_or("Index")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// ADR 0026 fitness function B (index half): the token set `index`
+    /// regenerates with no explicit type equals the registry's
+    /// Identity::Numbered token set, in the registry's own order.
+    #[test]
+    fn all_type_tokens_matches_every_numbered_registry_token_in_order() {
+        assert_eq!(
+            all_type_tokens(),
+            vec!["adr", "bdr", "prd", "issue", "research"]
+        );
+    }
+
+    /// The `constitution` row is a deliberate exclusion, not an oversight:
+    /// a singleton has no directory index for the bare sweep to regenerate.
+    #[test]
+    fn all_type_tokens_excludes_the_constitution_singleton() {
+        assert!(!all_type_tokens().contains(&"constitution".to_string()));
+    }
 
     #[test]
     fn numbered_prefix_accepts_four_digit_dash_form() {
@@ -608,6 +666,27 @@ mod tests {
     }
 
     #[test]
+    fn regenerate_is_a_no_op_when_the_type_directory_does_not_exist() {
+        let store = MapStore {
+            files: BTreeMap::new(),
+        };
+        let docs_dir = std::env::temp_dir().join(format!(
+            "living-docs-index-regenerate-noop-{}",
+            std::process::id()
+        ));
+        let type_dir = docs_dir.join("research");
+        assert!(!type_dir.exists());
+
+        let result = regenerate(&store, &docs_dir, "research", None);
+
+        assert!(result.is_ok());
+        assert!(
+            !type_dir.exists(),
+            "regenerate must not create the type directory when it is absent"
+        );
+    }
+
+    #[test]
     fn compute_rejects_an_unsupported_doc_type() {
         let store = MapStore {
             files: BTreeMap::new(),
@@ -616,6 +695,25 @@ mod tests {
         let result = compute(&store, Path::new("/bundle"), "glossary", None);
 
         assert!(result.is_err());
+    }
+
+    /// `index constitution` gets its own message, not the unsupported-type
+    /// one — the type IS supported, it just has no directory index, and the
+    /// unsupported-type message would list the very token the caller used.
+    #[test]
+    fn compute_rejects_an_explicit_constitution_index_with_its_own_message() {
+        let store = MapStore {
+            files: BTreeMap::new(),
+        };
+
+        let err = compute(&store, Path::new("/bundle"), "constitution", None)
+            .expect_err("constitution has no directory index");
+
+        assert!(err.contains("constitution.md"), "got: {err}");
+        assert!(
+            !err.contains("expected one of"),
+            "must not reuse the unsupported-type message: {err}"
+        );
     }
 
     #[test]

--- a/living-docs-core/src/commands/new.rs
+++ b/living-docs-core/src/commands/new.rs
@@ -1,8 +1,8 @@
 use crate::commands::next::next_number_from_store;
+use crate::doc_type::{self, Identity};
 use crate::paths;
 use crate::record::format_scalar;
 use crate::store::DocStore;
-use crate::templates;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -39,23 +39,40 @@ fn plan_at(
     title: &str,
     timestamp: &str,
 ) -> Result<(PathBuf, String), String> {
-    let dir_name = paths::dir_for(doc_type).ok_or_else(|| unsupported_type_message(doc_type))?;
-    let frontmatter_type = paths::frontmatter_type_for(doc_type)
-        .expect("dir_for and frontmatter_type_for cover the same doc types");
-    let template = templates::template_for(doc_type)
-        .expect("dir_for and template_for cover the same doc types");
-
-    let type_dir = docs_dir.join(dir_name);
-    let number = next_number_from_store(store, docs_dir, dir_name).map_err(|e| e.to_string())?;
-    let target_path = type_dir.join(format!("{number:04}-{}.md", paths::slugify(title)));
+    let spec = doc_type::spec_for(doc_type).ok_or_else(|| unsupported_type_message(doc_type))?;
+    let target_path = target_path_for(store, docs_dir, spec, title)?;
 
     if store.read(&target_path).is_ok() {
         return Err(format!("{} already exists", target_path.display()));
     }
 
-    let filled = fill_frontmatter(template, frontmatter_type, timestamp);
+    let filled = fill_frontmatter(spec.template, spec.frontmatter, timestamp);
     let filled = fill_frontmatter_title(&filled, title);
     Ok((target_path, filled))
+}
+
+/// Resolves `new`'s target path for `spec`'s identity shape: a
+/// [`Identity::Numbered`] type allocates the next number and slugifies
+/// `title` into `<dir>/NNNN-<slug>.md`; a [`Identity::Singleton`] type
+/// allocates nothing and resolves straight to `docs_dir.join(file)` — no
+/// number, no slug. Everything after this call (the clobber guard, the
+/// frontmatter fill) is identity-blind, so only the path itself differs.
+fn target_path_for(
+    store: &dyn DocStore,
+    docs_dir: &Path,
+    spec: &doc_type::DocTypeSpec,
+    title: &str,
+) -> Result<PathBuf, String> {
+    match spec.identity {
+        Identity::Numbered { dir: dir_name } => {
+            let number =
+                next_number_from_store(store, docs_dir, dir_name).map_err(|e| e.to_string())?;
+            Ok(docs_dir
+                .join(dir_name)
+                .join(format!("{number:04}-{}.md", paths::slugify(title))))
+        }
+        Identity::Singleton { file } => Ok(docs_dir.join(file)),
+    }
 }
 
 /// Plans `new`'s target path and filled content, timestamped now, without
@@ -85,8 +102,16 @@ fn scaffold(
     Ok(target_path)
 }
 
+/// The single definition of `new`/`index`'s unsupported-type error, naming
+/// the offending `doc_type` and every token the registry ([`doc_type::DOC_TYPES`])
+/// currently supports, rather than a hand-maintained list (ADR 0026).
 pub(crate) fn unsupported_type_message(doc_type: &str) -> String {
-    format!("unsupported doc type '{doc_type}' (expected one of adr, bdr, prd, issue)")
+    let supported = doc_type::DOC_TYPES
+        .iter()
+        .map(|spec| spec.token)
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("unsupported doc type '{doc_type}' (expected one of {supported})")
 }
 
 /// Targeted line-edit fill of `type`/`status`/`timestamp` inside the leading
@@ -308,6 +333,21 @@ mod tests {
         assert!(unsupported_type_message("constitution").contains("constitution"));
     }
 
+    /// ADR 0026 fitness function C: the message is generated from
+    /// `DOC_TYPES` rather than a hand-maintained list, so it can never omit
+    /// a token the registry actually supports.
+    #[test]
+    fn unsupported_type_message_lists_every_registry_token() {
+        let message = unsupported_type_message("bogus");
+        for spec in doc_type::DOC_TYPES {
+            assert!(
+                message.contains(spec.token),
+                "{message:?} is missing registry token {:?}",
+                spec.token
+            );
+        }
+    }
+
     /// A minimal in-memory [`DocStore`] test double, so `scaffold`'s tests
     /// need no filesystem at all — `living-docs-core` depends on no
     /// concrete adapter (issue 0006 slice 0006-D2).
@@ -374,6 +414,47 @@ mod tests {
         .expect("scaffold should succeed");
 
         assert_eq!(target, PathBuf::from("/bundle/adr/0001-first-decision.md"));
+    }
+
+    #[test]
+    fn scaffold_writes_a_singleton_constitution_with_no_number_or_slug() {
+        let store = MapStore::new();
+
+        let target = scaffold(
+            &store,
+            Path::new("/bundle"),
+            "constitution",
+            "Acme Constitution",
+            "2026-07-17T00:00:00Z",
+        )
+        .expect("scaffold should succeed");
+
+        assert_eq!(target, PathBuf::from("/bundle/constitution.md"));
+        let persisted = store
+            .read(&target)
+            .expect("scaffold must persist through DocStore::write");
+        assert!(persisted.contains("type: Constitution"));
+        assert!(persisted.contains("title: Acme Constitution"));
+    }
+
+    #[test]
+    fn scaffold_refuses_a_second_constitution() {
+        let store = MapStore::seeded(&[("/bundle/constitution.md", "existing content")]);
+
+        let err = scaffold(
+            &store,
+            Path::new("/bundle"),
+            "constitution",
+            "Acme Constitution",
+            "2026-07-17T00:00:00Z",
+        )
+        .expect_err("a second constitution must be refused");
+
+        assert!(err.contains("already exists"), "got: {err}");
+        assert_eq!(
+            store.read(Path::new("/bundle/constitution.md")).unwrap(),
+            "existing content"
+        );
     }
 
     #[test]

--- a/living-docs-core/src/doc_type.rs
+++ b/living-docs-core/src/doc_type.rs
@@ -1,0 +1,205 @@
+//! The single compile-time enumeration of the doc-type taxonomy (ADR 0026).
+//! Every site that once hand-wrote the doc-type tokens looks them up here
+//! instead, so a token's directory, frontmatter value and template can never
+//! disagree — the invariant `commands::new::plan_at` used to assert at
+//! runtime becomes unrepresentable.
+
+/// Where a doc type's records live, carried as an enum variant field rather
+/// than a struct field so a singleton type cannot have a stale directory
+/// (ADR 0026 decision point 1).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Identity {
+    /// `<dir>/NNNN-<slug>.md`; the number is allocated by `next`.
+    Numbered { dir: &'static str },
+    /// A single `<file>` relative to the bundle root; a second one is
+    /// refused.
+    Singleton { file: &'static str },
+}
+
+/// The axis `index` partitions a type's records along.
+#[derive(PartialEq, Eq, Debug)]
+pub enum IndexPartition {
+    OpenClosed,
+    ActiveSuperseded,
+    Flat,
+}
+
+/// Everything a doc type needs to be created, indexed and offered by every
+/// consumer: its token, path shape, frontmatter value, embedded template,
+/// index rendering and web-creatability.
+#[derive(PartialEq, Debug)]
+pub struct DocTypeSpec {
+    pub token: &'static str,
+    pub identity: Identity,
+    pub frontmatter: &'static str,
+    pub template: &'static str,
+    pub index_heading: &'static str,
+    pub index_partition: IndexPartition,
+    pub web_creatable: bool,
+}
+
+const ADR: DocTypeSpec = DocTypeSpec {
+    token: "adr",
+    identity: Identity::Numbered { dir: "adr" },
+    frontmatter: "ADR",
+    template: include_str!("../../skills/living-docs/templates/adr.md"),
+    index_heading: "ADRs",
+    index_partition: IndexPartition::ActiveSuperseded,
+    web_creatable: true,
+};
+
+const BDR: DocTypeSpec = DocTypeSpec {
+    token: "bdr",
+    identity: Identity::Numbered { dir: "bdr" },
+    frontmatter: "BDR",
+    template: include_str!("../../skills/living-docs/templates/bdr.md"),
+    index_heading: "BDRs",
+    index_partition: IndexPartition::ActiveSuperseded,
+    web_creatable: true,
+};
+
+const PRD: DocTypeSpec = DocTypeSpec {
+    token: "prd",
+    identity: Identity::Numbered { dir: "prd" },
+    frontmatter: "PRD",
+    template: include_str!("../../skills/living-docs/templates/prd.md"),
+    index_heading: "PRDs",
+    index_partition: IndexPartition::ActiveSuperseded,
+    web_creatable: true,
+};
+
+const ISSUE: DocTypeSpec = DocTypeSpec {
+    token: "issue",
+    identity: Identity::Numbered { dir: "issues" },
+    frontmatter: "Issue",
+    template: include_str!("../../skills/living-docs/templates/issue.md"),
+    index_heading: "Issues",
+    index_partition: IndexPartition::OpenClosed,
+    web_creatable: true,
+};
+
+const RESEARCH: DocTypeSpec = DocTypeSpec {
+    token: "research",
+    identity: Identity::Numbered { dir: "research" },
+    frontmatter: "Research",
+    template: include_str!("../../skills/living-docs/templates/research.md"),
+    index_heading: "Research",
+    index_partition: IndexPartition::Flat,
+    web_creatable: true,
+};
+
+/// `index_heading`/`index_partition` are inert for a singleton — it has no
+/// directory index to render — and are set to placeholder values rather than
+/// wrapped in an `Option`, since no directory-index code path ever reads them
+/// for this row (ADR 0026 decision point 6).
+const CONSTITUTION: DocTypeSpec = DocTypeSpec {
+    token: "constitution",
+    identity: Identity::Singleton {
+        file: "constitution.md",
+    },
+    frontmatter: "Constitution",
+    template: include_str!("../../skills/living-docs/templates/constitution.md"),
+    index_heading: "Constitution",
+    index_partition: IndexPartition::Flat,
+    web_creatable: true,
+};
+
+/// The sole enumeration of the doc-type taxonomy. Every consumer derives
+/// from this table instead of hand-syncing its own copy.
+pub const DOC_TYPES: &[DocTypeSpec] = &[ADR, BDR, PRD, ISSUE, RESEARCH, CONSTITUTION];
+
+/// Looks up a doc type by its CLI token.
+pub fn spec_for(token: &str) -> Option<&'static DocTypeSpec> {
+    DOC_TYPES.iter().find(|spec| spec.token == token)
+}
+
+/// Looks up a doc type by its numbered-series directory name — the reverse
+/// of a [`Identity::Numbered`] spec's `dir`. A singleton type has no
+/// directory, so it never matches.
+pub fn spec_for_dir(dir: &str) -> Option<&'static DocTypeSpec> {
+    DOC_TYPES.iter().find(|spec| matches_dir(spec, dir))
+}
+
+fn matches_dir(spec: &DocTypeSpec, dir: &str) -> bool {
+    match spec.identity {
+        Identity::Numbered { dir: spec_dir } => spec_dir == dir,
+        Identity::Singleton { .. } => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// ADR 0026 fitness function A: every row's template must actually carry
+    /// that row's frontmatter type, and `spec_for` must resolve each token
+    /// back to the exact same static row — so a row added with a mismatched
+    /// template, or one that fails to round-trip, fails to compile-time
+    /// agreement here rather than surfacing as a runtime panic.
+    #[test]
+    fn fitness_function_a_every_spec_matches_its_template_and_round_trips() {
+        for spec in DOC_TYPES {
+            assert!(
+                !spec.template.is_empty(),
+                "{} has an empty template",
+                spec.token
+            );
+
+            let type_line = spec
+                .template
+                .lines()
+                .find(|line| line.starts_with("type:"))
+                .unwrap_or_else(|| {
+                    panic!("{} template has no 'type:' frontmatter line", spec.token)
+                });
+            assert_eq!(
+                type_line,
+                format!("type: {}", spec.frontmatter),
+                "{} template's frontmatter type disagrees with its spec",
+                spec.token
+            );
+
+            let resolved = spec_for(spec.token)
+                .unwrap_or_else(|| panic!("{} did not round-trip through spec_for", spec.token));
+            assert_eq!(
+                resolved, spec,
+                "{} did not round-trip to an identical spec",
+                spec.token
+            );
+        }
+    }
+
+    #[test]
+    fn spec_for_returns_none_for_an_unknown_token() {
+        assert!(spec_for("glossary").is_none());
+        assert!(spec_for("").is_none());
+    }
+
+    /// The row this slice adds: `constitution` now resolves, and it resolves
+    /// as a [`Identity::Singleton`] naming exactly `constitution.md` — the
+    /// row `commands::new`/`commands::brief` branch on to write the bundle's
+    /// single unnumbered record.
+    #[test]
+    fn spec_for_resolves_constitution_as_a_singleton_named_constitution_md() {
+        let spec = spec_for("constitution").expect("constitution must be a registered token");
+        assert_eq!(
+            spec.identity,
+            Identity::Singleton {
+                file: "constitution.md"
+            }
+        );
+    }
+
+    #[test]
+    fn spec_for_dir_matches_the_plural_issues_directory() {
+        assert_eq!(spec_for_dir("issues").map(|spec| spec.token), Some("issue"));
+        assert_eq!(spec_for_dir("adr").map(|spec| spec.token), Some("adr"));
+    }
+
+    #[test]
+    fn spec_for_dir_returns_none_for_an_unknown_directory() {
+        assert!(spec_for_dir("constitution").is_none());
+        assert!(spec_for_dir("issue").is_none());
+        assert!(spec_for_dir("").is_none());
+    }
+}

--- a/living-docs-core/src/lib.rs
+++ b/living-docs-core/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod check;
 pub mod commands;
+pub mod doc_type;
 pub mod frontmatter;
 pub mod paths;
 pub mod pii;

--- a/living-docs-core/src/paths.rs
+++ b/living-docs-core/src/paths.rs
@@ -1,38 +1,26 @@
+use crate::doc_type::{self, Identity};
+
 /// Maps a doc-type token from the CLI to its docs-tree subdirectory (relative
 /// to `--docs-dir`). `issue` is deliberately plural (`issues`) — everything
-/// else matches the token.
-pub fn dir_for(doc_type: &str) -> Option<&'static str> {
-    match doc_type {
-        "adr" => Some("adr"),
-        "bdr" => Some("bdr"),
-        "prd" => Some("prd"),
-        "issue" => Some("issues"),
-        _ => None,
+/// else matches the token. `None` for both an unknown token and a singleton
+/// type, which has no directory (ADR 0026).
+pub fn dir_for(token: &str) -> Option<&'static str> {
+    match doc_type::spec_for(token)?.identity {
+        Identity::Numbered { dir } => Some(dir),
+        Identity::Singleton { .. } => None,
     }
 }
 
 /// Maps a docs-tree subdirectory name back to its doc-type token — the
 /// exact reverse of [`dir_for`].
 pub fn doc_type_for_dir(dir_name: &str) -> Option<&'static str> {
-    match dir_name {
-        "adr" => Some("adr"),
-        "bdr" => Some("bdr"),
-        "prd" => Some("prd"),
-        "issues" => Some("issue"),
-        _ => None,
-    }
+    Some(doc_type::spec_for_dir(dir_name)?.token)
 }
 
 /// Maps a doc-type token to the canonical value written to the frontmatter
 /// `type` field.
-pub fn frontmatter_type_for(doc_type: &str) -> Option<&'static str> {
-    match doc_type {
-        "adr" => Some("ADR"),
-        "bdr" => Some("BDR"),
-        "prd" => Some("PRD"),
-        "issue" => Some("Issue"),
-        _ => None,
-    }
+pub fn frontmatter_type_for(token: &str) -> Option<&'static str> {
+    Some(doc_type::spec_for(token)?.frontmatter)
 }
 
 /// Lowercase kebab-case slug: keeps ASCII alphanumerics, collapses any run of
@@ -69,10 +57,27 @@ mod tests {
     }
 
     #[test]
-    fn dir_for_rejects_unknown_types() {
-        assert_eq!(dir_for("constitution"), None);
+    fn dir_for_returns_none_for_an_unknown_token() {
         assert_eq!(dir_for("glossary"), None);
         assert_eq!(dir_for(""), None);
+    }
+
+    /// A singleton token is known to the registry but has no directory — a
+    /// different reason for `None` than an unknown token (ADR 0026
+    /// Consequences: "`dir_for` becoming fallible for a reason other than
+    /// unknown type"). The token is read off the registry's first
+    /// [`Identity::Singleton`] row rather than hardcoded, so a renamed row
+    /// fails this test instead of silently passing.
+    #[test]
+    fn dir_for_returns_none_for_a_known_singleton_type() {
+        let singleton_token = doc_type::DOC_TYPES
+            .iter()
+            .find(|spec| matches!(spec.identity, Identity::Singleton { .. }))
+            .expect("registry must carry at least one singleton row")
+            .token;
+
+        assert!(doc_type::spec_for(singleton_token).is_some());
+        assert_eq!(dir_for(singleton_token), None);
     }
 
     #[test]
@@ -92,9 +97,13 @@ mod tests {
 
     #[test]
     fn doc_type_for_dir_is_the_exact_reverse_of_dir_for() {
-        for doc_type in ["adr", "bdr", "prd", "issue"] {
-            let dir = dir_for(doc_type).expect("known doc type has a directory");
-            assert_eq!(doc_type_for_dir(dir), Some(doc_type));
+        let numbered_tokens = doc_type::DOC_TYPES
+            .iter()
+            .filter(|spec| matches!(spec.identity, Identity::Numbered { .. }))
+            .map(|spec| spec.token);
+        for token in numbered_tokens {
+            let dir = dir_for(token).expect("a Numbered doc type has a directory");
+            assert_eq!(doc_type_for_dir(dir), Some(token));
         }
     }
 

--- a/living-docs-core/src/record.rs
+++ b/living-docs-core/src/record.rs
@@ -23,6 +23,7 @@ use std::path::Path;
 
 use serde_yaml::Value;
 
+use crate::doc_type::{self, Identity};
 use crate::frontmatter::{
     frontmatter_block, parse_frontmatter, read_scalar_strict, scalar_to_string,
 };
@@ -33,10 +34,6 @@ pub const NUMBER_IDENTITY_KIND: &str = "number";
 
 /// The `identity_kind` discriminator for a path-identified OKF concept doc.
 pub const CONCEPT_IDENTITY_KIND: &str = "concept";
-
-/// Frontmatter `type` values that carry a sequential `NNNN` identity rather
-/// than a `concept_id` (ADR 0007 decision 2).
-const NUMBERED_DOC_TYPES: [&str; 4] = ["adr", "bdr", "prd", "issue"];
 
 /// Frontmatter keys that already have a universal typed column or dedicated
 /// handling elsewhere, and therefore never land in the EAV
@@ -158,8 +155,15 @@ fn extract_identity(path: &Path, doc_type: &str) -> (Option<i32>, Option<String>
     }
 }
 
+/// True when `doc_type` (matched case-insensitively) carries a sequential
+/// `NNNN` identity rather than a `concept_id` (ADR 0007 decision 2), derived
+/// from the doc-type registry's [`Identity::Numbered`] variant rather than a
+/// hand-maintained list (ADR 0026).
 fn is_numbered_doc_type(doc_type: &str) -> bool {
-    NUMBERED_DOC_TYPES.contains(&doc_type.to_lowercase().as_str())
+    matches!(
+        doc_type::spec_for(&doc_type.to_lowercase()).map(|spec| spec.identity),
+        Some(Identity::Numbered { .. })
+    )
 }
 
 /// The strict `NNNN-*.md` prefix of `path`'s filename (four ASCII digits

--- a/living-docs-core/src/templates.rs
+++ b/living-docs-core/src/templates.rs
@@ -1,14 +1,11 @@
-/// Compile-time embedded doc templates, keyed by the CLI's doc-type token.
-/// Embedding (rather than reading from disk at runtime) keeps the binary
+use crate::doc_type;
+
+/// Compile-time embedded doc templates, keyed by the CLI's doc-type token
+/// and looked up through the doc-type registry (ADR 0026). Embedding
+/// (rather than reading from disk at runtime) keeps the binary
 /// self-contained per ADR 0001.
-pub fn template_for(doc_type: &str) -> Option<&'static str> {
-    match doc_type {
-        "adr" => Some(include_str!("../../skills/living-docs/templates/adr.md")),
-        "bdr" => Some(include_str!("../../skills/living-docs/templates/bdr.md")),
-        "prd" => Some(include_str!("../../skills/living-docs/templates/prd.md")),
-        "issue" => Some(include_str!("../../skills/living-docs/templates/issue.md")),
-        _ => None,
-    }
+pub fn template_for(token: &str) -> Option<&'static str> {
+    Some(doc_type::spec_for(token)?.template)
 }
 
 #[cfg(test)]
@@ -27,7 +24,13 @@ mod tests {
 
     #[test]
     fn template_for_rejects_unknown_types() {
+        let unsupported = "glossary";
+        assert!(
+            doc_type::spec_for(unsupported).is_none(),
+            "fixture premise broken: `{unsupported}` is now a registry token — pick another",
+        );
+
         assert_eq!(template_for("bogus"), None);
-        assert_eq!(template_for("constitution"), None);
+        assert_eq!(template_for(unsupported), None);
     }
 }

--- a/living-docs-core/tests/hook_registry_parity.rs
+++ b/living-docs-core/tests/hook_registry_parity.rs
@@ -1,0 +1,88 @@
+//! ADR 0026 decision point 8: `block-docs-handwrite.sh` cannot read a Rust
+//! `const`, so its scope regex and deny message stay a hardcoded bash copy
+//! of `doc_type::DOC_TYPES` on purpose (fast, fail-open, binary-independent).
+//! The duplication is allowed to survive; drift between the copy and the
+//! registry is not. This test reads the hook script from disk and asserts
+//! both copies agree with the registry's `Identity::Numbered` rows, compared
+//! as sets so a spurious extra entry on either side fails too.
+
+use living_docs_core::doc_type::{Identity, DOC_TYPES};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::PathBuf;
+
+fn hook_source() -> String {
+    let path = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/.."))
+        .join("skills/living-docs/hooks/block-docs-handwrite.sh");
+    fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read hook script at {}: {e}", path.display()))
+}
+
+fn alternation_group_after<'a>(source: &'a str, marker: &str) -> &'a str {
+    let start = source.find(marker).unwrap_or_else(|| {
+        panic!("hook script marker `{marker}` not found — did the hook's structure change?")
+    }) + marker.len();
+    let rest = &source[start..];
+    let end = rest.find([')', '>']).unwrap_or_else(|| {
+        panic!("hook script alternation group after `{marker}` has no closing delimiter")
+    });
+    &rest[..end]
+}
+
+fn scope_regex_directories(source: &str) -> BTreeSet<String> {
+    alternation_group_after(source, "\"$BUNDLE\"/(")
+        .split('|')
+        .map(str::to_owned)
+        .collect()
+}
+
+fn deny_message_tokens(source: &str) -> BTreeSet<String> {
+    alternation_group_after(source, "living-docs new <")
+        .split('|')
+        .map(str::to_owned)
+        .collect()
+}
+
+fn registry_numbered_directories() -> BTreeSet<String> {
+    DOC_TYPES
+        .iter()
+        .filter_map(|spec| match spec.identity {
+            Identity::Numbered { dir } => Some(dir.to_owned()),
+            Identity::Singleton { .. } => None,
+        })
+        .collect()
+}
+
+fn registry_numbered_tokens() -> BTreeSet<String> {
+    DOC_TYPES
+        .iter()
+        .filter_map(|spec| match spec.identity {
+            Identity::Numbered { .. } => Some(spec.token.to_owned()),
+            Identity::Singleton { .. } => None,
+        })
+        .collect()
+}
+
+#[test]
+fn hook_scope_regex_agrees_with_the_registrys_numbered_directories() {
+    let hook_dirs = scope_regex_directories(&hook_source());
+    let registry_dirs = registry_numbered_directories();
+    assert_eq!(
+        hook_dirs, registry_dirs,
+        "block-docs-handwrite.sh's scope regex directories {hook_dirs:?} disagree with \
+         doc_type::DOC_TYPES's Identity::Numbered directories {registry_dirs:?} — edit \
+         the hook's scope regex to match the registry"
+    );
+}
+
+#[test]
+fn hook_deny_message_agrees_with_the_registrys_numbered_tokens() {
+    let hook_tokens = deny_message_tokens(&hook_source());
+    let registry_tokens = registry_numbered_tokens();
+    assert_eq!(
+        hook_tokens, registry_tokens,
+        "block-docs-handwrite.sh's guard_write deny message tokens {hook_tokens:?} disagree \
+         with doc_type::DOC_TYPES's Identity::Numbered tokens {registry_tokens:?} — edit \
+         the hook's deny message to match the registry"
+    );
+}

--- a/skills/living-docs/hooks/block-docs-handwrite.sh
+++ b/skills/living-docs/hooks/block-docs-handwrite.sh
@@ -3,8 +3,9 @@
 # block-docs-handwrite.sh — PreToolUse gate enforcing CLI-owned doc authoring
 # (ADR 0019 block rules, ADR 0020 scope, ADR 0021 in-repo distribution).
 #
-# Reads the Claude Code PreToolUse payload (JSON) on stdin. Inside the four
-# CLI-owned type directories of the docs bundle (adr|bdr|prd|issues) it blocks:
+# Reads the Claude Code PreToolUse payload (JSON) on stdin. Inside the
+# CLI-owned type directories of the docs bundle (adr|bdr|prd|issues|research)
+# it blocks:
 #   - a Write creating a new NNNN-*.md record    -> `living-docs new`
 #   - any direct write to a type index.md        -> `living-docs index`
 #   - a Write/Edit/MultiEdit whose result changes a CLI-owned frontmatter key
@@ -66,7 +67,7 @@ apply_edit() {
 
 guard_write() {
   if [ ! -e "$FILE" ]; then
-    deny "records are scaffolded by the CLI — run \`living-docs new <adr|bdr|prd|issue> \"<title>\"\` (numbering + frontmatter + skeleton), then write ONLY the body below the closing ---. Binary missing? \`make build\`."
+    deny "records are scaffolded by the CLI — run \`living-docs new <adr|bdr|prd|issue|research> \"<title>\"\` (numbering + frontmatter + skeleton), then write ONLY the body below the closing ---. Binary missing? \`make build\`."
   fi
   deny_unless_owned_lines_kept "$(cat "$FILE")" "$(json_field '.tool_input.content')"
 }
@@ -106,7 +107,7 @@ TOOL="$(json_field '.tool_name')"
 FILE="$(json_field '.tool_input.file_path')"
 [ -n "$FILE" ] || allow
 
-[[ "$FILE" =~ (^|/)"$BUNDLE"/(adr|bdr|prd|issues)/([^/]+)$ ]] || allow
+[[ "$FILE" =~ (^|/)"$BUNDLE"/(adr|bdr|prd|issues|research)/([^/]+)$ ]] || allow
 NAME="${BASH_REMATCH[3]}"
 
 if [ "$NAME" = "index.md" ]; then

--- a/skills/living-docs/templates/constitution.md
+++ b/skills/living-docs/templates/constitution.md
@@ -2,14 +2,15 @@
 type: Constitution
 title: <Product> Constitution
 description: Foundational scope, data model, and non-negotiables for <product>.
-status: Draft               # Draft | Ratified | Amended
+status: Draft
 timestamp: <ISO 8601 datetime>
 ---
 
 # Product Constitution
 
-<!-- Status lives in frontmatter (`status`). This file is singular — no NNNN prefix,
-     and it is NOT listed as a concept in any index.md. It is the bundle's root of trace. -->
+<!-- Status lives in frontmatter (`status`: Draft | Ratified | Amended). This file is
+     singular — no NNNN prefix, and it is NOT listed as a concept in any index.md.
+     It is the bundle's root of trace. -->
 
 ## Product
 

--- a/skills/living-docs/templates/research.md
+++ b/skills/living-docs/templates/research.md
@@ -1,0 +1,53 @@
+---
+type: Research
+title: <Short question or investigation title>
+description: <One sentence — the question this record answers.>
+status: Draft
+timestamp: <ISO 8601 datetime>
+---
+
+# NNNN. <Short question or investigation title>
+
+<!-- Status lives in frontmatter (`status`: Draft | Accepted | Superseded), not a body
+     line. A research record is evidence, not a decision: it is superseded when
+     re-investigation invalidates it, never "implemented". `living-docs supersede` adds
+     `superseded_by` when a later record replaces this one. -->
+
+## Question
+
+<The single question this record answers, stated so that an answer could be wrong. If a
+pending decision motivated the investigation, link it bundle-relative:
+[ADR](/adr/NNNN-<slug>.md), [PRD](/prd/NNNN-<slug>.md).>
+
+## Method
+
+<How the question was investigated, in enough detail for someone else to repeat it: what
+was read or measured, against which version or commit, with which tool, over what sample.
+State the date the evidence was gathered — the findings below are true as of that date and
+no later.>
+
+## Findings
+
+<What was observed, kept separate from what it means. One row per finding, each traceable
+to the method above and to a reference below. Record contradicting evidence too — a
+research record that only confirms its own premise has not investigated anything.>
+
+| Finding | Evidence | Confidence |
+|---|---|---|
+| <what was observed> | <reference [1] / measurement / file:line> | high / medium / low |
+
+## Implications
+
+<What follows for this project, and what does not. Name the decisions this evidence
+supports or rules out; do not make those decisions here — that is an ADR's job. Evidence
+and decision stay separate records.>
+
+## Open Questions
+
+<What this investigation did not settle, so the next reader knows where the edge is.>
+
+# References
+
+<!-- OKF §8. Each entry per `rules/citation-conventions.md`: ABNT NBR 6023 structure,
+     always carrying the link. -->
+[1] [<source>](<url>). Available at: <url>. Accessed on: <date>.

--- a/skills/living-docs/tests/hooks/run.sh
+++ b/skills/living-docs/tests/hooks/run.sh
@@ -47,6 +47,28 @@ EOF
 printf '# ADR index\n' >"$TMP/docs/adr/index.md"
 printf '# Docs\n' >"$TMP/docs/index.md"
 
+RESEARCH_RECORD="$TMP/docs/research/0001-field-notes.md"
+cat >"$RESEARCH_RECORD" <<'EOF'
+---
+type: Research
+title: Field notes
+description: A fixture record.
+status: Proposed
+tags: [fixture]
+timestamp: 2026-01-01T00:00:00Z
+---
+
+# 0001. Field notes
+
+## Context
+
+Body prose mentioning frontmatter in passing.
+
+## Findings
+
+We will keep this fixture minimal.
+EOF
+
 fail=0
 
 payload_write() { # payload_write <file> <content>
@@ -112,8 +134,12 @@ run_case fenced-status-edit-allowed 0 absent "living-docs" _=1 -- \
 run_case same-frontmatter-rewrite-allowed 0 absent "living-docs" _=1 -- \
 	"$(payload_write "$RECORD" "$(cat "$RECORD")")"
 
-run_case research-record-allowed 0 absent "living-docs" _=1 -- \
+run_case research-new-record-write-blocked 2 present "living-docs new" _=1 -- \
 	"$(payload_write "$TMP/docs/research/0003-notes.md" $'---\ntype: Research\n---\nbody')"
+run_case research-type-index-write-blocked 2 present "living-docs index" _=1 -- \
+	"$(payload_write "$TMP/docs/research/index.md" '# Research index')"
+run_case research-body-edit-allowed 0 absent "living-docs" _=1 -- \
+	"$(payload_edit "$RESEARCH_RECORD" 'keep this fixture minimal' 'keep this fixture tiny')"
 run_case bundle-root-index-allowed 0 absent "living-docs" _=1 -- \
 	"$(payload_write "$TMP/docs/index.md" '# Docs')"
 run_case non-docs-path-allowed 0 absent "living-docs" _=1 -- \

--- a/web/src/views.rs
+++ b/web/src/views.rs
@@ -10,6 +10,7 @@
 //! injected as-is through `PreEscaped`.
 
 use db_store::{NavEntry, ProjectView, RecordMeta, RelatedRef, SearchHit};
+use living_docs_core::doc_type;
 use maud::{html, Markup, PreEscaped};
 
 /// Renders the full three-pane document: `<head>` with the served
@@ -353,10 +354,15 @@ fn tags_section(tags: &[String]) -> Markup {
     }
 }
 
-/// The doc types Atlas's create form offers — the same four
-/// `living_docs_core::paths::dir_for` accepts (ADR 0016, issue 0010 slice
-/// 3): `adr`, `bdr`, `prd`, `issue`.
-const CREATABLE_DOC_TYPES: [&str; 4] = ["adr", "bdr", "prd", "issue"];
+/// The doc types Atlas's create form offers, in the doc-type registry's
+/// declared order — every spec whose `web_creatable` flag is set (ADR 0016,
+/// issue 0010 slice 3; ADR 0026), rather than a hand-maintained list.
+fn creatable_doc_types() -> impl Iterator<Item = &'static str> {
+    doc_type::DOC_TYPES
+        .iter()
+        .filter(|spec| spec.web_creatable)
+        .map(|spec| spec.token)
+}
 
 /// Renders `POST /new`'s create form: a doc-type select, a title input, and
 /// a submit button, in the same plain (label-less) input style
@@ -381,7 +387,7 @@ pub fn create_form(doc_type: Option<&str>, title: Option<&str>, error: Option<&s
 fn doc_type_select(selected: Option<&str>) -> Markup {
     html! {
         select name="doc_type" {
-            @for option in CREATABLE_DOC_TYPES {
+            @for option in creatable_doc_types() {
                 option value=(option) selected[selected == Some(option)] { (option) }
             }
         }
@@ -782,6 +788,21 @@ mod tests {
                 "missing option for {doc_type}: {rendered}"
             );
         }
+    }
+
+    /// ADR 0026 fitness function B (web half): the number of options the
+    /// create form renders equals the number of `web_creatable` specs in
+    /// the registry, so a registry row added without setting/clearing
+    /// `web_creatable` can never silently drift from the rendered form.
+    #[test]
+    fn create_form_option_count_matches_the_registrys_web_creatable_count() {
+        let rendered = create_form(None, None, None).into_string();
+        let expected = doc_type::DOC_TYPES
+            .iter()
+            .filter(|spec| spec.web_creatable)
+            .count();
+
+        assert_eq!(rendered.matches("<option value=\"").count(), expected);
     }
 
     #[test]


### PR DESCRIPTION
Implements [ADR 0026](docs/adr/0026-a-single-doctype-registry-replaces-nine-hand-synced-enumerations-and-research-and-constitution-enter-as-rows.md). Adds `research` and `constitution` as creatable doc types — the thing that motivated the work — by removing the reason adding one was expensive.

## The problem

Nine hand-synced lists enumerated the doc types, across `new`, `brief`, `index`, `paths`, `record`, `templates`, `check` and `web`. Adding a type meant eighteen edits. Two of those sites reached the taxonomy through `.expect()`, so an inconsistent entry panicked at runtime instead of failing to compile. `constitution` had a written template and no way to create it; three tests pinned that half-wired state as if it were the contract.

## The change

`DOC_TYPES` is a compile-time table and the single source. `Identity` is an enum whose `Numbered` variant **carries** the directory, so a type without one is unrepresentable rather than merely unused — that is what lets `constitution` land as a singleton without a stale `constitution/` directory anywhere in the system.

`check` follows the registry too: the bundle-root singleton is CLI-owned for the canonical-frontmatter invariant and exempt from index membership, both derived from `Identity::Singleton` instead of a filename literal.

## What holds it in place

Four fitness functions, plus a cross-language test that reads `block-docs-handwrite.sh` and asserts its hardcoded alternation equals the registry's numbered rows. The hook stays a bash copy on purpose — it must be fast, fail-open, and work when the binary is absent — so the duplication survives and the drift does not.

Every fitness function was mutation-proven, and two mutations changed the plan rather than confirming it:

- The AC that was supposed to guard the research template named the wrong instrument. `fill_frontmatter` overwrites the template's `type:` line from the spec, so corrupting the template cannot fail `new`. Only fitness A catches it.
- A bare `index` run created a directory for every registry token. Invisible with four rows; with five it turned `examples/linkly/docs` from passing `check` to failing it. `regenerate` is now a no-op for a type whose directory does not exist — directories come from `new`, never from `index`.

## Verification

- 861 tests (33 suites); `make check` green
- `living-docs check docs` → `OK — 53 docs`; `examples/linkly/docs` → `OK — 17 docs`
- Manually reproduced: `new constitution` twice, bare `index` vs. explicit `index constitution`, `brief constitution` → `check` end to end

## Notes for the reviewer

Delivered as six reviewed slices plus a follow-up hardening slice. One review finding did **not** survive investigation and is worth knowing: a predicted macOS symlink false positive in `is_bundle_singleton` does not reproduce, because the directory walk builds every path by joining onto the bundle root it was handed and `read_dir` does not resolve symlinks. Canonicalizing would have made a pure predicate touch disk and broken every in-memory-store fixture. The response was a test pinning that invariant, not a code change — the reasoning is recorded in the ADR's Follow-ups.

Still deliberately deferred, both recorded as separate decisions: making `check::size::has_size_target` registry-driven (it encodes an epistemic category, not identity), and wiring the `glossary` template.

The first commit is unrelated: four CLI gaps found while adopting living-docs in a downstream repo, recorded as issues 0014–0017. Issue 0017's research half is closed by this PR.

🤖 Co-authored with Claude Code
