### PR TITLE
chore(ci): bump actions/checkout v4 -> v5 to drop the node 20 deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Version consistency (VERSION ↔ every SKILL.md)
         run: ./scripts/check-version.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -75,7 +75,7 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # aarch64-unknown-linux-gnu cross-compiles from an x86_64 runner and needs a
       # matching cross linker; the other three targets build natively on their runner.
@@ -117,7 +117,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Verify every expected release asset is published and checksum-valid
         env:


### PR DESCRIPTION
## Summary

The `main` CI run (`21b1d72`) passed but emitted a GitHub Actions deprecation: `actions/checkout@v4` targets Node.js 20, which the runner now force-runs on Node.js 24. This bumps all four `actions/checkout@v4` occurrences (`ci.yml` ×1, `release.yml` ×3) to `@v5`, which targets Node 24 natively — clearing the warning with no behavior change.

## Changes
- `.github/workflows/ci.yml` — `actions/checkout@v4` → `@v5`.
- `.github/workflows/release.yml` — three `actions/checkout@v4` → `@v5`.

## Test plan
- [x] `grep -rn 'actions/checkout@' .github/workflows/` — all four read `@v5`, none remain `@v4`.
- [x] Both workflow files parse as valid YAML; diff is the version tags only (4 insertions / 4 deletions).
- [ ] CI green on this branch (the workflow change is exercised by this PR's own run).

## Notes
- Out of scope: `dtolnay/rust-toolchain@1.96.0` and `softprops/action-gh-release@v2` were not flagged by the deprecation and stay pinned.
- Living Docs tracks issues under `docs/`, not GitHub Issues — no closing keyword applies.
