### PR TITLE
refactor(core): decide the body-size target from the registry, not a literal list

### DIFF
--- a/docs/adr/0027-every-rule-keyed-by-doc-type-becomes-a-registry-field-and-glossary-is-not-a-doc-type.md
+++ b/docs/adr/0027-every-rule-keyed-by-doc-type-becomes-a-registry-field-and-glossary-is-not-a-doc-type.md
@@ -1,0 +1,127 @@
+---
+type: ADR
+title: Every rule keyed by doc type becomes a registry field, and glossary is not a doc type
+description: A row is a doc type the tool creates, numbers or places; a field is any rule it applies once the type is known — so the body-size rule moves into DocTypeSpec and glossary stays out.
+status: Accepted
+timestamp: 2026-07-30T20:19:45Z
+---
+
+# 0027. Every rule keyed by doc type becomes a registry field, and glossary is not a doc type
+
+## Context
+
+[ADR 0026](/adr/0026-a-single-doctype-registry-replaces-nine-hand-synced-enumerations-and-research-and-constitution-enter-as-rows.md)
+replaced nine hand-synced doc-type enumerations with one compile-time `DocTypeSpec`
+registry, and deliberately left two questions open. Both are the same question — what
+belongs in the registry — and they answer in opposite directions, which is why they are
+settled together.
+
+The first is `check::size::has_size_target`, deciding whether a record's body is measured
+against the 100/120-line target:
+
+```rust
+fn has_size_target(doc_type: &str) -> bool {
+    matches!(doc_type, "ADR" | "BDR" | "PRD" | "Issue")
+}
+```
+
+This is a tenth enumeration, and the worst-behaved of the ten, because it fails *open*.
+Every list ADR 0026 absorbed announced a missing type loudly — a panic, an unresolvable
+directory, a missing index row. This one announces nothing: a new row is silently exempt,
+and no reader is told a decision was made on their behalf. The test meant to guard it,
+`every_decision_and_execution_record_type_carries_the_target`, iterates the literal
+`["ADR", "BDR", "PRD", "Issue"]` — mirroring the implementation instead of constraining
+it, so it cannot fail when a type is added.
+
+ADR 0026 deferred it because a size target "encodes an epistemic category, not identity".
+That reason does not survive contact with the registry as built: `DocTypeSpec` already
+carries `frontmatter`, `template` and the index metadata, none of which are identity
+either, and the row's own docblock says it holds everything a doc-type consumer needs.
+`Identity` carries identity — the rest of the row is precisely this kind of rule.
+
+The second is the `glossary` template, which ships under `skills/living-docs/templates/`
+with no way to create the record it describes — the half-wired state `constitution` was in
+before ADR 0026. The obvious move is to make it a row. Reading it first says otherwise:
+
+```yaml
+type: Context
+title: "Glossary"
+```
+
+It declares `type: Context`, not `type: Glossary`, and `Context` is a category with many
+members: the shipped `context-index.md` states that each group file "owns one coherent
+slice of the vocabulary". A glossary is one such slice, not a type of its own, and it has
+no number and no fixed path — `context/glossary.md` and `context/billing.md` are peers.
+
+`Identity` cannot express that shape. `Numbered { dir }` gives a directory and an `NNNN`
+prefix; `Singleton { file }` gives one fixed path. A Context group file is plural like the
+first and unnumbered like the second: an author-named record inside a directory. Wiring
+`glossary` does not need a row, it needs a third identity variant — a larger decision,
+with its own consequences for `new`, `index` and `check`, that this ADR does not make.
+
+The two remaining unwired templates are not candidates at all: `architecture-index.md` and
+`context-index.md` each declare themselves OKF reserved `index.md` files carrying no
+frontmatter — directory scaffolds, not records.
+
+## Decision
+
+We will move every rule keyed by doc type into `DocTypeSpec`, beginning with the body-size
+rule, and we will not make `glossary` a registry row.
+
+`has_size_target` becomes a `body_size` field on the row, typed as an enum rather than a
+`bool` so that a call site reads as a rule and a future third rule stays representable.
+`check::size` reads that rule through the registry instead of matching on strings, and its
+guard test iterates `DOC_TYPES` rather than a literal list — the fitness-function shape
+ADR 0026 established. Because the field is required, a new row cannot compile without
+stating its body-size rule, which turns a silent default into a decision.
+
+The registry's boundary is thereby stated positively, and applies to the next candidate
+without re-deriving it: **a row is a doc type the tool creates, numbers or places; a field
+is any rule the tool applies once it knows the type.**
+
+`Identity` decides the first; everything else on the row is the second. `glossary` fails
+the row test — the tool cannot place it, because its placement is the author's choice —
+so it stays unwired until `Identity` grows a variant for an author-named record in a
+directory.
+
+## Consequences
+
+**Easier / gained:**
+- Adding a doc type is still one row, and it will not compile until its body-size rule is
+  stated — the one list that could fail open no longer can.
+- "Is a Research doc exempt?" is answered by reading the Research row rather than by
+  grepping the check module, and the next unwired template is decided by a stated
+  admission rule rather than by argument.
+
+**Harder / accepted trade-offs:**
+- The `Context` and `Architecture View` families stay hand-authored, so the gap ADR 0026
+  closed for `constitution` stays open for `glossary`. Accepted rather than force a shape
+  the registry cannot hold: a wrong row costs more than a missing one, because it becomes
+  a premise every consumer reads as true.
+- A registry row now carries a check-layer concern. Deliberate coupling — rules keyed by
+  type are cheaper to keep honest in one table than in N modules, and `check::size` still
+  owns the thresholds themselves.
+
+**Follow-ups:**
+- [Issue 0018](/issues/0018-identity-cannot-express-an-author-named-record-in-a-directory-so-glossary-and-the-context-family-stay-hand-authored.md)
+  for the third `Identity` variant, which is what `glossary` and the wider `Context` and
+  `Architecture View` families are waiting on.
+- The 100/120-line thresholds stay global constants in `check::size`. Per-type thresholds
+  become representable in the new field, but no type wants them and inventing the need
+  would reintroduce the configurability this registry exists to avoid.
+
+## Verification
+
+**Implementation impact:** `living-docs-core/src/{doc_type.rs, check/size.rs}`.
+
+**Verification criteria:**
+- `has_size_target` no longer exists, and no literal doc-type list or `matches!` over type
+  names remains anywhere in `living-docs-core/src/check/size.rs`.
+- Fitness function: a test iterates `DOC_TYPES` and asserts, for every row, that a body one
+  line over the warn threshold is flagged exactly when that row's `body_size` rule says it
+  should be — replacing `every_decision_and_execution_record_type_carries_the_target`, not
+  sitting beside it. Adding a row without deciding fails to compile; deciding wrongly
+  fails this test.
+- `living-docs check docs` and `living-docs check examples/linkly/docs` report the same
+  violation counts as before — a refactor of where the rule lives, not of what it decides.
+- `DOC_TYPES` contains no `glossary` row.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -32,6 +32,7 @@ repo teaches. The decision *log* is this listing plus each record's `status` /
 * [0023 — Hooks ship through two deterministic channels: an in-repo Claude Code plugin and a living-docs hooks install verb](0023-hooks-ship-through-two-deterministic-channels-an-in-repo-claude-code-plugin-and-a-living-docs-hooks-install-verb.md) - Accepted
 * [0025 — Releases are born draft and earn publication by passing the asset gate](0025-releases-are-born-draft-and-earn-publication-by-passing-the-asset-gate.md) - Accepted
 * [0026 — A single DocType registry replaces nine hand-synced enumerations, and research and constitution enter as rows](0026-a-single-doctype-registry-replaces-nine-hand-synced-enumerations-and-research-and-constitution-enter-as-rows.md) - Accepted
