### PR TITLE
fix: quote fts5 query tokens and derive project slug from repo dir name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,24 @@ The tool never writes rationale prose, never chooses a doc's epistemic type, nev
 which alternative wins. Those belong to the authoring model. Everything the tool does must
 be reproducible from its inputs.
 
+### 5. Responsibility split + file-size ratchet (issue 0028)
+
+Maintainability is a gate, not an advisory. Layout rules for all Rust code:
+
+- **One responsibility per module.** `cli/src/main.rs` holds only clap wiring and
+  dispatch; every verb lives in `cli/src/commands/<verb>.rs`. New verbs are BORN in
+  their own module — never added to `main.rs`.
+- **Hard cap: 30 lines per function.** Enforced by clippy `too_many_lines`
+  (`clippy.toml` threshold 30, `-D warnings` in CI). This is the primary clarity
+  instrument — Clean Code's limit is about functions, not files.
+- **Hard cap: 300 lines per `.rs` file** (sibling `tests.rs` has its own 300 cap).
+  Enforced by `scripts/check-file-size.sh` (ratchet: a grandfathered file may only
+  shrink; growing one fails the check).
+- **Sibling test files.** A `#[cfg(test)]` module over ~100 lines moves to
+  `<module>/tests.rs` via `mod tests;` — private access preserved, production file clean.
+- Deep modules still win over many shallow files (rule 2): split by responsibility,
+  never by line-count alone — the file cap is the backstop, not the design driver.
+
 ## Architecture
 
 Target shape is a **modular monolith** (start here; split into crates only when a real

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -255,8 +255,10 @@ enum DbCmd {
     /// one named project (ADR 0005, issue 0005 slice 0005-B).
     Sync {
         /// The project slug to sync into. Defaults to a slug derived from
-        /// `--docs-dir`'s own directory name, keeping single-project usage
-        /// working without naming a project explicitly.
+        /// `--docs-dir`: its own directory name, or its parent directory's
+        /// name when the final component is literally `docs` — so every
+        /// repo's `<repo>/docs` bundle gets a project unique to that repo
+        /// instead of every repo colliding on the literal word `docs`.
         #[arg(long)]
         project: Option<String>,
     },
@@ -747,17 +749,39 @@ async fn sync_read_model(
 
 const DEFAULT_PROJECT_SLUG: &str = "default";
 
-/// Derives a stable project slug from `docs_dir`'s own final path
-/// component when `--project` is omitted, so repeated syncs of the same
-/// bundle land in the same project. Falls back to `"default"` when
-/// `docs_dir` has no usable final component (e.g. `.` or `/`).
+/// Derives a stable project slug from `docs_dir` when `--project` is
+/// omitted, so repeated syncs of the same bundle land in the same project.
+/// The final path component names the project, UNLESS it is literally
+/// `docs` and a parent directory exists — then the parent directory's name
+/// is used instead, so every repo's `<repo>/docs` bundle gets a slug unique
+/// to that repo rather than every repo colliding on the literal word
+/// `docs` (issue 0026). Falls back to `"default"` when no usable component
+/// is derivable (e.g. `.` or `/`).
 fn derive_project_slug(docs_dir: &Path) -> String {
-    docs_dir
-        .file_name()
-        .and_then(|name| name.to_str())
+    let canonical = docs_dir
+        .canonicalize()
+        .unwrap_or_else(|_| docs_dir.to_path_buf());
+    project_slug_component(&canonical)
         .map(paths::slugify)
         .filter(|slug| !slug.is_empty())
         .unwrap_or_else(|| DEFAULT_PROJECT_SLUG.to_owned())
+}
+
+/// The path component `derive_project_slug` should slugify: the parent
+/// directory's name when `path`'s final component is literally `docs` and
+/// a parent name exists, otherwise `path`'s own final component.
+fn project_slug_component(path: &Path) -> Option<&str> {
+    let final_name = path.file_name()?.to_str()?;
+    if final_name == "docs" {
+        if let Some(parent_name) = path
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(|n| n.to_str())
+        {
+            return Some(parent_name);
+        }
+    }
+    Some(final_name)
 }
 
 fn run_search(query: &str, engine: Engine, project: Option<String>) -> ExitCode {
@@ -943,12 +967,25 @@ mod tests {
     }
 
     #[test]
-    fn derive_project_slug_uses_the_docs_dir_final_component() {
-        assert_eq!(derive_project_slug(Path::new("/repo/docs")), "docs");
+    fn derive_project_slug_uses_the_parent_directory_name_when_the_final_component_is_docs() {
+        assert_eq!(
+            derive_project_slug(Path::new("/repo-name/docs")),
+            "repo-name"
+        );
+        assert_eq!(derive_project_slug(Path::new("/repo/docs")), "repo");
+    }
+
+    #[test]
+    fn derive_project_slug_keeps_the_final_component_when_it_is_not_literally_docs() {
         assert_eq!(
             derive_project_slug(Path::new("/repo/client-docs")),
             "client-docs"
         );
+    }
+
+    #[test]
+    fn derive_project_slug_keeps_docs_when_it_has_no_parent_directory() {
+        assert_eq!(derive_project_slug(Path::new("/docs")), "docs");
     }
 
     #[test]

--- a/cli/tests/search.rs
+++ b/cli/tests/search.rs
@@ -190,3 +190,76 @@ fn db_sync_defaults_to_paradedb_and_requires_database_url_when_none_is_set() {
     let _ = fs::remove_dir_all(&docs);
     let _ = fs::remove_dir_all(&cwd);
 }
+
+#[test]
+fn db_sync_then_search_with_a_hyphenated_query_finds_the_seeded_record_instead_of_erroring() {
+    let docs = temp_dir("docs-hyphen");
+    let cwd = temp_dir("cwd-hyphen");
+    write_record(
+        &docs,
+        "adr",
+        "0001-bi-temporal.md",
+        "Bi-Temporal Edge Tracking",
+        "Adopt a bi-temporal model for the edge cache.",
+        "The bi-temporal edge model tracks both valid time and system time.",
+    );
+
+    let sync_output = run(&cwd, &docs, &["--engine", "sqlite", "db", "sync"]);
+    assert!(
+        sync_output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&sync_output.stderr)
+    );
+
+    let hit_output = run(
+        &cwd,
+        &docs,
+        &["--engine", "sqlite", "search", "bi-temporal edge"],
+    );
+    assert!(
+        hit_output.status.success(),
+        "a hyphenated query must not error, stderr: {}",
+        String::from_utf8_lossy(&hit_output.stderr)
+    );
+    let hit_stdout = String::from_utf8_lossy(&hit_output.stdout);
+    assert!(
+        hit_stdout.contains("Bi-Temporal Edge Tracking"),
+        "got: {hit_stdout}"
+    );
+
+    let _ = fs::remove_dir_all(&docs);
+    let _ = fs::remove_dir_all(&cwd);
+}
+
+#[test]
+fn db_sync_derives_the_project_slug_from_the_repo_directory_when_docs_dir_is_named_docs() {
+    let repo_root = temp_dir("repo-for-slug");
+    let docs = repo_root.join("docs");
+    fs::create_dir_all(&docs).unwrap();
+    let cwd = temp_dir("cwd-repo-slug");
+    write_record(
+        &docs,
+        "adr",
+        "0001-only.md",
+        "Only Decision",
+        "The only seeded record.",
+        "Body text.",
+    );
+    let expected_project_slug = repo_root.file_name().unwrap().to_str().unwrap();
+
+    let sync_output = run(&cwd, &docs, &["--engine", "sqlite", "db", "sync"]);
+
+    assert!(
+        sync_output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&sync_output.stderr)
+    );
+    let sync_stdout = String::from_utf8_lossy(&sync_output.stdout);
+    assert!(
+        sync_stdout.contains(&format!("(project: {expected_project_slug})")),
+        "expected the repo directory name as the project slug, got: {sync_stdout}"
+    );
+
+    let _ = fs::remove_dir_all(&repo_root);
+    let _ = fs::remove_dir_all(&cwd);
+}

--- a/db-store/src/search.rs
+++ b/db-store/src/search.rs
@@ -76,20 +76,36 @@ async fn sqlite_search(
                 JOIN records r ON r.id = records_fts.rowid \
                 JOIN projects p ON p.id = r.project_id \
                 WHERE records_fts MATCH ?1 AND r.deleted_at IS NULL";
+    let match_query = fts5_quote(query);
     let statement = match scope {
         Some(slug) => Statement::from_sql_and_values(
             conn.get_database_backend(),
             format!("{base} AND p.slug = ?2 ORDER BY rank"),
-            [query.into(), slug.into()],
+            [match_query.into(), slug.into()],
         ),
         None => Statement::from_sql_and_values(
             conn.get_database_backend(),
             format!("{base} ORDER BY rank"),
-            [query.into()],
+            [match_query.into()],
         ),
     };
 
     SearchRow::find_by_statement(statement).all(conn).await
+}
+
+/// Neutralizes FTS5 query syntax in a user-supplied search string: splits
+/// `query` on whitespace, doubles any `"` inside each token per FTS5's own
+/// escaping rule, and wraps every token in double quotes so it binds as a
+/// literal phrase rather than a column filter, boolean operator, or
+/// NOT-prefix (issue 0026 — a hyphenated term like `bi-temporal` otherwise
+/// aborts the query). An all-whitespace or empty `query` returns an empty
+/// string, matching `MATCH ""`'s existing no-op behavior.
+fn fts5_quote(query: &str) -> String {
+    query
+        .split_whitespace()
+        .map(|token| format!("\"{}\"", token.replace('"', "\"\"")))
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 async fn postgres_search(
@@ -132,7 +148,7 @@ fn unsupported_backend_err() -> DbErr {
 mod tests {
     use super::*;
     use crate::sync::sync;
-    use crate::sync::test_support::seeded_corpus;
+    use crate::sync::test_support::{seeded_corpus, single_record_corpus_at};
     use crate::{connect_in_memory, migrate};
 
     #[tokio::test]
@@ -160,5 +176,41 @@ mod tests {
         let hits = search(&conn, "zzzznomatch").await.expect("search");
 
         assert!(hits.is_empty());
+    }
+
+    #[tokio::test]
+    async fn search_with_a_hyphenated_term_matches_instead_of_erroring() {
+        let conn = connect_in_memory().await.expect("connect");
+        migrate(&conn).await.expect("migrate");
+        let (store, bundle) = single_record_corpus_at("/bundle", "Bi-Temporal Edge Tracking");
+        sync(&conn, &store, &bundle).await.expect("sync");
+
+        let hits = search(&conn, "bi-temporal edge")
+            .await
+            .expect("a hyphenated query must not raise an FTS5 syntax error");
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].title, "Bi-Temporal Edge Tracking");
+    }
+
+    #[tokio::test]
+    async fn search_with_operator_laden_queries_matches_only_literal_terms() {
+        let conn = connect_in_memory().await.expect("connect");
+        migrate(&conn).await.expect("migrate");
+        let (store, bundle) = seeded_corpus();
+        sync(&conn, &store, &bundle).await.expect("sync");
+
+        for injection_shaped_query in ["foo OR bar", "title:x", "unmatched \" quote", "-"] {
+            let hits = search(&conn, injection_shaped_query)
+                .await
+                .unwrap_or_else(|err| {
+                    panic!("query {injection_shaped_query:?} must not raise a syntax error: {err}")
+                });
+
+            assert!(
+                hits.is_empty(),
+                "query {injection_shaped_query:?} must match no seeded record, got: {hits:?}"
+            );
+        }
     }
 }

--- a/docs/adr/0031-the-knowledge-graph-is-a-typed-bi-temporal-edge-set-in-the-existing-relational-store.md
+++ b/docs/adr/0031-the-knowledge-graph-is-a-typed-bi-temporal-edge-set-in-the-existing-relational-store.md
@@ -1,0 +1,56 @@
+---
+type: ADR
+title: The knowledge graph is a typed bi-temporal edge set in the existing relational store
+description: The knowledge graph is typed bi-temporal edges widening the existing relations table in SQLite/ParadeDB — no graph engine, no probabilistic layer; queries are depth-bounded recursive CTEs.
+status: Proposed
+timestamp: 2026-08-05T20:18:36Z
+---
+
+# 0031. The knowledge graph is a typed bi-temporal edge set in the existing relational store
+
+## Context
+
+The handoff that motivated [research 0003](/research/0003-provenance-aware-knowledge-graph-for-living-docs.md) proposed a knowledge graph with lineage between records and code, backed by a graph database (Neo4j was named) and a probabilistic inference layer (ProbLog) for confidence and impact scores. The research refuted both components and confirmed the graph itself. Three forces bound the decision. First, the determinism boundary (ADR 0001): no LLM and no heuristic inference inside the tool. Second, the db-store already holds the substrate — a `relations` table (today only `kind="supersede"`), records with `status`/`revision`/`deleted_at`, and FTS5 — so the graph is an evolution of an existing projection, not a new system. Third, the embedded graph-engine field collapsed in 2025 (Kuzu archived, CozoDB abandoned, IndraDB dormant, Neo4j JVM-only), while SQLite recursive CTEs carry two orders of magnitude of headroom at this scale.
+
+## Decision
+
+We will model the knowledge graph as a typed, bi-temporal edge set inside the existing relational store, in both engines (SQLite and ParadeDB). Concretely:
+
+- **Nodes** are what already exists: records (and, in a later ADR, code symbols). No new node store.
+- **Edges** live in the widened `relations` table. `kind` becomes a typed vocabulary (`supersedes`, `references`, `blocked_by`, `motivated_by`, plus doc-code kinds when ADR 0032 lands). Body markdown links between records — today validated by `check` and thrown away — are persisted as `references` edges at sync time.
+- **Temporality** follows the SQL:2011 four-column pattern on each edge: `valid_from`/`valid_to` (event timeline — when the relation held true) and `system_from`/`system_to` (transaction timeline — when the store learned it). Supersede sets `valid_to` on the displaced edge; nothing is deleted. This is Graphiti's invalidation rule stripped of its LLM front-end: pure interval logic.
+- **Queries** (`why`, `impact`, `as-of`) are depth-bounded recursive CTEs in the domain layer of `living-docs-core`, executed by db-store. Unbounded path enumeration is out.
+- **Confidence and impact are deterministic**: status enums, graph reachability, and (if ever wanted) exponential recency decay computed at query time. There is no stored score.
+
+Rejected alternatives: a dedicated graph engine (dependency risk without payoff at this scale; every embedded candidate is dead or license-encumbered) and a probabilistic-logic layer (no peer provenance system — W3C PROV, OpenLineage, Graphiti — uses one; ProbLog is Python-only with #P-complete exact inference; a stored probability would also smuggle non-reproducible judgment past the determinism boundary).
+
+## Consequences
+
+**Easier / gained:**
+- Graph queries arrive as a schema migration plus CTEs — no new infrastructure, one deployable, both backends.
+- Full history survives by construction: `as-of` reads reconstruct what the doc graph asserted at any past commit or date.
+- The edge vocabulary gives `check` new deterministic invariants (dangling `blocked_by`, contradiction between `supersedes` edge and status).
+
+**Harder / accepted trade-offs:**
+- Bi-temporal columns complicate every edge write: sync must close intervals instead of overwriting rows.
+- Typed kinds require a registry-driven vocabulary (ADR 0026 pattern) — a hand-synced enum would regress lesson 3973.
+- CTE queries live in SQL, not a graph DSL; complex traversals stay verbose.
+
+**Follow-ups:**
+- ADR 0032 decides how doc-code edges are declared and anchored.
+- Frontmatter tail keys that reference records (`blocked_by: [NNNN]`) get promoted from EAV storage to resolved edges at sync time.
+
+## Verification
+
+**Implementation impact:** `db-store/src/migration.rs`, `db-store/src/sync.rs`, `living-docs-core` (edge kind vocabulary + query domain), `cli` (query verbs).
+
+**Verification criteria:**
+- Syncing a bundle twice produces byte-identical edge sets (idempotence, extends the ADR 0001 fitness family).
+- `living-docs supersede` closes the displaced edge's `valid_to` and never deletes a row; an `as-of` query dated before the supersede still returns the old edge.
+- Edge kinds come from one registry row set; a test fails when a kind literal appears outside the registry.
+
+# References
+
+[1] [Research 0003 — provenance-aware knowledge graph for living-docs](/research/0003-provenance-aware-knowledge-graph-for-living-docs.md)
+[2] [XTDB — Time in XTDB (SQL:2011 bitemporal pattern)](https://docs.xtdb.com/about/time-in-xtdb.html)
+[3] [Zep: A Temporal Knowledge Graph Architecture for Agent Memory](https://arxiv.org/abs/2501.13956)

--- a/docs/adr/0032-doc-code-lineage-is-declared-not-inferred.md
+++ b/docs/adr/0032-doc-code-lineage-is-declared-not-inferred.md
@@ -1,0 +1,56 @@
+---
+type: ADR
+title: Doc-code lineage is declared, not inferred
+description: Every doc-code lineage fact is a declared event (trailer, covers glob, FQN anchor, explicit rename re-declaration) — the tool never infers links heuristically; staleness fails loud at the gate.
+status: Proposed
+timestamp: 2026-08-05T20:18:36Z
+---
+
+# 0032. Doc-code lineage is declared, not inferred
+
+## Context
+
+[Research 0003](/research/0003-provenance-aware-knowledge-graph-for-living-docs.md) established three field facts. Plain-text code references in docs rot silently in most projects, and the decay driver is rename/move/deprecation refactoring. Automated (IR/ML) link recovery is not good enough to substitute for curated links, and human vetting degrades the best machine-generated link sets. In the field, links that were never created (47% of release artifacts) outnumber links that broke (12%) — creation friction is the larger enemy. Every shipped system that re-anchors positions after change (GitHub review comments, Gerrit ported comments, Swimm auto-sync) does it heuristically and accepts decay. [Issue 0024](/issues/0024-doc-code-pairing-for-living-docs-commit-trailers-covers-based-drift-detection-and-executable-acceptance.md) already specifies the layered pairing design (commit trailers, `covers:` globs, executable acceptance). What it leaves open is the identity model: what a doc-code link points AT, and who resolves change.
+
+## Decision
+
+We will treat every doc-code lineage fact as a **declared event**, never an inference, and anchor links to **position-independent identities**:
+
+- **Commit trailers (`Living-Doc: NNNN`, issue 0024 Layer 1) are the episode stream.** Each linked commit is a provenance episode in the ADR 0031 graph: a `implemented_by` edge from record to commit, `system_from` = sync time, `valid_from` = commit time.
+- **Anchors point at identities, not positions.** Path-level anchors are `covers:` globs (issue 0024 Layer 2). Symbol-level anchors, when a record needs finer grain, are fully-qualified-name monikers in the SCIP style — no file line, no byte offset, resolved against a tree-sitter index at check time.
+- **Renames are declared, not guessed.** When a covered path or anchored symbol is renamed, the link is re-bound by an explicit CLI event (`living-docs covers`/anchor re-declaration in the same commit), which closes the old edge's `valid_to` and opens a new edge. The tool never runs similarity heuristics to chase a moved symbol; that judgment belongs to the authoring model or the human, outside the determinism boundary.
+- **Staleness is a loud, deterministic verdict.** `drift`/`verify` fail when an anchor no longer resolves or a covered path changed without a trailer. An unresolved anchor is an error to fix in the commit that caused it — never a score to decay silently.
+
+Rejected alternative: heuristic auto-re-binding inside the tool (Swimm's model). It trades loud breakage for silent approximation — the exact failure mode the field data shows developers miss.
+
+## Consequences
+
+**Easier / gained:**
+- Lineage queries ("why does this module exist", "which code implements ADR N") become graph traversals over declared edges with commit-grade provenance.
+- Anchors survive every edit that does not rename the anchored identity; renames fail fast at the gate in the commit that caused them.
+- Zero new friction beyond issue 0024: the trailer and glob mechanics are unchanged; this ADR fixes their identity semantics and graph representation.
+
+**Harder / accepted trade-offs:**
+- Rename ergonomics depend on the gate: a rename without re-declaration blocks at `drift`, and the author pays the re-binding cost at that moment.
+- Symbol-level anchors need a tree-sitter identity source; until one ships, records anchor at path granularity only.
+- No benchmark exists for ADR-to-code traceability; the design is validated by dogfooding telemetry, not literature.
+
+**Follow-ups:**
+- Issue 0024 Layers 1-2 implement the event stream and path anchors; a future issue specifies the symbol-anchor index.
+- Record rename-frequency telemetry to measure real anchor half-life before tuning anything.
+
+## Verification
+
+**Implementation impact:** `cli` (`commits`/`verify`/`reconcile`/`drift` verbs), `living-docs-core` (anchor + trailer domain), `db-store/src/sync.rs` (edge materialization from trailers).
+
+**Verification criteria:**
+- A commit with a `Living-Doc: NNNN` trailer materializes exactly one `implemented_by` edge on next sync; re-sync is idempotent.
+- Renaming a covered path without re-declaration makes `drift` exit non-zero; the same rename plus a re-declaration in the same commit passes and closes/opens edges bi-temporally.
+- No code path in the tool computes similarity between an old and a new anchor target (fitness: grep-level assertion that no fuzzy-match dependency enters the workspace).
+
+# References
+
+[1] [Research 0003 — provenance-aware knowledge graph for living-docs](/research/0003-provenance-aware-knowledge-graph-for-living-docs.md)
+[2] [Issue 0024 — doc-code pairing](/issues/0024-doc-code-pairing-for-living-docs-commit-trailers-covers-based-drift-detection-and-executable-acceptance.md)
+[3] [SCIP protobuf schema — position-independent symbol grammar](https://github.com/sourcegraph/scip/blob/main/scip.proto)
+[4] [TAN, W.; WAGNER, S.; TREUDE, C. Detecting Outdated Code Element References in Software Repository Documentation](https://arxiv.org/abs/2212.01479)

--- a/docs/adr/0033-new-consumers-are-fronts-in-the-workspace-never-new-repos-until-a-deploy-cadence-or-ownership-trigger-fires.md
+++ b/docs/adr/0033-new-consumers-are-fronts-in-the-workspace-never-new-repos-until-a-deploy-cadence-or-ownership-trigger-fires.md
@@ -1,0 +1,46 @@
+---
+type: ADR
+title: New consumers are fronts in the workspace, never new repos, until a deploy-cadence or ownership trigger fires
+description: Every new consumer (API, MCP, frontend) is a front inside the Cargo workspace over living-docs-core; crates.io publication serves external consumers; a repo split waits for a deploy-cadence or ownership trigger.
+status: Proposed
+timestamp: 2026-08-05T20:33:40Z
+---
+
+# 0033. New consumers are fronts in the workspace, never new repos, until a deploy-cadence or ownership trigger fires
+
+## Context
+
+The knowledge-graph direction (ADRs 0031/0032) raised the question of splitting `cli`, `core`, `db-store`, and a future graph module into separate repositories, motivated by future consumers: an HTTP API, a frontend, MCP servers. The re-deliberation confirmed what ADR 0002 locked, with sharper reasons. New consumers need stable interfaces, not repo boundaries: an API server and an MCP server are fronts over `living-docs-core`, exactly the shape `web` already has; a frontend consumes the HTTP API, not the Rust code; external Rust consumers consume published crates. The direct precedent is Graphiti itself — core, server, and MCP server ship from one repository. The local scar argues the same way: taming nine version-declaration sites took three release rounds inside ONE repo (lessons 3987/3988/4091); multiple repos multiply that class of bug plus semver coordination and split CI. A separate "graph core" would also reopen what ADR 0031 settled: the graph is a projection of the same records, not a system.
+
+## Decision
+
+We will add every new consumer as a front inside the existing Cargo workspace (`mcp` is the first candidate, alongside `cli` and `web`). When external consumption demands stable versioned artifacts, we will publish `living-docs-core` (and adapters as needed) to crates.io from the monorepo rather than extract repositories. A repository split is reconsidered only when a named trigger fires: a front needs an independent deploy cadence, or a component gains separate ownership. A frontend in a non-Rust toolchain may live outside the workspace; its boundary is the HTTP API.
+
+## Consequences
+
+**Easier / gained:**
+- Domain changes stay atomic: one PR crosses core, adapters, and every front; no cross-repo semver dance.
+- New fronts inherit the release train, CI, and the version gate (`check-version.sh`) instead of re-growing them.
+- The hexagonal ports remain the extraction seam, so a future split stays cheap precisely because it is not exercised early.
+
+**Harder / accepted trade-offs:**
+- One release train: a front cannot ship on its own cadence without firing the trigger and revisiting this ADR.
+- The workspace grows; build times and the version-site count grow with each front (each new front's version site must enter `check-version.sh` on day one).
+
+**Follow-ups:**
+- Issue 0027 specifies the MCP front.
+- Publishing `living-docs-core` to crates.io gets its own decision when the first external consumer is real, not before.
+
+## Verification
+
+**Implementation impact:** workspace `Cargo.toml` members; `scripts/check-version.sh` when a front is added.
+
+**Verification criteria:**
+- Every front in the workspace depends on `living-docs-core` and never on another front (dependency-direction check).
+- A new front's version declaration site is covered by `check-version.sh` in the same PR that adds the front.
+
+# References
+
+[1] [ADR 0002 — hexagonal core, Cargo workspace](/adr/0002-hexagonal-core-workspace.md)
+[2] [Research 0003 — provenance-aware knowledge graph for living-docs](/research/0003-provenance-aware-knowledge-graph-for-living-docs.md)
+[3] [getzep/graphiti — core, server, and MCP server in one repository](https://github.com/getzep/graphiti)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -36,6 +36,9 @@ repo teaches. The decision *log* is this listing plus each record's `status` /
 * [0028 — The release binary is the unit of distribution: install.sh only bootstraps it and every placement becomes a CLI verb](0028-the-release-binary-is-the-unit-of-distribution-install-sh-only-bootstraps-it-and-every-placement-becomes-a-cli-verb.md) - Accepted
 * [0029 — The status vocabulary is per doc type, sourced from one DocTypeSpec field -- not one global list validated against every template's own dialect](0029-the-status-vocabulary-is-per-doc-type-sourced-from-one-doctypespec-field-not-one-global-list-validated-against-every-template-s-own-dialect.md) - Accepted
 * [0030 — Uniform brace markers for body placeholders](0030-uniform-brace-markers-for-body-placeholders.md) - Proposed
+* [0031 — The knowledge graph is a typed bi-temporal edge set in the existing relational store](0031-the-knowledge-graph-is-a-typed-bi-temporal-edge-set-in-the-existing-relational-store.md) - Proposed
+* [0032 — Doc-code lineage is declared, not inferred](0032-doc-code-lineage-is-declared-not-inferred.md) - Proposed
+* [0033 — New consumers are fronts in the workspace, never new repos, until a deploy-cadence or ownership trigger fires](0033-new-consumers-are-fronts-in-the-workspace-never-new-repos-until-a-deploy-cadence-or-ownership-trigger-fires.md) - Proposed
 
 ## Superseded
 

--- a/docs/issues/0025-describe-and-status-resolve-record-numbers-ambiguously-across-doc-type-directories.md
+++ b/docs/issues/0025-describe-and-status-resolve-record-numbers-ambiguously-across-doc-type-directories.md
@@ -1,0 +1,33 @@
+---
+type: Issue
+title: describe and status resolve record numbers ambiguously across doc-type directories
+description: Bare record numbers are only unique per directory, so describe/status silently mutate the first registry match — add a type-qualified reference and fail on ambiguity. Cannot self-describe via CLI precisely because 0025 collides with ADR 0025.
+status: open
+timestamp: 2026-08-05T20:18:36Z
+---
+
+<!-- Status lives in frontmatter (`status`), not a body line. Settable values are
+     exactly open | in-progress | closed. `living-docs supersede` sets Superseded on
+     this issue -- never set it by hand -- when a later issue replaces it. Everything
+     BELOW the closing `---` is the issue body and MUST stay byte-identical to the
+     published tracker body — strip the frontmatter when publishing. -->
+
+## describe and status resolve record numbers ambiguously across doc-type directories
+
+`living-docs describe <NNNN>` (and by shared record-resolution, `status`) resolves a bare number against the doc-type registry in order and stops at the first match. Numbers are only unique per directory, so a number that exists in more than one directory silently mutates the wrong record. Observed in practice on 2026-08-05: `living-docs describe 0003 "<research description>"` overwrote the description of ADR 0003 (`docs/adr/0003-storage-backend-model.md`) when the intended target was research 0003. The write succeeded silently; only `git diff` revealed the wrong target.
+
+### Scope
+
+- Accept a type-qualified record reference on every number-resolving verb (`describe`, `status`, `supersede`, future `covers`/`commits`): a type token prefix such as `research/0003` or `adr 0003` — exact grammar to be decided with the fix, reusing the registry's `token` field.
+- When a bare number matches records in more than one directory, fail with the candidate list instead of picking the first match. A bare number that matches exactly one directory keeps working unchanged.
+- KEPT: single-directory resolution behavior, the shared record-resolution helper (one fix covers all verbs), and the CLI-owned frontmatter contract.
+
+### Acceptance
+
+- With a number present in two directories, the bare-number form exits non-zero and lists both candidates; no file is modified.
+- The type-qualified form mutates exactly the record in the named directory, demonstrated by a test fixture with colliding numbers across `adr/` and `research/`.
+- A bare number unique to one directory resolves exactly as today (regression fixture).
+
+### Plan
+
+Single slice: extend the shared record-resolution helper with an optional type token + ambiguity detection, update `describe`/`status`/`supersede` argument parsing, add the colliding-number fixtures.

--- a/docs/issues/0026-corpus-import-seed-the-knowledge-graph-read-model-from-real-repos-to-make-graph-slices-demoable-from-day-one.md
+++ b/docs/issues/0026-corpus-import-seed-the-knowledge-graph-read-model-from-real-repos-to-make-graph-slices-demoable-from-day-one.md
@@ -1,0 +1,41 @@
+---
+type: Issue
+title: "Corpus import: seed the knowledge graph read-model from real repos to make graph slices demoable from day one"
+description: Sync real repos into one read-model (multi-project sync exists; verify it) and add a deterministic `import` verb for non-conformant bundles, so every knowledge-graph slice demos against a real corpus instead of fixtures.
+status: open
+timestamp: 2026-08-05T20:25:27Z
+---
+
+<!-- Status lives in frontmatter (`status`), not a body line. Settable values are
+     exactly open | in-progress | closed. `living-docs supersede` sets Superseded on
+     this issue -- never set it by hand -- when a later issue replaces it. Everything
+     BELOW the closing `---` is the issue body and MUST stay byte-identical to the
+     published tracker body — strip the frontmatter when publishing. -->
+
+## Corpus import: seed the knowledge graph read-model from real repos to make graph slices demoable from day one
+
+The knowledge-graph work ([ADR 0031](/adr/0031-the-knowledge-graph-is-a-typed-bi-temporal-edge-set-in-the-existing-relational-store.md), [ADR 0032](/adr/0032-doc-code-lineage-is-declared-not-inferred.md)) needs real data before its first query verb lands: an edge model validated only against fixtures proves conformance, not usefulness. Multi-project sync already exists (`db sync --docs-dir <path> --project <slug>`, ADR 0005), so a conformant bundle can enter a shared read-model today. What is missing is (a) a verified multi-repo corpus workflow, (b) a deterministic import path for repos whose docs are NOT living-docs-conformant, and (c) making that corpus the standing demo target for every graph slice. This also feeds the calibration-pending items of [issue 0024](/issues/0024-doc-code-pairing-for-living-docs-commit-trailers-covers-based-drift-detection-and-executable-acceptance.md) with real usage data.
+
+Part of [PRD 0001](/prd/0001-living-docs-atlas-multi-project-authoring-wiki-over-living-docs-core.md) (multi-project read-model); feeds ADR 0031/0032.
+
+### Scope
+
+- **Conformant repos (verify, fix, document):** `db sync --project <slug> --engine sqlite` for N repos into one `.living-docs/index.db`; cross-project `search` returns hits with project attribution; `relations` rows stay project-scoped. Whatever breaks under real multi-repo usage gets fixed here.
+- **Non-conformant repos (new, deterministic):** `living-docs import <src-dir> --type <token> --project <slug>` maps foreign docs into records by mechanical rules only: filename `NNNN-slug` gives number and slug; first `#` heading gives title (filename stem as fallback); existing frontmatter keys map when they match; everything unmappable lands in the EAV tail; imported records carry a CLI-owned `imported: true` marker. The USER names the doc type per directory — the tool never classifies a document (determinism boundary, ADR 0001). The import ends with a report: N mapped, M skipped, each skip with its reason.
+- **Corpus as demo harness:** a documented smoke flow (script or make target) that syncs the chosen repos and runs the current demo query set; every future graph slice (edge widening, `why`/`impact`/`as-of`, trailers) demos against this corpus, not against fixtures.
+- KEPT: the authoring contract and `check` strictness for native bundles — import relaxes MAPPING, never invariants; a synced conformant bundle passes the same checks as today.
+- Out of scope: LLM-assisted classification or content rewriting of imported docs (authoring-model work, ADR 0001); write-back to the source repos (import is read-only toward the source); code-symbol nodes (later slice per ADR 0032).
+
+### Acceptance
+
+- Two or more real repos sync into one SQLite read-model; `living-docs search` returns cross-project hits attributed to the right project slug.
+- Importing a non-conformant docs directory produces records with correct number/title/type from mechanical rules alone, an `imported: true` marker, and a mapping report listing every skipped file with a reason; re-import is idempotent.
+- Supersede relations present in imported conformant bundles appear as `relations` rows scoped to their project.
+- The demo smoke flow runs end-to-end from a clean checkout: sync all corpus repos, execute the demo queries, exit zero.
+- A native bundle synced through this path passes `check` unchanged (no invariant relaxation leaks).
+
+### Plan
+
+1. Corpus smoke: pick 2-3 real repos (this repo + at least one downstream consumer), verify multi-project sync + cross-project search, fix what breaks, document the flow. Two defects already observed in the first single-repo smoke (2026-08-05): a hyphenated query (`bi-temporal`) aborts `search --engine sqlite` with an FTS5 syntax error (`no such column: temporal`) — user queries need sanitizing or quoting before they reach MATCH; and the default project slug derives from the docs dir name (every repo becomes project `docs`) — the default should derive from the repo directory name, or multi-repo corpora will collide on the first sync without `--project`.
+2. `import` verb for one non-conformant repo with the mechanical mapping + report; idempotence test.
+3. Wire the corpus into the graph slices' demo ACs (each ADR 0031/0032 slice demos against the corpus from this point on).

--- a/docs/issues/0027-mcp-front-expose-living-docs-core-verbs-as-mcp-tools.md
+++ b/docs/issues/0027-mcp-front-expose-living-docs-core-verbs-as-mcp-tools.md
@@ -1,0 +1,36 @@
+---
+type: Issue
+title: "MCP front: expose living-docs core verbs as MCP tools"
+description: A read-only MCP server crate in the workspace exposing search/show/list and, as they land, the graph verbs — agents consume the read-model through typed tools instead of parsing markdown.
+status: open
+timestamp: 2026-08-05T20:33:40Z
+---
+
+<!-- Status lives in frontmatter (`status`), not a body line. Settable values are
+     exactly open | in-progress | closed. `living-docs supersede` sets Superseded on
+     this issue -- never set it by hand -- when a later issue replaces it. Everything
+     BELOW the closing `---` is the issue body and MUST stay byte-identical to the
+     published tracker body — strip the frontmatter when publishing. -->
+
+## MCP front: expose living-docs core verbs as MCP tools
+
+Agents are first-class consumers of living docs, and today they consume them by shelling out to the CLI or parsing markdown. An MCP server front makes the read-model and the knowledge graph directly consumable by any MCP-capable agent, with typed tools instead of ad-hoc parsing. Implements [ADR 0033](/adr/0033-new-consumers-are-fronts-in-the-workspace-never-new-repos-until-a-deploy-cadence-or-ownership-trigger-fires.md) (fronts in the workspace); consumes the graph verbs of [ADR 0031](/adr/0031-the-knowledge-graph-is-a-typed-bi-temporal-edge-set-in-the-existing-relational-store.md) as they land. Precedent: Graphiti ships its MCP server from the same repository as its core.
+
+### Scope
+
+- New workspace member `mcp`: an MCP server (stdio transport first) that depends on `living-docs-core` and the db-store read-model, never on `cli` or `web`.
+- Initial read-only tool set mapping existing verbs: `search`, `show` (record by type+number), `list` (by type/status), plus graph verbs (`why`, `impact`, `as-of`) as ADR 0031 slices deliver them.
+- Version site registered in `check-version.sh` in the same PR that creates the crate (ADR 0033 verification criterion).
+- KEPT: the CLI as the authoring surface — the MCP front is read-only in its first iteration; authoring tools (new/status/supersede) are a later decision with the same optimistic-concurrency rules as ADR 0016.
+- Out of scope: HTTP/SSE transport; authoring tools; any LLM-side logic (the server serves data, the consuming agent judges).
+
+### Acceptance
+
+- An MCP client lists the tools and gets typed schemas; `search` over a synced corpus returns the same hits as `living-docs search` for the same query.
+- `show` returns a record's frontmatter fields and body for a type+number reference, without number-collision ambiguity (depends on issue 0025's qualified reference).
+- The crate builds in the workspace, depends only on core + db-store, and its version site fails `check-version.sh` when out of sync (fitness).
+
+### Plan
+
+1. Crate skeleton + stdio MCP server + `search`/`show`/`list` over the existing read-model.
+2. Graph tools (`why`/`impact`/`as-of`) as ADR 0031 query verbs land — same slice adds them to both `cli` and `mcp`.

--- a/docs/issues/0028-responsibility-split-one-verb-per-module-sibling-test-files-and-a-hard-file-size-ratchet-enforced-by-a-deterministic-check.md
+++ b/docs/issues/0028-responsibility-split-one-verb-per-module-sibling-test-files-and-a-hard-file-size-ratchet-enforced-by-a-deterministic-check.md
@@ -1,0 +1,45 @@
+---
+type: Issue
+title: "Responsibility split: one verb per module, sibling test files, and a hard file-size ratchet enforced by a deterministic check"
+description: Mechanical responsibility split (verb-per-module in cli, phase modules in db-store sync, sibling test files) plus a 400-line hard cap enforced by a ratcheting check-file-size.sh — maintainability becomes a gate, not an advisory.
+status: open
+timestamp: 2026-08-05T20:49:48Z
+---
+
+<!-- Status lives in frontmatter (`status`), not a body line. Settable values are
+     exactly open | in-progress | closed. `living-docs supersede` sets Superseded on
+     this issue -- never set it by hand -- when a later issue replaces it. Everything
+     BELOW the closing `---` is the issue body and MUST stay byte-identical to the
+     published tracker body — strip the frontmatter when publishing. -->
+
+## Responsibility split: one verb per module, sibling test files, and a hard file-size ratchet enforced by a deterministic check
+
+The three largest source files concentrate most of the codebase's reading cost: `db-store/src/sync.rs` (1,157 lines), `cli/src/main.rs` (1,085 — every verb, clap wiring, and inline tests in one file), `db-store/src/migration.rs` (706). The `check/` modules (150-400 lines each) show the readable shape the rest should have. The maintainer wants maintainability and code comprehension protected as a HARD rule, not an advisory — the codebase is growing (graph slices, `import`, MCP front are all queued). A constraint without an instrument is a vibe: this issue ships the rule AND its deterministic check. No new crates: modules and folders first (ADR 0002/0033 seams stay as they are); a crate split waits for a real seam.
+
+### Scope
+
+- **Layout rules (become CLAUDE.md hard rule 5):**
+  - `cli/src/main.rs` holds only clap wiring and dispatch; every verb lives in `cli/src/commands/<verb>.rs`.
+  - `db-store/src/sync.rs` splits by phase (`sync/records.rs`, `sync/relations.rs`, `sync/tags.rs`, orchestrator in `sync/mod.rs`).
+  - A `#[cfg(test)]` module over ~100 lines moves to a sibling file via `mod tests;` (keeps private access, cleans the production file).
+  - Hard cap: 30 lines per FUNCTION — the primary clarity instrument (Clean Code's limit targets functions, not files).
+  - Hard cap: 300 lines per `.rs` file (counted without the sibling `tests.rs`, which has its own 300 cap).
+- **The instruments:** (a) clippy `too_many_lines` with `clippy.toml` threshold 30, promoted to deny in CI, for the function cap (grandfathered oversized functions get targeted `#[allow(clippy::too_many_lines)]` with a shrinking inventory); (b) `scripts/check-file-size.sh` (wired into CI next to `check-version.sh`): fails when any `.rs` file exceeds 300 lines, with an explicit grandfather list that may only SHRINK (ratchet — a grandfathered file that grows fails the check; a file that drops under the cap leaves the list permanently).
+- **Behavior freeze:** this is a mechanical move refactor. The full test suite (922 tests) is the characterization harness: green before, green after, no test semantics changed. Public CLI behavior byte-identical.
+- KEPT: crate boundaries (core / fs-store / db-store / cli / web); the deep-module philosophy — one module per responsibility, not many shallow files; `migration.rs` may stay grandfathered if its shape resists a clean phase split (schema-per-table split is allowed, not required, this pass).
+- Out of scope: any behavior change, rename of public items, new crates, `living-docs-core/check/*` (already conformant).
+
+### Acceptance
+
+- `cli/src/main.rs` is under 150 lines and contains no verb logic; every verb compiles from `cli/src/commands/`.
+- `db-store/src/sync.rs` is replaced by a `sync/` module tree; each file under 300 lines.
+- `scripts/check-file-size.sh` exits non-zero when a non-grandfathered `.rs` file exceeds 300 lines or a grandfathered file grows; exits zero on the post-refactor tree; runs in CI.
+- `cargo clippy` runs with `too_many_lines` at threshold 30 denied in CI; every `#[allow(clippy::too_many_lines)]` carries an inventory entry that only shrinks.
+- `cargo test --workspace` passes with the same test count (adaptations limited to `use` paths and `mod` declarations); `cargo fmt --check` and clippy stay clean.
+- CLAUDE.md carries the layout rules as hard rule 5, pointing at the check as its instrument.
+
+### Plan
+
+1. R1 — `cli` split: verbs to `cli/src/commands/`, test mods to sibling files, `main.rs` reduced to wiring.
+2. R2 — `db-store` split: `sync/` phase modules; migration split only if clean.
+3. R3 — `scripts/check-file-size.sh` + grandfather list + CI wiring + CLAUDE.md hard rule 5.

--- a/docs/issues/index.md
+++ b/docs/issues/index.md
@@ -22,6 +22,10 @@ one slice per fresh context, starting from the skeleton.
 * [0022 — Template placeholders are fragile for programmatic editing](0022-template-placeholders-are-fragile-for-programmatic-editing.md) - Proposed
 * [0023 — next reports 0001 for issue because run_next passes the CLI token straight through instead of resolving its directory](0023-next-reports-0001-for-issue-because-run-next-passes-the-cli-token-straight-through-instead-of-resolving-its-directory.md) - Proposed
 * [0024 — Doc-code pairing for living-docs: commit trailers, covers-based drift detection, and executable acceptance](0024-doc-code-pairing-for-living-docs-commit-trailers-covers-based-drift-detection-and-executable-acceptance.md) - open
+* [0025 — describe and status resolve record numbers ambiguously across doc-type directories](0025-describe-and-status-resolve-record-numbers-ambiguously-across-doc-type-directories.md) - open
+* [0026 — Corpus import: seed the knowledge graph read-model from real repos to make graph slices demoable from day one](0026-corpus-import-seed-the-knowledge-graph-read-model-from-real-repos-to-make-graph-slices-demoable-from-day-one.md) - open
+* [0027 — MCP front: expose living-docs core verbs as MCP tools](0027-mcp-front-expose-living-docs-core-verbs-as-mcp-tools.md) - open
+* [0028 — Responsibility split: one verb per module, sibling test files, and a hard file-size ratchet enforced by a deterministic check](0028-responsibility-split-one-verb-per-module-sibling-test-files-and-a-hard-file-size-ratchet-enforced-by-a-deterministic-check.md) - open
 
 ## Closed
 

--- a/docs/research/0003-provenance-aware-knowledge-graph-for-living-docs.md
+++ b/docs/research/0003-provenance-aware-knowledge-graph-for-living-docs.md
@@ -1,0 +1,110 @@
+---
+type: Research
+title: Provenance-aware knowledge graph for living-docs
+description: "Evidence for evolving living-docs into a provenance-aware doc-code knowledge graph: what transfers from Graphiti without an LLM, which storage serves it, and whether ProbLog earns its complexity."
+status: Draft
+timestamp: 2026-08-05T20:09:05Z
+---
+
+# 0003. Provenance-aware knowledge graph for living-docs
+
+## Question
+
+Can living-docs evolve into a provenance-aware knowledge graph that links records to code symbols, with Graphiti-style bi-temporality, while it keeps the determinism boundary of [ADR 0001](/adr/0001-living-docs-cli.md)? Do the components proposed in the incoming handoff — a dedicated graph database (Neo4j) and a probabilistic inference layer (ProbLog) — earn their complexity?
+
+## Method
+
+Falsify-mode deep research, evidence gathered on 2026-08-05. The working hypothesis: living-docs gains doc-code lineage by promoting its implicit edges (supersede, frontmatter refs, body links) to a first-class graph in the existing relational store, and by adopting Graphiti's bi-temporal edge-invalidation model without its LLM extraction layer; a ProbLog layer does not pay its cost at this scale.
+
+Six parallel search angles ran refute-first against four named falsifiers, plus one exploration of the living-docs codebase (workspace at v0.10.1). Sources followed the priority ladder: primary papers and source code first, official specs and vendor docs second, practitioner reports third. Load-bearing claims were cross-checked across at least two independent sources where such sources exist. Roughly 60 sources were reviewed; the ones cited below carried the verdicts.
+
+Falsifier verdicts:
+
+- **F1 — "Graphiti's bi-temporal value is inseparable from LLM extraction": REFUTED.** The invalidation state machine (`resolve_edge_contradictions`) is pure datetime-interval logic with zero LLM calls [5]; `add_triplet` accepts pre-structured input and skips extraction [6]; timestamp extraction is skipped when dates are pre-set [5]. LLMs serve only as the parser for unstructured prose.
+- **F2 — "Relational storage cannot serve the traversals": REFUTED at this scale.** Documented breakdown thresholds sit two orders of magnitude above the living-docs workload [22][29]. Caveat: keep traversals depth-bounded; unbounded path enumeration over dense graphs degrades combinatorially [22].
+- **F3 — "Deterministic doc-code anchors rot faster than they help": UNRESOLVED, leaning refuted.** No tier-1 study directly compares checked anchors against ML recovery under refactoring; the benchmark does not exist [21]. Indirect evidence favors checked anchors: the decay driver is refactoring, which structural detection handles [17]; checked anchors turn silent rot into loud breakage, the failure mode developers actually miss [15]; ML recovery is not a viable fallback [14].
+- **F4 — "A probabilistic layer is load-bearing": REFUTED.** No comparable provenance system uses probabilistic inference [33][35][1]; production systems that need graded weighting use deterministic exponential decay [36]; ProbLog is Python-only, Beta, with #P-complete exact inference [30][31]; Scallop has a Rust core but is a v0.2 research prototype [32].
+
+Known limits of this run: two academic searches (Phelps & Wilensky robust locations; LHDiff) were blocked by search-safety filters, so the annotation-anchoring literature thread is under-evidenced; all F1 evidence originates from Zep (paper plus repo), mitigated by reading the source code directly rather than trusting prose claims.
+
+## Findings
+
+| Finding | Evidence | Confidence |
+|---|---|---|
+| Graphiti's bi-temporal engine is deterministic: four timestamps per edge (`created_at`/`expired_at` on the system timeline, `valid_at`/`invalid_at` on the event timeline) and interval-logic invalidation; LLMs only parse unstructured input | [1][2][4][5][6] | high |
+| At living-docs scale (~10^3 nodes, ~10^4 edges), SQLite recursive CTEs traverse with two orders of magnitude of headroom; graph-extension layers (Apache AGE) benchmark slower than hand-written CTEs | [22][23][29] | high |
+| Every embedded graph engine is a dependency risk as of late 2025: Kuzu archived after the Apple acquisition, CozoDB abandoned, IndraDB dormant, Neo4j JVM-only, SurrealDB BSL-licensed; Graphiti itself deprecated its only embedded backend | [24][25][26][28][3] | high |
+| Bi-temporal modeling reduces to the SQL:2011 four-column pattern (`valid_from`/`valid_to`, `system_from`/`system_to`) with AS OF queries, implementable in plain SQLite — XTDB is the prior art | [27] | high |
+| Plain-text code references in docs rot silently in most projects; the decay driver is rename/move/deprecation refactoring; structural refactoring-aware link evolution beats re-running IR recovery; automated recovery is "not sufficiently good" for high-assurance use | [15][16][17][14] | high |
+| Maintained, trustworthy trace links pay: developers were 24% faster and 50% more correct in the one strong controlled experiment (n=71) | [13][43] | medium |
+| Position-independent symbol identity is proven practice: SCIP symbols are FQN strings with no positional component; stack-graphs bind names deterministically per file from tree-sitter; rename/move resilience is heuristic in every shipped system — no tool maintains a declared cross-commit identity | [7][8][9][10][12] | high |
+| No comparable provenance system uses probabilistic inference: W3C PROV-DM models validity as deterministic events with no confidence attribute; OpenLineage is deterministic run events; Graphiti uses recency-wins invalidation; graded weighting in production is exponential decay | [33][34][35][1][36] | high |
+| Market gap: no tool combines decision-record lifecycle, AST-identity doc-code anchors, and deterministic staleness verdicts — Swimm is snippet-level and heuristic, ADR tooling has zero code links, Glean/potpie treat docs as generation targets or RAG context | [37][38][39][40] | medium |
+| In OSS, missing trace links (47% of release artifacts) dominate broken links (12%): non-creation, not decay, is the larger failure mode — anchor-creation friction must be near zero | [20] | medium |
+| The graph substrate already exists in this repo: db-store has a `relations` table (today only `kind="supersede"`), records carry `status`/`revision`/`deleted_at`, FTS5 is in place; body links are validated by `check` but never persisted as edges | living-docs v0.10.1 source: `db-store/src/migration.rs`, `db-store/src/sync.rs:313-347`, `living-docs-core/src/check/links.rs` | high |
+
+Contradicting evidence recorded: Swimm's commercial success rests on heuristic anchor re-binding [37], which argues that heuristics have value — the resolution is placement, not rejection: heuristic re-binding belongs to the authoring model outside the tool, while the tool fails loudly. Human vetting of machine-generated links degrades high-quality matrices [18], so "add a human in the loop" is not a free correctness upgrade.
+
+## Implications
+
+This evidence supports: promoting the existing `relations` table to a typed, bi-temporal edge set (SQL:2011 four-column pattern) inside the current SQLite/Postgres db-store; anchoring records to code via SCIP-style position-independent symbol identifiers; treating renames as declared lineage events recorded at refactor time, not guessed; making the doc-gate emit deterministic staleness verdicts (loud breakage over silent rot); and expressing any graded "confidence" as status enums plus optional recency decay computed at query time.
+
+This evidence rules out: adopting Neo4j or any embedded graph engine (dependency risk without payoff at this scale); a ProbLog/probabilistic-logic inference layer (no peer-system precedent, no Rust path, #P-complete); and heuristic anchor re-binding inside the tool (belongs to the authoring model per the determinism boundary).
+
+This repo already holds a compatible design: [issue 0024](/issues/0024-doc-code-pairing-for-living-docs-commit-trailers-covers-based-drift-detection-and-executable-acceptance.md) specifies commit trailers, `covers:`-glob drift detection, and executable acceptance. The evidence here maps onto it directly — trailers are declared lineage events (Graphiti's episode pattern), `drift` is the loud-breakage staleness verdict, and the additions this research motivates are symbol-level (FQN) anchors as a finer grain than path globs, plus the bi-temporal edge model over the existing `relations` table.
+
+The decisions themselves belong to ADRs that this note feeds; it makes none of them.
+
+## Open Questions
+
+- No benchmark or dataset exists for ADR-to-code traceability [21]; early telemetry from dogfooding is the only evidence substitute for the staleness-verdict design.
+- The half-life of FQN anchors under real refactoring is unmeasured; instrument it before tuning any decay weights.
+- Whether graded confidence scoring is wanted at all, versus plain status + reachability — no surveyed system needed it.
+- How doc-code edges surface in the web front (read-only projection vs. authoring) is untouched by this research.
+- The academic robust-anchoring thread (Phelps & Wilensky; LHDiff) remains unread due to blocked searches.
+
+# References
+
+[1] [RASMUSSEN, P. et al. Zep: A Temporal Knowledge Graph Architecture for Agent Memory. arXiv, 2025](https://arxiv.org/abs/2501.13956). Available at: https://arxiv.org/abs/2501.13956. Accessed on: 2026-08-05.
+[2] [Zep paper, HTML full text v1](https://arxiv.org/html/2501.13956v1). Available at: https://arxiv.org/html/2501.13956v1. Accessed on: 2026-08-05.
+[3] [GETZEP. graphiti README. GitHub, 2026](https://github.com/getzep/graphiti). Available at: https://github.com/getzep/graphiti. Accessed on: 2026-08-05.
+[4] [GETZEP. graphiti_core/edges.py](https://github.com/getzep/graphiti/blob/main/graphiti_core/edges.py). Available at: https://github.com/getzep/graphiti/blob/main/graphiti_core/edges.py. Accessed on: 2026-08-05.
+[5] [GETZEP. graphiti_core/utils/maintenance/edge_operations.py](https://github.com/getzep/graphiti/blob/main/graphiti_core/utils/maintenance/edge_operations.py). Available at: https://github.com/getzep/graphiti/blob/main/graphiti_core/utils/maintenance/edge_operations.py. Accessed on: 2026-08-05.
+[6] [GETZEP. graphiti_core/graphiti.py (add_triplet)](https://github.com/getzep/graphiti/blob/main/graphiti_core/graphiti.py). Available at: https://github.com/getzep/graphiti/blob/main/graphiti_core/graphiti.py. Accessed on: 2026-08-05.
+[7] [SOURCEGRAPH. SCIP protobuf schema (scip.proto)](https://github.com/sourcegraph/scip/blob/main/scip.proto). Available at: https://github.com/sourcegraph/scip/blob/main/scip.proto. Accessed on: 2026-08-05.
+[8] [SOURCEGRAPH. Announcing SCIP. 2022](https://sourcegraph.com/blog/announcing-scip). Available at: https://sourcegraph.com/blog/announcing-scip. Accessed on: 2026-08-05.
+[9] [GITHUB. Introducing stack graphs. 2021](https://github.blog/open-source/introducing-stack-graphs/). Available at: https://github.blog/open-source/introducing-stack-graphs/. Accessed on: 2026-08-05.
+[10] [GIT. git-blame documentation (-M/-C move detection)](https://git-scm.com/docs/git-blame). Available at: https://git-scm.com/docs/git-blame. Accessed on: 2026-08-05.
+[11] [GERRIT. REST API — ported_comments](https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html). Available at: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html. Accessed on: 2026-08-05.
+[12] [GRUND, F.; DUALA-EKOKO, E. et al. CodeShovel: Unearthing Method Histories. ICSE, 2021](https://github.com/ataraxie/codeshovel). Available at: https://github.com/ataraxie/codeshovel. Accessed on: 2026-08-05.
+[13] [MÄDER, P.; EGYED, A. Do developers benefit from requirements traceability? Empirical Software Engineering, 2015](https://link.springer.com/article/10.1007/s10664-014-9314-z). Available at: https://link.springer.com/article/10.1007/s10664-014-9314-z. Accessed on: 2026-08-05.
+[14] [GUO, J.; STEGHÖFER, J.-P.; VOGELSANG, A.; CLELAND-HUANG, J. Natural Language Processing for Requirements Traceability. arXiv, 2024](https://arxiv.org/abs/2405.10845). Available at: https://arxiv.org/abs/2405.10845. Accessed on: 2026-08-05.
+[15] [TAN, W.; WAGNER, S.; TREUDE, C. Detecting Outdated Code Element References in Software Repository Documentation. arXiv, 2022](https://arxiv.org/abs/2212.01479). Available at: https://arxiv.org/abs/2212.01479. Accessed on: 2026-08-05.
+[16] [WEN, F. et al. A Large-Scale Empirical Study on Code-Comment Inconsistencies. ICPC, 2019](https://dl.acm.org/doi/abs/10.1109/ICPC.2019.00019). Available at: https://dl.acm.org/doi/abs/10.1109/ICPC.2019.00019. Accessed on: 2026-08-05.
+[17] [RAHIMI, M.; CLELAND-HUANG, J. Evolving software trace links between requirements and source code. Empirical Software Engineering, 2018](https://link.springer.com/article/10.1007/s10664-017-9561-x). Available at: https://link.springer.com/article/10.1007/s10664-017-9561-x. Accessed on: 2026-08-05.
+[18] [NIU, N. et al. Gray Links in the Use of Requirements Traceability. FSE, 2016](https://homepages.uc.edu/~niunn/papers/FSE16.pdf). Available at: https://homepages.uc.edu/~niunn/papers/FSE16.pdf. Accessed on: 2026-08-05.
+[19] [BUCHGEHER, G. et al. Using Architecture Decision Records in Open Source Projects. IEEE Access, 2023](https://ieeexplore.ieee.org/document/10155430/). Available at: https://ieeexplore.ieee.org/document/10155430/. Accessed on: 2026-08-05.
+[20] [Establishing Traceability between Release Notes & Software Artifacts: Practitioners' Perspectives. arXiv, 2025](https://arxiv.org/abs/2511.18187). Available at: https://arxiv.org/abs/2511.18187. Accessed on: 2026-08-05.
+[21] [KIT SDQ. Trace Link Recovery for Architecture Decision Records](https://sdq.kastel.kit.edu/wiki/Trace_Link_Recovery_for_Architecture_Decision_Records_(ADRs)). Available at: https://sdq.kastel.kit.edu/wiki/Trace_Link_Recovery_for_Architecture_Decision_Records_(ADRs). Accessed on: 2026-08-05.
+[22] [SQLITE. The WITH Clause — Queries Against A Graph](https://sqlite.org/lang_with.html). Available at: https://sqlite.org/lang_with.html. Accessed on: 2026-08-05.
+[23] [PAPATHANASIOU, D. simple-graph: a graph database in SQLite](https://github.com/dpapathanasiou/simple-graph). Available at: https://github.com/dpapathanasiou/simple-graph. Accessed on: 2026-08-05.
+[24] [THE REGISTER. KuzuDB graph database abandoned, community mulls options. 2025](https://www.theregister.com/software/2025/10/14/kuzudb-graph-database-abandoned-community-mulls-options/). Available at: https://www.theregister.com/software/2025/10/14/kuzudb-graph-database-abandoned-community-mulls-options/. Accessed on: 2026-08-05.
+[25] [DBDB.IO. CozoDB entry (abandoned since 2024)](https://dbdb.io/db/cozodb). Available at: https://dbdb.io/db/cozodb. Accessed on: 2026-08-05.
+[26] [OXIGRAPH. SPARQL graph database in Rust](https://github.com/oxigraph/oxigraph). Available at: https://github.com/oxigraph/oxigraph. Accessed on: 2026-08-05.
+[27] [XTDB. Time in XTDB — SQL:2011 bitemporal model](https://docs.xtdb.com/about/time-in-xtdb.html). Available at: https://docs.xtdb.com/about/time-in-xtdb.html. Accessed on: 2026-08-05.
+[28] [NEO4J. Using Neo4j embedded in Java applications. v2026.06](https://neo4j.com/docs/java-reference/current/java-embedded/). Available at: https://neo4j.com/docs/java-reference/current/java-embedded/. Accessed on: 2026-08-05.
+[29] [EXOBENCH. How Fast Are Postgres 19 Graph Queries? Part 1. 2026](https://exobench.ai/blog/pg19-graph-queries-part-1). Available at: https://exobench.ai/blog/pg19-graph-queries-part-1. Accessed on: 2026-08-05.
+[30] [PYPI. problog 2.2.10 (Beta). 2026](https://pypi.org/project/problog/). Available at: https://pypi.org/project/problog/. Accessed on: 2026-08-05.
+[31] [KU LEUVEN DTAI. ProbLog — How it works](https://dtai.cs.kuleuven.be/problog/). Available at: https://dtai.cs.kuleuven.be/problog/. Accessed on: 2026-08-05.
+[32] [SCALLOP-LANG. Scallop (Rust core, provenance semirings)](https://github.com/scallop-lang/scallop). Available at: https://github.com/scallop-lang/scallop. Accessed on: 2026-08-05.
+[33] [W3C. PROV-DM: The PROV Data Model. Recommendation, 2013](https://www.w3.org/TR/prov-dm/). Available at: https://www.w3.org/TR/prov-dm/. Accessed on: 2026-08-05.
+[34] [W3C. PROV Overview. 2013](https://www.w3.org/TR/prov-overview/). Available at: https://www.w3.org/TR/prov-overview/. Accessed on: 2026-08-05.
+[35] [OPENLINEAGE. Object Model specification](https://openlineage.io/docs/spec/object-model/). Available at: https://openlineage.io/docs/spec/object-model/. Accessed on: 2026-08-05.
+[36] [MILVUS. Exponential Decay reranker documentation](https://milvus.io/docs/exponential-decay.md). Available at: https://milvus.io/docs/exponential-decay.md. Accessed on: 2026-08-05.
+[37] [SWIMM. How does Swimm's Auto-sync feature work? 2021. [COI: vendor]](https://swimm.io/blog/how-does-swimm-s-auto-sync-feature-work). Available at: https://swimm.io/blog/how-does-swimm-s-auto-sync-feature-work. Accessed on: 2026-08-05.
+[38] [VAILL, T. log4brains — ADR knowledge base](https://github.com/thomvaill/log4brains). Available at: https://github.com/thomvaill/log4brains. Accessed on: 2026-08-05.
+[39] [META. Indexing code at scale with Glean. 2024](https://engineering.fb.com/2024/12/19/developer-tools/glean-open-source-code-indexing/). Available at: https://engineering.fb.com/2024/12/19/developer-tools/glean-open-source-code-indexing/. Accessed on: 2026-08-05.
+[40] [POTPIE-AI. potpie — Context Graph. [COI: vendor]](https://github.com/potpie-ai/potpie). Available at: https://github.com/potpie-ai/potpie. Accessed on: 2026-08-05.
+[41] [BARBERO, M. Understanding Software Provenance Attestation: SLSA and in-toto. 2023](https://mikael.barbero.tech/blog/post/2023-12-28-slsa-and-in-toto/). Available at: https://mikael.barbero.tech/blog/post/2023-12-28-slsa-and-in-toto/. Accessed on: 2026-08-05.
+[42] [GITHUB. stack-graphs repository](https://github.com/github/stack-graphs). Available at: https://github.com/github/stack-graphs. Accessed on: 2026-08-05.
+[43] [The Impact of Traceability on Software Maintenance and Evolution: A Mapping Study. arXiv, 2021](https://arxiv.org/abs/2108.02133). Available at: https://arxiv.org/abs/2108.02133. Accessed on: 2026-08-05.

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -6,3 +6,4 @@ spawns implementation slices.
 
 * [0001 — Worldwide PII detection catalog — deterministic regex + checksum reference](0001-worldwide-pii-detection-catalog.md) - Accepted
 * [0002 — Ontology tooling and the code-to-docs bridge — Rust-native options for a living-docs knowledge layer](0002-ontology-tooling-codegraph-docs-bridge.md) - Accepted
+* [0003 — Provenance-aware knowledge graph for living-docs](0003-provenance-aware-knowledge-graph-for-living-docs.md) - Draft


### PR DESCRIPTION
## Summary

Fixes the two defects found in the first corpus smoke (issue 0026, plan step 1), plus the session's docs batch.

**Code (S1a):**
- `fts5_quote`: sqlite `search` now wraps each whitespace-split query token in double quotes before the FTS5 `MATCH` binding. Hyphenated terms (`bi-temporal`) no longer abort with 'no such column'; operator-laden input (`OR`, `title:x`, quotes, lone `-`) matches only literal terms — user input can never alter query semantics.
- `derive_project_slug`: when the docs dir's final component is `docs`, the slug now comes from the repo directory name. Multi-repo corpora no longer collide on the slug `docs`.

**Docs:**
- Research note 0003 (provenance-aware knowledge graph, falsify-mode).
- ADRs 0031 (typed bi-temporal edge set in the relational store), 0032 (doc-code lineage is declared, not inferred), 0033 (new consumers are workspace fronts).
- Issues 0025–0028 (describe/status ambiguity, corpus import, MCP front, responsibility split + file-size ratchet).
- CLAUDE.md hard rule 5: function ≤30 / file ≤300 caps with deterministic instruments.

## Test plan
- `cargo test --workspace`: 922 passed, 35 suites, 0 failures.
- `cargo fmt --check`: clean.
- New tests: hyphenated-query and operator-injection negative tests (db-store), slug derivation branches (cli), 2 sync+search e2e tests.
- `living-docs check` doc-gate green over 73 docs (pre-commit hook).