### PR TITLE
test(release): give the version gate the negative fixtures it never had

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ LIVING_DOCS_BIN := target/release/living-docs
         install-opencode install-codex install-pi install-all install-pocock \
         project-claude project-opencode project-codex project-pi \
         uninstall uninstall-all check lint test-fixtures test-hooks \
-        test-release-gate version \
+        test-release-gate test-version-gate version \
         cli-dev-image cli-build cli-test cli-fmt cli-clippy build cli-install \
         up down db-up db-psql db-logs db-test
 
@@ -84,7 +84,7 @@ uninstall: ## Remove the global Claude Code install
 uninstall-all: ## Remove the install for every supported harness
 	$(INSTALL) all --uninstall
 
-check: version build test-fixtures test-hooks test-release-gate ## Check version sync, validate install.sh, run Rust tests, living-docs check + mermaid, hook fixtures, release-asset gate fixtures, dry-run harnesses
+check: version build test-fixtures test-hooks test-release-gate test-version-gate ## Check version sync, validate install.sh, run Rust tests, living-docs check + mermaid, hook fixtures, release-asset gate fixtures, version-gate fixtures, dry-run harnesses
 	bash -n install.sh
 	bash -n scripts/check-version.sh
 	bash -n scripts/verify-release-assets.sh
@@ -101,6 +101,9 @@ test-hooks: ## Run the write-gate hook fixtures (ADR 0021)
 
 test-release-gate: ## Run the verify-release-assets.sh fixtures (ADR 0024), stubbed gh
 	./scripts/tests/verify-release-assets/run.sh
+
+test-version-gate: ## Run the check-version.sh fixtures, synthetic repos
+	./scripts/tests/check-version/run.sh
 
 version: ## Assert the release version is consistent across VERSION and every SKILL.md
 	./scripts/check-version.sh

--- a/scripts/check-version.sh
+++ b/scripts/check-version.sh
@@ -26,6 +26,30 @@ check() { # check <label> <actual>
 	fi
 }
 