+* [0027 — Every rule keyed by doc type becomes a registry field, and glossary is not a doc type](0027-every-rule-keyed-by-doc-type-becomes-a-registry-field-and-glossary-is-not-a-doc-type.md) - Accepted
 
 ## Superseded
 

--- a/docs/issues/0018-identity-cannot-express-an-author-named-record-in-a-directory-so-glossary-and-the-context-family-stay-hand-authored.md
+++ b/docs/issues/0018-identity-cannot-express-an-author-named-record-in-a-directory-so-glossary-and-the-context-family-stay-hand-authored.md
@@ -1,0 +1,72 @@
+---
+type: Issue
+title: Identity cannot express an author-named record in a directory, so glossary and the Context family stay hand-authored
+description: Add a third Identity variant for records that live in a directory but are named by their author rather than numbered by the tool, so glossary and the Context family become creatable.
+status: Proposed
+timestamp: 2026-07-30T20:21:19Z
+---
+
+<!-- OKF frontmatter above carries the tracker metadata (`status`: open | in-progress |
+     closed | superseded) that previously lived only in the directory index. Everything
+     BELOW the closing `---` is the issue body and MUST stay byte-identical to the
+     published tracker body — strip the frontmatter when publishing. -->
+
+## Identity cannot express an author-named record in a directory
+
+Follow-up from [ADR 0027](/adr/0027-every-rule-keyed-by-doc-type-becomes-a-registry-field-and-glossary-is-not-a-doc-type.md).
+
+`DocTypeSpec::identity` has two variants. `Numbered { dir }` places a record in a
+directory under an `NNNN` prefix the tool allocates. `Singleton { file }` places it at one
+fixed path. A third shape exists in the corpus and neither variant fits it: a record that
+lives in a directory, has many peers, and is named by its author rather than numbered by
+the tool.
+
+Three shipped artifacts are waiting on it. The `glossary` template declares
+`type: Context` and is one vocabulary group file among many — `context/glossary.md` and
+`context/billing.md` are peers, not a first and a second. The `Context` family generally,
+and the `Architecture View` family behind `architecture-index.md`, have the same shape.
+All three are hand-copied today: there is no `living-docs new` verb that produces them,
+which is the gap ADR 0026 closed for `constitution` and left open here.
+
+The cost of the gap is not only ergonomic. A hand-copied record starts outside the
+canonical-frontmatter invariant and outside index membership, so the two checks that keep
+the numbered types honest do not apply to it.
+
+### Scope
+
+Included: a third `Identity` variant for author-named records in a directory, and
+whatever `new`, `index`, `check` and the web front need in order to honor it. Wiring the
+`glossary` template as the first row that uses it.
+
+Explicitly kept: `Numbered` and `Singleton` keep their current meaning and their current
+rows. This adds a variant; it does not reshape the two that exist.
+
+Explicitly out: `architecture-index.md` and `context-index.md` stay unwired regardless.
+Both declare themselves OKF reserved `index.md` files carrying no frontmatter — they
+scaffold a directory and are not records, so no identity variant applies to them.
+
+### Acceptance
+
+- `DOC_TYPES` contains a `glossary` row, and `living-docs new glossary "..."` — or
+  whatever naming the design settles on — produces a record that `living-docs check`
+  passes without hand-editing.
+- The record produced is subject to the canonical-frontmatter invariant and to whatever
+  index rule the design chooses, and a test pins which of the two applies.
+- Fitness function: the check layer learns the new variant from the registry, in the shape
+  `is_bundle_singleton` already uses — adding a second author-named row requires no edit
+  inside `check`.
+- `living-docs check docs` and `living-docs check examples/linkly/docs` stay green.
+
+### Plan
+
+Design first: an ADR settling what the tool owns for an author-named record. The open
+questions are the naming rule (does the tool derive the filename from the title, or accept
+it verbatim?), index membership (is a `Context` group file listed in an index the tool
+regenerates, given that `context-index.md` is authored prose rather than a generated
+listing?), and whether `type:` collision matters now that two rows could share one
+frontmatter value — `spec_for` and `spec_for_dir` key on token and directory, so nothing
+resolves a spec from its frontmatter value today, but that is an unstated invariant rather
+than a guaranteed one.
+
+Then one slice per question the ADR closes, in the order registry variant → `new` →
+`check`, so each is demoable on its own.

