### PR TITLE
fix: honor --docs-dir in fmt/check and resolve next's doc-type token [#14] [#23]

### DIFF
--- a/cli/src/commands/check.rs
+++ b/cli/src/commands/check.rs
@@ -21,15 +21,17 @@ pub(crate) fn run_check(
 
 /// The db backend has no notion of `check`'s `[BUNDLE_ROOT]` positional
 /// argument — its `DocStore` is scoped to `--docs-dir` at construction — so
-/// it always checks `docs_dir`, ignoring `paths`; the fs backend keeps its
-/// existing `lint-docs.sh`-compatible behavior unchanged.
+/// it always checks `docs_dir`, ignoring `paths`. The fs backend prefers a
+/// positional `[BUNDLE_ROOT]` when given one, and otherwise falls back to
+/// `docs_dir` — so `--docs-dir X fmt`/`check` operates on `X`, never a
+/// hardcoded `docs`.
 pub(crate) fn check_bundle(backend: Backend, docs_dir: &Path, paths: Vec<PathBuf>) -> PathBuf {
     match backend {
         Backend::Db => docs_dir.to_path_buf(),
         Backend::Fs => paths
             .into_iter()
             .next()
-            .unwrap_or_else(|| PathBuf::from("docs")),
+            .unwrap_or_else(|| docs_dir.to_path_buf()),
     }
 }
 
@@ -58,8 +60,14 @@ mod tests {
     }
 
     #[test]
-    fn check_bundle_defaults_to_docs_for_the_fs_backend_when_no_paths_are_given() {
+    fn check_bundle_falls_back_to_docs_dir_for_the_fs_backend_when_no_paths_are_given() {
         let bundle = check_bundle(Backend::Fs, Path::new("/repo/docs"), Vec::new());
-        assert_eq!(bundle, PathBuf::from("docs"));
+        assert_eq!(bundle, PathBuf::from("/repo/docs"));
+    }
+
+    #[test]
+    fn check_bundle_honors_a_custom_docs_dir_for_the_fs_backend_when_no_paths_are_given() {
+        let bundle = check_bundle(Backend::Fs, Path::new("/repo/custom"), Vec::new());
+        assert_eq!(bundle, PathBuf::from("/repo/custom"));
     }
 }

--- a/cli/src/commands/fmt.rs
+++ b/cli/src/commands/fmt.rs
@@ -7,9 +7,10 @@ use std::process::ExitCode;
 
 /// `fmt` is fs-backend only (db-mode is canonical by construction on
 /// export), so it needs no `build_backend_store`/`Engine` plumbing — it
-/// reuses [`check_bundle`]'s `[BUNDLE_ROOT]` resolution against a fixed
-/// [`fs_store::FsStore`], the same way [`crate::commands::leak_gate::run_leak_gate`]
-/// always inspects a materialized filesystem bundle regardless of `--backend`.
+/// reuses [`check_bundle`]'s `[BUNDLE_ROOT]` resolution (a positional path
+/// wins; otherwise `--docs-dir`) against a fixed [`fs_store::FsStore`], the
+/// same way [`crate::commands::leak_gate::run_leak_gate`] always inspects a
+/// materialized filesystem bundle regardless of `--backend`.
 pub(crate) fn run_fmt(docs_dir: &Path, paths: Vec<PathBuf>) -> ExitCode {
     let bundle = check_bundle(Backend::Fs, docs_dir, paths);
     living_docs_core::commands::fmt::run(&fs_store::FsStore::new(), &bundle)

--- a/cli/src/commands/next.rs
+++ b/cli/src/commands/next.rs
@@ -1,9 +1,44 @@
-//! `next` verb wrapper: delegates straight to `living_docs_core::commands::next::run`.
+//! `next` verb wrapper: resolves the doc-type token to its directory, then
+//! delegates to `living_docs_core::commands::next::run`.
 
+use crate::store::report_failure;
 use living_docs_core::commands;
+use living_docs_core::paths;
 use std::path::Path;
 use std::process::ExitCode;
 
+/// `commands::next::run` scans `docs_dir/doc_type` for the highest existing
+/// `NNNN` prefix, where `doc_type` must already be the record DIRECTORY name
+/// (e.g. `issues`), not the CLI token (e.g. `issue`) — [`paths::dir_for`]
+/// resolves the token the same way `new` does, so `next issue` reports one
+/// past the highest existing issue number instead of always `0001`.
 pub(crate) fn run_next(docs_dir: &Path, doc_type: &str) -> ExitCode {
-    commands::next::run(docs_dir, doc_type)
+    match paths::dir_for(doc_type) {
+        Some(dir) => commands::next::run(docs_dir, dir),
+        None => report_failure(&format!("unknown doc type '{doc_type}'")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_bundle(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("living-docs-cli-next-{label}-{nanos}"))
+    }
+
+    #[test]
+    fn run_next_fails_cleanly_for_an_unknown_doc_type_token() {
+        let bundle = temp_bundle("unknown-token");
+
+        let exit_code = run_next(&bundle, "glossary");
+
+        assert_eq!(exit_code, ExitCode::FAILURE);
+    }
 }

--- a/cli/tests/cli.rs
+++ b/cli/tests/cli.rs
@@ -85,6 +85,45 @@ fn next_ignores_files_without_the_nnnn_dash_prefix() {
     let _ = fs::remove_dir_all(&docs);
 }
 
+/// Regression for the `next issue` footgun: `issue` is the only registered
+/// token whose directory (`issues`) differs from the token itself, so this
+/// is the one case that catches `run_next` passing the raw token straight
+/// through instead of resolving it via `paths::dir_for` first.
+#[test]
+fn next_issue_resolves_the_token_to_the_issues_directory() {
+    let docs = temp_dir("next-issue-token");
+    let issues_dir = docs.join("issues");
+    fs::create_dir_all(&issues_dir).unwrap();
+    fs::write(issues_dir.join("0001-first.md"), "content").unwrap();
+    fs::write(issues_dir.join("0004-fourth.md"), "content").unwrap();
+
+    let output = living_docs()
+        .args(["--docs-dir", docs.to_str().unwrap(), "next", "issue"])
+        .output()
+        .expect("failed to run living-docs");
+
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "0005");
+
+    let _ = fs::remove_dir_all(&docs);
+}
+
+#[test]
+fn next_on_an_unknown_doc_type_token_exits_nonzero_and_prints_no_number() {
+    let docs = temp_dir("next-unknown-token");
+
+    let output = living_docs()
+        .args(["--docs-dir", docs.to_str().unwrap(), "next", "glossary"])
+        .output()
+        .expect("failed to run living-docs");
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("glossary"));
+
+    let _ = fs::remove_dir_all(&docs);
+}
+
 /// ADR 0019, AC ac-s4-3: the root `--help` about text carries the same
 /// body-only instruction `new` prints after a created path.
 #[test]

--- a/docs/issues/0014-docs-dir-is-silently-accepted-but-ignored-by-fmt-and-check-which-operate-on-the-cwd-bundle.md
+++ b/docs/issues/0014-docs-dir-is-silently-accepted-but-ignored-by-fmt-and-check-which-operate-on-the-cwd-bundle.md
@@ -2,7 +2,7 @@
 type: Issue
 title: "--docs-dir is silently accepted but ignored by fmt and check, which operate on the cwd bundle"
 description: Make fmt and check either honor --docs-dir or hard-error on it, so the flag can never silently rewrite a different tree than the one the user pointed at.
-status: Proposed
+status: closed
 timestamp: 2026-07-30T18:58:08Z
 ---
 

--- a/docs/issues/0015-status-with-a-bare-record-number-resolves-across-type-directories-adrs-first.md
+++ b/docs/issues/0015-status-with-a-bare-record-number-resolves-across-type-directories-adrs-first.md
@@ -2,7 +2,7 @@
 type: Issue
 title: status with a bare record number resolves across type directories, ADRs first
 description: Accept a type qualifier on status and hard-error on an ambiguous bare record number, so a number shared across type directories can no longer mutate the wrong record.
-status: Proposed
+status: closed
 timestamp: 2026-07-30T18:58:44Z
 ---
 

--- a/docs/issues/0021-new-has-no-description-flag-yet-description-is-cli-owned-frontmatter.md
+++ b/docs/issues/0021-new-has-no-description-flag-yet-description-is-cli-owned-frontmatter.md
@@ -2,7 +2,7 @@
 type: Issue
 title: new has no --description flag, yet description is CLI-owned frontmatter
 description: Add a --description flag (and a later describe verb) so new no longer seeds a placeholder the user must hand-edit, contradicting the CLI-ownership contract.
-status: Proposed
+status: closed
 timestamp: 2026-08-03T12:05:00Z
 ---
 

--- a/docs/issues/0022-template-placeholders-are-fragile-for-programmatic-editing.md
+++ b/docs/issues/0022-template-placeholders-are-fragile-for-programmatic-editing.md
@@ -2,7 +2,7 @@
 type: Issue
 title: Template placeholders are fragile for programmatic editing
 description: Give body placeholders a fenced, uniform marker format (or a --body-file option) so programmatic edit tooling does not depend on byte-exact angle-bracket matching.
-status: Proposed
+status: closed
 timestamp: 2026-08-03T12:05:00Z
 ---
 

--- a/docs/issues/0023-next-reports-0001-for-issue-because-run-next-passes-the-cli-token-straight-through-instead-of-resolving-its-directory.md
+++ b/docs/issues/0023-next-reports-0001-for-issue-because-run-next-passes-the-cli-token-straight-through-instead-of-resolving-its-directory.md
@@ -2,7 +2,7 @@
 type: Issue
 title: next reports 0001 for issue because run_next passes the CLI token straight through instead of resolving its directory
 description: Fix run_next to resolve the CLI token to its record directory via paths::dir_for before scanning, the way new already does.
-status: Proposed
+status: closed
 timestamp: 2026-08-03T12:09:03Z
 ---
 

--- a/docs/issues/0025-describe-and-status-resolve-record-numbers-ambiguously-across-doc-type-directories.md
+++ b/docs/issues/0025-describe-and-status-resolve-record-numbers-ambiguously-across-doc-type-directories.md
@@ -2,7 +2,7 @@
 type: Issue
 title: describe and status resolve record numbers ambiguously across doc-type directories
 description: Bare record numbers are only unique per directory, so describe/status silently mutate the first registry match — add a type-qualified reference and fail on ambiguity. Cannot self-describe via CLI precisely because 0025 collides with ADR 0025.
-status: open
+status: closed
 timestamp: 2026-08-05T20:18:36Z
 ---
 

--- a/docs/issues/index.md
+++ b/docs/issues/index.md
@@ -11,18 +11,12 @@ one slice per fresh context, starting from the skeleton.
 * [0011 — Atlas edit — optimistic concurrency via a revision precondition](0011-atlas-edit-optimistic-concurrency-via-revision-precondition.md) - open
 * [0012 — Atlas supersede — browser parity with the CLI supersede verb](0012-atlas-supersede-browser-parity-with-the-cli-supersede-verb.md) - open
 * [0013 — Atlas delete — a new verb with no CLI precedent](0013-atlas-delete-a-new-verb-with-no-cli-precedent.md) - open
-* [0014 — --docs-dir is silently accepted but ignored by fmt and check, which operate on the cwd bundle](0014-docs-dir-is-silently-accepted-but-ignored-by-fmt-and-check-which-operate-on-the-cwd-bundle.md) - Proposed
-* [0015 — status with a bare record number resolves across type directories, ADRs first](0015-status-with-a-bare-record-number-resolves-across-type-directories-adrs-first.md) - Proposed
 * [0016 — check needs a ratchet or changed-files mode so brownfield repos can arm the pre-commit channel](0016-check-needs-a-ratchet-or-changed-files-mode-so-brownfield-repos-can-arm-the-pre-commit-channel.md) - Proposed
 * [0017 — bundle vocabulary gaps: no research doc type in index and no terminal closed status for issues](0017-bundle-vocabulary-gaps-no-research-doc-type-in-index-and-no-terminal-closed-status-for-issues.md) - Proposed
 * [0018 — Identity cannot express an author-named record in a directory, so glossary and the Context family stay hand-authored](0018-identity-cannot-express-an-author-named-record-in-a-directory-so-glossary-and-the-context-family-stay-hand-authored.md) - Proposed
 * [0019 — The harness matrix is six targets where four are the same copy with a different destination](0019-the-harness-matrix-is-six-targets-where-four-are-the-same-copy-with-a-different-destination.md) - Proposed
 * [0020 — The tracker status vocabulary disagrees across the template comment, the validator, and issue 0017 -- and has no in-progress state](0020-the-tracker-status-vocabulary-disagrees-across-the-template-comment-the-validator-and-issue-0017-and-has-no-in-progress-state.md) - Proposed
-* [0021 — new has no --description flag, yet description is CLI-owned frontmatter](0021-new-has-no-description-flag-yet-description-is-cli-owned-frontmatter.md) - Proposed
-* [0022 — Template placeholders are fragile for programmatic editing](0022-template-placeholders-are-fragile-for-programmatic-editing.md) - Proposed
-* [0023 — next reports 0001 for issue because run_next passes the CLI token straight through instead of resolving its directory](0023-next-reports-0001-for-issue-because-run-next-passes-the-cli-token-straight-through-instead-of-resolving-its-directory.md) - Proposed
 * [0024 — Doc-code pairing for living-docs: commit trailers, covers-based drift detection, and executable acceptance](0024-doc-code-pairing-for-living-docs-commit-trailers-covers-based-drift-detection-and-executable-acceptance.md) - open
-* [0025 — describe and status resolve record numbers ambiguously across doc-type directories](0025-describe-and-status-resolve-record-numbers-ambiguously-across-doc-type-directories.md) - open
 * [0026 — Corpus import: seed the knowledge graph read-model from real repos to make graph slices demoable from day one](0026-corpus-import-seed-the-knowledge-graph-read-model-from-real-repos-to-make-graph-slices-demoable-from-day-one.md) - open
 * [0027 — MCP front: expose living-docs core verbs as MCP tools](0027-mcp-front-expose-living-docs-core-verbs-as-mcp-tools.md) - open
 
@@ -38,6 +32,12 @@ one slice per fresh context, starting from the skeleton.
 * [0008 — living-docs brief — deterministic pre-filled scaffold that leaves only the judgment slots for the authoring model](0008-brief-scaffold.md) - done
 * [0008 — Three-pane web shell with metadata panel and Cmd+K palette](0008-three-pane-web-shell-with-metadata-panel-and-cmd-k-palette.md) - done
 * [0009 — Per-type doc size targets — authoring convention in the skill corpus + advisory warning in check, plus the same-change economic rationale](0009-doc-size-targets.md) - done
+* [0014 — --docs-dir is silently accepted but ignored by fmt and check, which operate on the cwd bundle](0014-docs-dir-is-silently-accepted-but-ignored-by-fmt-and-check-which-operate-on-the-cwd-bundle.md) - closed
+* [0015 — status with a bare record number resolves across type directories, ADRs first](0015-status-with-a-bare-record-number-resolves-across-type-directories-adrs-first.md) - closed
+* [0021 — new has no --description flag, yet description is CLI-owned frontmatter](0021-new-has-no-description-flag-yet-description-is-cli-owned-frontmatter.md) - closed
+* [0022 — Template placeholders are fragile for programmatic editing](0022-template-placeholders-are-fragile-for-programmatic-editing.md) - closed
+* [0023 — next reports 0001 for issue because run_next passes the CLI token straight through instead of resolving its directory](0023-next-reports-0001-for-issue-because-run-next-passes-the-cli-token-straight-through-instead-of-resolving-its-directory.md) - closed
+* [0025 — describe and status resolve record numbers ambiguously across doc-type directories](0025-describe-and-status-resolve-record-numbers-ambiguously-across-doc-type-directories.md) - closed
 * [0028 — Responsibility split: one verb per module, sibling test files, and a hard file-size ratchet enforced by a deterministic check](0028-responsibility-split-one-verb-per-module-sibling-test-files-and-a-hard-file-size-ratchet-enforced-by-a-deterministic-check.md) - closed
 * [0029 — status verb cannot set the issue lifecycle: number resolution prefers the ADR on cross-type collision and the status vocabulary is ADR-only](0029-status-verb-cannot-set-the-issue-lifecycle-number-resolution-prefers-the-adr-on-cross-type-collision-and-the-status-vocabulary-is-adr-only.md) - closed
 * [0030 — db commands can create a literal 'sqlite:' directory by treating the connection string as a filesystem path](0030-db-commands-can-create-a-literal-sqlite-directory-by-treating-the-connection-string-as-a-filesystem-path.md) - closed


### PR DESCRIPTION
## Summary

Two deterministic-layer CLI resolution footguns, both a value resolved against the wrong contract, plus the bookkeeping to close the issues they and earlier work already resolved.

- **Issue 0014** — `fmt` and `check` silently ignored the global `--docs-dir`. `check_bundle`'s fs-backend fallback resolved to a hardcoded `docs`, so `living-docs --docs-dir X fmt` rewrote `cwd/docs`, never `X`. It now falls back to the resolved `docs_dir`; a positional `[BUNDLE_ROOT]` still wins and the db-backend branch is unchanged.
- **Issue 0023** — `living-docs next issue` always reported `0001` in a bundle full of issues. `run_next` passed the raw CLI token (`issue`) to `commands::next::run`, which expects the record *directory* name (`issues`); `issue` is the only registered type whose token differs from its directory. `run_next` now resolves the token through `paths::dir_for` first, mirroring how `new` resolves it; an unknown token exits nonzero naming the token instead of silently scanning the wrong path.

## Changes

- `cli/src/commands/check.rs` — `check_bundle` fs fallback `PathBuf::from("docs")` → `docs_dir.to_path_buf()`; docblock states the resolution order; unit tests for the fs fallback, a custom `docs_dir`, positional-wins, and db-backend-ignores-positional.
- `cli/src/commands/fmt.rs` — docblock updated to state `check_bundle`'s resolution order now honored by `fmt`.
- `cli/src/commands/next.rs` — `run_next` resolves the token via `living_docs_core::paths::dir_for`; clean nonzero-exit error on an unknown token; unit test for the error path.
- `cli/tests/cli.rs` — two integration tests spawning the real binary: `next issue` resolves to the `issues` directory and reports the correct next number; an unknown token exits nonzero and prints no number.
- `docs/issues/{0014,0015,0021,0022,0023,0025}*.md`, `docs/issues/index.md` — status set to `closed` and index regenerated via the CLI (see below).

## Issues closed

- **0014**, **0023** — fixed in this branch.
- **0015**, **0025** — subsumed by the 0029 type-qualified record resolver (merged in #39).
- **0021** (`new --description`), **0022** (template placeholders) — already implemented in earlier work.

Closes #14, #23, #15, #25, #21, #22.

## Test plan

- [x] `cargo test --workspace` — green (942 tests, incl. the new `check_bundle` and `next`-token tests).
- [x] `cargo clippy --workspace --all-targets` — 0 issues.
- [x] `cargo fmt --check` — clean.
- [x] `scripts/check-file-size.sh` — OK (32 grandfathered files, limit 300).
- [x] `living-docs check docs` — OK, 75 docs, no invariant violations.

## Notes

The quality-gate reported `skip` for these Rust-only diffs (a known node+rust stack-detection quirk), so the cargo/script commands above are the effective gate. Each commit is scoped to one concern (fix 0014, fix 0023, docs).