+# Detection is deliberately looser than extraction: a file must be caught as "declares a
+# version" even when its key is malformed (e.g. a stray space before the colon), so that
+# case fails loudly below instead of extraction's strict anchor silently missing it and the
+# file being read as if it declared no version at all.
+check_versioned_class() { # check_versioned_class <required|optional> <file>...
+	local requirement="$1"
+	shift
+	local f rel v
+	for f in "$@"; do
+		rel="${f#"$root"/}"
+		if ! grep -qE '^[[:space:]]*version[[:space:]]*:' "$f"; then
+			[[ "$requirement" == required ]] && check "$rel" ""
+			continue
+		fi
+		v="$(sed -nE 's/^version:[[:space:]]*"?([^"]+)"?.*/\1/p' "$f" | head -1)"
+		if [[ -z "$v" ]]; then
+			printf 'MALFORMED: %-40s declares a version key not in canonical form (expected: version: X)\n' "$rel"
+			fail=1
+			continue
+		fi
+		check "$rel" "$v"
+	done
+}
+
 check "VERSION" "$file_ver"
 
 skill_mds=("$root"/skills/*/SKILL.md)
@@ -33,40 +57,25 @@ if [[ ! -e "${skill_mds[0]}" ]]; then
 	echo "ERROR: no skills/*/SKILL.md files found" >&2
 	exit 1
 fi
-for skill_md in "${skill_mds[@]}"; do
-	v="$(grep -E '^version:' "$skill_md" | head -1 | sed -E 's/^version:[[:space:]]*"?([^"]+)"?.*/\1/')"
-	check "${skill_md#"$root"/}" "$v"
-done
+check_versioned_class required "${skill_mds[@]}"
 
 plugin_json="$root/.claude-plugin/plugin.json"
 plugin_v="$(grep -E '"version":' "$plugin_json" | head -1 | sed -E 's/.*"version":[[:space:]]*"([^"]+)".*/\1/')"
 check ".claude-plugin/plugin.json" "$plugin_v"
 
-# Files under .github/instructions/ may legitimately carry no `version:` line
-# (e.g. an applyTo-only frontmatter block) — those are skipped, not gated.
 instruction_mds=("$root"/.github/instructions/*.md)
 if [[ ! -e "${instruction_mds[0]}" ]]; then
 	echo "ERROR: no .github/instructions/*.md files found" >&2
 	exit 1
 fi
-for instruction_md in "${instruction_mds[@]}"; do
-	grep -qE '^version:' "$instruction_md" || continue
-	v="$(grep -E '^version:' "$instruction_md" | head -1 | sed -E 's/^version:[[:space:]]*"?([^"]+)"?.*/\1/')"
-	check "${instruction_md#"$root"/}" "$v"
-done
+check_versioned_class optional "${instruction_mds[@]}"
 
-# Files under .cursor/rules/ may legitimately carry no `version:` line
-# (e.g. an applyTo-only frontmatter block) — those are skipped, not gated.
 cursor_rule_mdcs=("$root"/.cursor/rules/*.mdc)
 if [[ ! -e "${cursor_rule_mdcs[0]}" ]]; then
 	echo "ERROR: no .cursor/rules/*.mdc files found" >&2
 	exit 1
 fi
-for cursor_rule_mdc in "${cursor_rule_mdcs[@]}"; do
-	grep -qE '^version:' "$cursor_rule_mdc" || continue
-	v="$(grep -E '^version:' "$cursor_rule_mdc" | head -1 | sed -E 's/^version:[[:space:]]*"?([^"]+)"?.*/\1/')"
-	check "${cursor_rule_mdc#"$root"/}" "$v"
-done
+check_versioned_class optional "${cursor_rule_mdcs[@]}"
 
 if [[ "$fail" -ne 0 ]]; then
 	echo "Version check FAILED."

--- a/scripts/tests/check-version/run.sh
+++ b/scripts/tests/check-version/run.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+#
+# run.sh — fixture tests for scripts/check-version.sh.
+#
+# check-version.sh derives its `root` from its own location (dirname "$0"/..), so each case
+# builds a synthetic repo under mktemp -d and runs a COPY of the real script from
+# $TMP/<case>/scripts/check-version.sh against that synthetic tree. No network access.
+#
+# Exit: 0 = all cases pass, 1 = at least one failed.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_SRC="$HERE/../../check-version.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail=0
+
+write_frontmatter() { # write_frontmatter <file> <version-line-or-empty>
+  local file="$1" line="$2"
+  mkdir -p "$(dirname "$file")"
+  {
+    echo "---"
+    echo "title: fixture"
+    [[ -n "$line" ]] && echo "$line"
+    echo "---"
+    echo "# fixture"
+  } >"$file"
+}
+
+write_plugin() { # write_plugin <dir> <version>
+  cat >"$1/.claude-plugin/plugin.json" <<JSON
+{
+  "name": "fixture",
+  "version": "$2"
+}
+JSON
+}
+
+set_all_versions() { # set_all_versions <dir> <version>
+  local dir="$1" version="$2"
+  printf '%s' "$version" >"$dir/VERSION"
+  write_frontmatter "$dir/skills/foo/SKILL.md" "version: \"$version\""
+  write_plugin "$dir" "$version"
+  write_frontmatter "$dir/.github/instructions/foo.md" "version: \"$version\""
+  write_frontmatter "$dir/.cursor/rules/foo.mdc" "version: \"$version\""
+}
+
+new_repo() { # new_repo <name> -> prints the path to a consistent baseline repo at 0.9.0
+  local dir="$TMP/$1"
+  mkdir -p "$dir/scripts" "$dir/skills/foo" "$dir/.claude-plugin" \
+    "$dir/.github/instructions" "$dir/.cursor/rules"
+  cp "$SCRIPT_SRC" "$dir/scripts/check-version.sh"
+  chmod +x "$dir/scripts/check-version.sh"
+  set_all_versions "$dir" "0.9.0"
+  printf '%s' "$dir"
+}
+
+invoke() { # invoke <repo-dir> [args...]
+  local dir="$1"
+  shift
+  OUT="$("$dir/scripts/check-version.sh" "$@" 2>&1)"
+  RC=$?
+}
+
+check() { # check <name> <ok:0|1>
+  if [[ "$2" == 1 ]]; then
+    printf '  ok    %s\n' "$1"
+  else
+    printf '  FAIL  %s\n' "$1"
+    printf '        exit=%s\n%s\n' "$RC" "$OUT" | sed 's/^/        out | /'
+    fail=1
+  fi
+}
+
+assert_exit() { # assert_exit <name> <expected>
+  local ok=0
+  [[ "$RC" == "$2" ]] && ok=1
+  check "$1" "$ok"
+}
+
+assert_out_has() { # assert_out_has <name> <substring>
+  local ok=0
+  grep -qF -- "$2" <<<"$OUT" && ok=1
+  check "$1" "$ok"
+}
+
+assert_out_count() { # assert_out_count <name> <substring> <expected-count>
+  local ok=0 actual
+  actual="$(grep -cF -- "$2" <<<"$OUT")"
+  [[ "$actual" == "$3" ]] && ok=1
+  check "$1" "$ok"
+}
+
+echo "check-version fixtures"
+echo
+
+echo "case 1: fully consistent tree"
+repo="$(new_repo case1)"
+invoke "$repo"
+assert_exit    "1-exit-0"      0
+assert_out_has "1-version-ok"  "Version OK"
+
+echo "case 2: a skills/*/SKILL.md drifted"
+repo="$(new_repo case2)"
+write_frontmatter "$repo/skills/foo/SKILL.md" 'version: "0.0.1"'
+invoke "$repo"
+assert_exit    "2-exit-1"     1
+assert_out_has "2-names-file" "skills/foo/SKILL.md"
+
+echo "case 3: .claude-plugin/plugin.json drifted"
+repo="$(new_repo case3)"
+write_plugin "$repo" "0.0.1"
+invoke "$repo"
+assert_exit    "3-exit-1"     1
+assert_out_has "3-names-file" ".claude-plugin/plugin.json"
+
+echo "case 4: a .github/instructions/*.md drifted"
+repo="$(new_repo case4)"
+write_frontmatter "$repo/.github/instructions/foo.md" 'version: "0.0.1"'
+invoke "$repo"
+assert_exit    "4-exit-1"     1
+assert_out_has "4-names-file" ".github/instructions/foo.md"
+
+echo "case 5: a .cursor/rules/*.mdc drifted"
+repo="$(new_repo case5)"
+write_frontmatter "$repo/.cursor/rules/foo.mdc" 'version: "0.0.1"'
+invoke "$repo"
+assert_exit    "5-exit-1"     1
+assert_out_has "5-names-file" ".cursor/rules/foo.mdc"
+
+echo "case 6: regression — .cursor/rules/*.mdc with a space before the colon"
+repo="$(new_repo case6)"
+write_frontmatter "$repo/.cursor/rules/foo.mdc" 'version : "0.0.1"'
+invoke "$repo"
+assert_exit    "6-exit-1"        1
+assert_out_has "6-malformed"     "MALFORMED"
+assert_out_has "6-names-file"    ".cursor/rules/foo.mdc"
+
+echo "case 7: same malformed form in .github/instructions and skills/*/SKILL.md, both reported"
+repo="$(new_repo case7)"
+write_frontmatter "$repo/.github/instructions/foo.md" 'version : "0.0.1"'
+write_frontmatter "$repo/skills/foo/SKILL.md" 'version : "0.0.1"'
+invoke "$repo"
+assert_exit     "7-exit-1"           1
+assert_out_has  "7-names-instruction" ".github/instructions/foo.md"
+assert_out_has  "7-names-skill"       "skills/foo/SKILL.md"
+assert_out_count "7-both-reported"    "MALFORMED" 2
+
+echo "case 8: .github/instructions/*.md with no version key at all — legitimately skipped"
+repo="$(new_repo case8)"
+write_frontmatter "$repo/.github/instructions/foo.md" ""
+invoke "$repo"
+assert_exit    "8-exit-0"     0
+assert_out_has "8-version-ok" "Version OK"
+
+echo "case 9: skills/*/SKILL.md with no version key at all — required, so it fails"
+repo="$(new_repo case9)"
+write_frontmatter "$repo/skills/foo/SKILL.md" ""
+invoke "$repo"
+assert_exit "9-exit-1" 1
+
+echo "case 10: explicit tag argument, matching tree"
+repo="$(new_repo case10a)"
+set_all_versions "$repo" "1.2.3"
+invoke "$repo" v1.2.3
+assert_exit    "10a-exit-0"     0
+assert_out_has "10a-version-ok" "Version OK: 1.2.3"
+
+echo "case 10: explicit tag argument, mismatched tree"
+repo="$(new_repo case10b)"
+invoke "$repo" v1.2.3
+assert_exit "10b-exit-1" 1
+
+echo "case 11: empty glob for a required class"
+repo="$(new_repo case11)"
+rm -rf "${repo:?}/skills"
+invoke "$repo"
+assert_exit    "11-exit-1"    1
+assert_out_has "11-error"     "ERROR: no skills/*/SKILL.md files found"
+
+echo
+if ((fail == 0)); then
+  echo "All check-version fixtures passed."
+  exit 0
+else
+  echo "check-version fixture failures."
+  exit 1
+fi


### PR DESCRIPTION
`scripts/check-version.sh` was repaired three times in the last week, each repair adding a file class the previous one had missed. This PR fixes the reason that kept happening.

## The gate had never been seen to fail

`make check` ran `bash -n` on it plus one invocation against the real repository tree. That tree is internally consistent by construction, so the gate never failed — every previous "fix" was verified only by the gate continuing to pass, which it would have done either way. Its sibling `verify-release-assets.sh` has had a full fixture suite since ADR 0024. This one had none.

The fixtures are the deliverable. The hole below is one case in them.

## The hole

Detection and extraction shared the anchor `^version:`:

```bash
grep -qE '^version:' "$file" || continue          # detection
grep -E '^version:' "$file" | sed -E '...'        # extraction
```

A file declaring `version : "0.9.0"` — a space before the colon, still valid YAML, read as `0.9.0` by every real consumer — does not match. The gate concluded "declares no version" and **skipped it**. It failed open on precisely the malformed input it exists to shout about.

Detection is now deliberately looser than extraction (`^[[:space:]]*version[[:space:]]*:`), and anything detected-but-not-strictly-extractable is a hard error naming the file and the canonical form. Never a silent skip.

## Why the loops were deduplicated

That fix had to land in three file classes, and those three classes were three copy-pasted loops — the same triplication behind both earlier misses. They collapse into one `check_versioned_class <required|optional> <file>...`. `plugin.json` stays a separate direct check because it is JSON, not YAML frontmatter, and routing it through the helper would make the helper worse.

This is deduplication that is load-bearing for the fix, not cleanup riding along: adding a fifth file class is now one call instead of a fourth loop to forget.

## The suite

Eleven cases, each building a synthetic repo under `mktemp` and running a copy of the real script — faithful because `root` derives from `$0`, so no test-only flag was added to production. Coverage: consistency, drift in each of the four gated classes, the malformed-key regression in all three YAML classes, both no-version cases (optional skips, required fails), the explicit-tag release path in both directions, and the empty-glob guard.

Case 7 puts a malformed key in two files at once and asserts both are reported — one malformed file must not hide the next.

Wired into `make check` as `test-version-gate`, alongside `test-release-gate`.

## Verification

- 11/11 fixture cases green; `shellcheck` and `bash -n` clean on both scripts; `make check` exit 0
- Real tree unchanged: `./scripts/check-version.sh` → `Version OK: 0.9.0`
- Mutation-proven against the real repo: rewriting a `.cursor/rules/*.mdc` version line with a stray space now fails with `MALFORMED: ...`, where the pre-change script exited 0

Known small weakness, left deliberately: fixture case 9 asserts an exit code without an output assertion. Case 1 makes an unrelated crash implausible, but it is the softest assertion in the suite.

🤖 Co-authored with Claude Code