--- a/docs/issues/index.md
+++ b/docs/issues/index.md
@@ -15,6 +15,7 @@ one slice per fresh context, starting from the skeleton.
 * [0015 — status with a bare record number resolves across type directories, ADRs first](0015-status-with-a-bare-record-number-resolves-across-type-directories-adrs-first.md) - Proposed
 * [0016 — check needs a ratchet or changed-files mode so brownfield repos can arm the pre-commit channel](0016-check-needs-a-ratchet-or-changed-files-mode-so-brownfield-repos-can-arm-the-pre-commit-channel.md) - Proposed
 * [0017 — bundle vocabulary gaps: no research doc type in index and no terminal closed status for issues](0017-bundle-vocabulary-gaps-no-research-doc-type-in-index-and-no-terminal-closed-status-for-issues.md) - Proposed
+* [0018 — Identity cannot express an author-named record in a directory, so glossary and the Context family stay hand-authored](0018-identity-cannot-express-an-author-named-record-in-a-directory-so-glossary-and-the-context-family-stay-hand-authored.md) - Proposed
 
 ## Closed
 

--- a/living-docs-core/src/check/size.rs
+++ b/living-docs-core/src/check/size.rs
@@ -1,9 +1,11 @@
 //! Advisory body-size check (issue 0009) — decision/execution records aim for
 //! ~100 body lines; past 120 the check prints a `SIZE` note. Advisory only:
