### PR TITLE
docs: file issue 0030 for the literal sqlite: directory artifact

### DIFF
--- a/docs/issues/0030-db-commands-can-create-a-literal-sqlite-directory-by-treating-the-connection-string-as-a-filesystem-path.md
+++ b/docs/issues/0030-db-commands-can-create-a-literal-sqlite-directory-by-treating-the-connection-string-as-a-filesystem-path.md
@@ -1,0 +1,32 @@
+---
+type: Issue
+title: db commands can create a literal 'sqlite:' directory by treating the connection string as a filesystem path
+description: <One sentence — the change and its motivation.>
+status: open
+timestamp: 2026-08-06T21:03:43Z
+---
+
+<!-- Status lives in frontmatter (`status`), not a body line. Settable values are
+     exactly open | in-progress | closed. `living-docs supersede` sets Superseded on
+     this issue -- never set it by hand -- when a later issue replaces it. Everything
+     BELOW the closing `---` is the issue body and MUST stay byte-identical to the
+     published tracker body — strip the frontmatter when publishing. -->
+
+## db commands can create a literal 'sqlite:' directory by treating the connection string as a filesystem path
+
+An empty directory literally named `sqlite:` appeared at the repository root. The name matches a SQLite connection-string prefix (`sqlite:...`), so some code path most likely passed the connection string to a filesystem call that creates parent directories. The suspects are the `db sync` / `search` engine wiring and the `--engine sqlite` fallback path (`.living-docs/index.db` when `$DATABASE_URL` is unset) from [ADR 0004](/adr/0004-db-engine-and-data-layer.md). The directory was empty, so no data was written through the wrong path; the defect is silent litter plus the risk that a future write lands in it.
+
+### Scope
+
+- Find the code path that turns the connection string into a directory-creation call and make it parse the string into a path first (or reject it loudly).
+- KEPT: the engine selection contract of ADR 0004 (ParadeDB via `$DATABASE_URL` default, SQLite opt-in) and the `.living-docs/index.db` fallback location.
+
+### Acceptance
+
+- Running the `db`/`search` commands with each engine configuration (`--engine sqlite` with and without `$DATABASE_URL`, and the ParadeDB default) never creates a `sqlite:`-named filesystem entry.
+- A regression test covers the connection-string-to-path translation for the sqlite engine.
+
+### Plan
+
+1. Reproduce: trace which command created the directory (audit the connection-string handling in the db-store engine setup).
+2. Fix the translation (strip/parse the scheme prefix before any `create_dir_all`/open call) and add the regression test.

--- a/docs/issues/index.md
+++ b/docs/issues/index.md
@@ -27,6 +27,7 @@ one slice per fresh context, starting from the skeleton.
 * [0027 — MCP front: expose living-docs core verbs as MCP tools](0027-mcp-front-expose-living-docs-core-verbs-as-mcp-tools.md) - open
 * [0028 — Responsibility split: one verb per module, sibling test files, and a hard file-size ratchet enforced by a deterministic check](0028-responsibility-split-one-verb-per-module-sibling-test-files-and-a-hard-file-size-ratchet-enforced-by-a-deterministic-check.md) - open
 * [0029 — status verb cannot set the issue lifecycle: number resolution prefers the ADR on cross-type collision and the status vocabulary is ADR-only](0029-status-verb-cannot-set-the-issue-lifecycle-number-resolution-prefers-the-adr-on-cross-type-collision-and-the-status-vocabulary-is-adr-only.md) - open
+* [0030 — db commands can create a literal 'sqlite:' directory by treating the connection string as a filesystem path](0030-db-commands-can-create-a-literal-sqlite-directory-by-treating-the-connection-string-as-a-filesystem-path.md) - open
 
 ## Closed
 


### PR DESCRIPTION
## Summary

Files issue 0030 (`docs/issues/0030`): an empty directory literally named `sqlite:` appeared at the repo root, which points at a code path that treats the SQLite connection string as a filesystem path. The issue records the reproduction scope, the suspects (the `--engine sqlite` wiring and the `.living-docs/index.db` fallback from ADR 0004), and the acceptance criteria for the fix. Docs-only — no code change.

## Test plan

- [x] `living-docs check` green — 75 docs, no invariant violations.
- [x] `living-docs index` regenerated the issues index row.

## Notes

GitHub Actions is in a major outage right now, so the CI check will not run on this PR; the doc-gate ran locally (pre-commit + `living-docs check`).

🤖 Co-authored with Claude Code