-//! it never affects the exit code, and long-form evidence types (Research and
-//! the non-record docs) are exempt.
+//! it never affects the exit code. Which doc types the target applies to is
+//! decided per-row by `doc_type::DocTypeSpec::body_size` (ADR 0027), not by
+//! this module.
 
 use super::{file_name_str, records, Reporter};
+use crate::doc_type::{self, BodySize};
 use crate::frontmatter;
 use crate::store::DocStore;
 use std::path::PathBuf;
@@ -30,15 +32,10 @@ pub(crate) fn check_body_size(store: &dyn DocStore, all_md: &[PathBuf], reporter
 
 fn over_target_body_lines(content: &str) -> Option<usize> {
     let doc_type = frontmatter::read_scalar_from_str(content, "type")?;
-    if !has_size_target(&doc_type) {
-        return None;
-    }
-    let lines = body_line_count(content);
-    (lines > WARN_LINES).then_some(lines)
-}
-
-fn has_size_target(doc_type: &str) -> bool {
-    matches!(doc_type, "ADR" | "BDR" | "PRD" | "Issue")
+    let spec = doc_type::spec_for_frontmatter(&doc_type)?;
+    (spec.body_size == BodySize::Targeted)
+        .then(|| body_line_count(content))
+        .filter(|lines| *lines > WARN_LINES)
 }
 
 fn body_line_count(content: &str) -> usize {
@@ -104,13 +101,50 @@ mod tests {
     }
 
     #[test]
-    fn every_decision_and_execution_record_type_carries_the_target() {
-        for doc_type in ["ADR", "BDR", "PRD", "Issue"] {
-            assert_eq!(
-                over_target_body_lines(&doc_with_body_lines(doc_type, 121)),
-                Some(121),
-                "{doc_type} should carry the size target"
-            );
+    fn a_type_absent_from_the_registry_is_exempt_regardless_of_length() {
+        assert!(
+            doc_type::spec_for_frontmatter("Context").is_none(),
+            "fixture premise broken: `Context` is now a registered frontmatter value — pick another unregistered type",
+        );
+        assert_eq!(
+            over_target_body_lines(&doc_with_body_lines("Context", 400)),
+            None
+        );
+    }
+
+    /// Proves `check::size` reads `doc_type::DOC_TYPES` rather than a
+    /// hardcoded list of which types get the size target — it does not, and
+    /// cannot, prove any single row's `body_size` verdict is *correct*. That
+    /// is held by the pinned tests beside it: `a_body_one_line_over_...`
+    /// pins ADR = Targeted, `research_is_exempt_regardless_of_length` pins
+    /// Research = Exempt.
+    #[test]
+    fn every_registry_row_is_flagged_exactly_when_its_body_size_is_targeted() {
+        let mut saw_targeted = false;
+        let mut saw_exempt = false;
+        for spec in doc_type::DOC_TYPES {
+            let over_target = over_target_body_lines(&doc_with_body_lines(spec.frontmatter, 121));
+            match spec.body_size {
+                BodySize::Targeted => {
+                    saw_targeted = true;
+                    assert_eq!(
+                        over_target,
+                        Some(121),
+                        "{} is Targeted so it should carry the size target",
+                        spec.frontmatter
+                    );
+                }
+                BodySize::Exempt => {
+                    saw_exempt = true;
+                    assert_eq!(
+                        over_target, None,
+                        "{} is Exempt so it should not carry the size target",
+                        spec.frontmatter
+                    );
+                }
+            }
         }
+        assert!(saw_targeted, "no Targeted row was exercised");
+        assert!(saw_exempt, "no Exempt row was exercised");
     }
 }

--- a/living-docs-core/src/doc_type.rs
+++ b/living-docs-core/src/doc_type.rs
@@ -16,6 +16,14 @@ pub enum Identity {
     Singleton { file: &'static str },
 }
 
+/// Whether a doc type's body is measured against the advisory 100/120-line
+/// target in `check::size`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum BodySize {
+    Targeted,
+    Exempt,
+}
+
 /// The axis `index` partitions a type's records along.
 #[derive(PartialEq, Eq, Debug)]
 pub enum IndexPartition {
@@ -26,7 +34,8 @@ pub enum IndexPartition {
 
 /// Everything a doc type needs to be created, indexed and offered by every
 /// consumer: its token, path shape, frontmatter value, embedded template,
-/// index rendering and web-creatability.
+/// index rendering, web-creatability, and whether its body carries the
+/// advisory size target.
 #[derive(PartialEq, Debug)]
 pub struct DocTypeSpec {
     pub token: &'static str,
@@ -36,6 +45,7 @@ pub struct DocTypeSpec {
     pub index_heading: &'static str,
     pub index_partition: IndexPartition,
     pub web_creatable: bool,
+    pub body_size: BodySize,
 }
 
 const ADR: DocTypeSpec = DocTypeSpec {
@@ -46,6 +56,7 @@ const ADR: DocTypeSpec = DocTypeSpec {
     index_heading: "ADRs",
     index_partition: IndexPartition::ActiveSuperseded,
     web_creatable: true,
+    body_size: BodySize::Targeted,
 };
 
 const BDR: DocTypeSpec = DocTypeSpec {
@@ -56,6 +67,7 @@ const BDR: DocTypeSpec = DocTypeSpec {
     index_heading: "BDRs",
     index_partition: IndexPartition::ActiveSuperseded,
     web_creatable: true,
+    body_size: BodySize::Targeted,
 };
 
 const PRD: DocTypeSpec = DocTypeSpec {
@@ -66,6 +78,7 @@ const PRD: DocTypeSpec = DocTypeSpec {
     index_heading: "PRDs",
     index_partition: IndexPartition::ActiveSuperseded,
     web_creatable: true,
+    body_size: BodySize::Targeted,
 };
 
 const ISSUE: DocTypeSpec = DocTypeSpec {
@@ -76,6 +89,7 @@ const ISSUE: DocTypeSpec = DocTypeSpec {
     index_heading: "Issues",
     index_partition: IndexPartition::OpenClosed,
     web_creatable: true,
+    body_size: BodySize::Targeted,
 };
 
 const RESEARCH: DocTypeSpec = DocTypeSpec {
@@ -86,6 +100,7 @@ const RESEARCH: DocTypeSpec = DocTypeSpec {
     index_heading: "Research",
     index_partition: IndexPartition::Flat,
     web_creatable: true,
+    body_size: BodySize::Exempt,
 };
 
 /// `index_heading`/`index_partition` are inert for a singleton — it has no
@@ -102,6 +117,7 @@ const CONSTITUTION: DocTypeSpec = DocTypeSpec {
     index_heading: "Constitution",
     index_partition: IndexPartition::Flat,
     web_creatable: true,
+    body_size: BodySize::Exempt,
 };
 
 /// The sole enumeration of the doc-type taxonomy. Every consumer derives
@@ -111,6 +127,16 @@ pub const DOC_TYPES: &[DocTypeSpec] = &[ADR, BDR, PRD, ISSUE, RESEARCH, CONSTITU
 /// Looks up a doc type by its CLI token.
 pub fn spec_for(token: &str) -> Option<&'static DocTypeSpec> {
     DOC_TYPES.iter().find(|spec| spec.token == token)
+}
+
+/// Looks up a doc type by its `type:` frontmatter value. Returns the first
+/// match, which is well-defined only because `frontmatter` values are unique
+/// across `DOC_TYPES` — an invariant guarded by
+/// `frontmatter_values_are_unique_so_spec_for_frontmatter_is_well_defined`.
+pub fn spec_for_frontmatter(frontmatter: &str) -> Option<&'static DocTypeSpec> {
+    DOC_TYPES
+        .iter()
+        .find(|spec| spec.frontmatter == frontmatter)
 }
 
 /// Looks up a doc type by its numbered-series directory name — the reverse
@@ -201,5 +227,19 @@ mod tests {
         assert!(spec_for_dir("constitution").is_none());
         assert!(spec_for_dir("issue").is_none());
         assert!(spec_for_dir("").is_none());
+    }
+
+    /// ADR 0027: `spec_for_frontmatter` resolves the first row whose
+    /// `frontmatter` matches, so a duplicate would make that resolution
+    /// non-deterministic. This guards the invariant, not a literal list.
+    #[test]
+    fn frontmatter_values_are_unique_so_spec_for_frontmatter_is_well_defined() {
+        let unique: std::collections::HashSet<&str> =
+            DOC_TYPES.iter().map(|spec| spec.frontmatter).collect();
+        assert_eq!(
+            unique.len(),
+            DOC_TYPES.len(),
+            "DOC_TYPES has duplicate frontmatter values"
+        );
     }
 }


### PR DESCRIPTION
Closes the two follow-ups [ADR 0026](docs/adr/0026-a-single-doctype-registry-replaces-nine-hand-synced-enumerations-and-research-and-constitution-enter-as-rows.md) deferred. They are the same question — what belongs in the `DocTypeSpec` registry — and they answer in opposite directions, which is why [ADR 0027](docs/adr/0027-every-rule-keyed-by-doc-type-becomes-a-registry-field-and-glossary-is-not-a-doc-type.md) settles them together.

## The body-size rule moves in

`check::size::has_size_target` was `matches!(doc_type, "ADR" | "BDR" | "PRD" | "Issue")` — the tenth hand-synced doc-type enumeration, and the only one that fails **open**. Every list ADR 0026 absorbed announced a missing type loudly. This one announced nothing: a new registry row was silently exempt. Its guard test iterated the same literal, so it mirrored the implementation instead of constraining it.

`body_size` is now a **required** field on the row. That is the mechanism, not decoration — a new doc type will not compile until it decides. Verdicts are unchanged; this is a refactor of where the rule lives, not of what it decides.

One consequence worth naming: `has_size_target` keyed on the *frontmatter* value, not the CLI token, so this needed a `spec_for_frontmatter` lookup — which makes the uniqueness of `frontmatter` values across `DOC_TYPES` load-bearing for the first time. It held by accident. It now holds on purpose, with its own fitness function.

## glossary stays out

The obvious move was to make `glossary` a row. Reading the template first says otherwise: it declares `type: Context`, and `Context` is a category with many members — one vocabulary group file among peers, with no number and no fixed path. `Identity` has no variant for that shape. Wiring it does not need a row, it needs a third variant, which is a larger decision. Issue 0018 records it.

The other two unwired templates are not candidates at all: `architecture-index.md` and `context-index.md` declare themselves OKF reserved `index.md` files with no frontmatter.

## What holds it in place

Three tests in `check/size.rs` that look redundant and are not:

- One **registry-iterating fitness function** proves `check::size` reads the table rather than a hardcoded list.
- Two **pinned single-row tests** hold the registry's own verdicts as ground truth.

Neither can do the other's job, and the review round that produced this structure is worth knowing about. The prescribed mutation for the fitness function — flip `RESEARCH.body_size` to `Targeted` — did **not** fail it, and the Coder reported that rather than faking a passing demo. It cannot fail: the test derives each row's expected outcome from the same field being mutated. Its real contract is consumer-conformance, so the mutation belongs on the consumer. Both corrected mutations bite: dropping the `Targeted` guard fails the Exempt branch, always returning `None` fails the Targeted branch.

## Verification

- 862 tests; `cargo fmt`/`clippy`/`make check` green
- `living-docs check docs` → `OK — 56 docs`; `examples/linkly/docs` → `OK — 17 docs`, byte-identical to a pre-change binary built in a throwaway worktree
- Live evidence for the exempt path: `docs/constitution.md` has a 131-line body, over the threshold, and is correctly not flagged

🤖 Co-authored with Claude Code
