### PR TITLE
docs: ADR 0034 — artifacts as directory-bundle records, plus slice issues 0031-0033

### DIFF
--- a/docs/adr/0034-artifacts-are-directory-bundle-records-a-canonical-readme-plus-a-validated-file-manifest-on-a-new-bundle-identity.md
+++ b/docs/adr/0034-artifacts-are-directory-bundle-records-a-canonical-readme-plus-a-validated-file-manifest-on-a-new-bundle-identity.md
@@ -1,0 +1,55 @@
+---
+type: ADR
+title: "Artifacts are directory-bundle records: a canonical README plus a validated file manifest on a new Bundle identity"
+description: Add a third Identity variant, Bundle, for directory-per-record artifacts whose canonical README lists the files it references, and register an artifact doc type on it with a check-validated manifest.
+status: Proposed
+timestamp: 2026-08-07T14:36:44Z
+---
+
+# 0034. Artifacts are directory-bundle records on a new Bundle identity
+
+## Context
+
+After [ADR 0026](/adr/0026-a-single-doctype-registry-replaces-nine-hand-synced-enumerations-and-research-and-constitution-enter-as-rows.md) and [ADR 0027](/adr/0027-every-rule-keyed-by-doc-type-becomes-a-registry-field-and-glossary-is-not-a-doc-type.md), every doc type is one row in the `DOC_TYPES` table. The `new`, `index`, `check`, and web consumers derive a type's directory, frontmatter, template, and rules from that row, so no site hand-codes a type.
+
+`DocTypeSpec::identity` carries two shapes. `Numbered { dir }` places one `<dir>/NNNN-slug.md` file; the tool allocates the number. `Singleton { file }` places one fixed file. Both model a record that IS a single Markdown file.
+
+A new need does not fit either shape: an **artifact** — a delivered output such as a report, a diagram, a dataset snapshot — is a document PLUS the files that document references. The document alone is not the record; the referenced files travel with it. A `Numbered` file cannot own companion files, and a `Singleton` is one fixed path.
+
+[Issue 0018](/issues/0018-identity-cannot-express-an-author-named-record-in-a-directory-so-glossary-and-the-context-family-stay-hand-authored.md) already found that `Identity` cannot express a record living in a directory. [Issue 0024](/issues/0024-doc-code-pairing-for-living-docs-commit-trailers-covers-based-drift-detection-and-executable-acceptance.md) already asked for drift detection between a document and the files it covers. An artifact is where both pressures meet, so it earns a third identity rather than a special case bolted onto a consumer.
+
+## Decision
+
+We will add a third `Identity` variant, `Bundle { dir }`, and register an `artifact` doc type on it.
+
+- **Bundle shape.** An artifact record IS the directory `artifacts/NNNN-slug/`. The tool allocates the `NNNN` prefix through `next`, exactly as `Numbered` does, so an artifact is referable by number or by slug and its name cannot collide.
+- **Canonical document.** The directory holds `README.md` as its one record file. `README.md` carries the OKF frontmatter and body and is subject to the canonical-frontmatter invariant. The name is `README.md`, never `index.md`: OKF reserves `index.md` for a no-frontmatter scaffold (issue 0018), and `README.md` renders when a reader opens the directory on GitHub or the web front.
+- **Validated file manifest.** The frontmatter carries a `files:` list naming each referenced file, bundle-directory-relative. `check` fails when a listed file is absent and warns when the directory holds a file that the manifest does not list (an orphan). This makes doc-to-file drift a gate signal, the shape issue 0024 wants.
+- **Registry row.** `ARTIFACT` joins `DOC_TYPES`: `token: "artifact"`, `identity: Bundle { dir: "artifacts" }`, `frontmatter: "Artifact"`, `index_partition: Flat`, `body_size: Exempt`, `status_vocabulary: ["Draft", "Published", "Archived"]`, `web_creatable: false`. Web authoring stays db-mode-only ([ADR 0016](/adr/0016-atlas-makes-the-web-a-db-mode-authoring-front-superseding-web-read-only.md)); a bundle of binary files is out of that path for now, so the row opts out rather than forcing a half-built web flow.
+- **Search scope.** The db-store projection and FTS index the `README.md` body, as for any record. The referenced files are opaque payload and stay out of the index.
+
+The consumers learn the variant from the registry: `check` gains one `Bundle` arm, and a second bundle-type row later requires no edit inside `check` — the fitness shape issue 0018 named.
+
+## Consequences
+
+**Easier / gained:**
+- Artifacts become first-class, tool-created records: `living-docs new artifact "..."` scaffolds a conformant bundle, so an artifact starts inside the frontmatter invariant and index membership rather than hand-copied outside both.
+- Doc-to-file drift is caught by `check`, giving issue 0024 its first concrete instrument.
+- The `Bundle` variant is reusable: any future directory-as-record type (a design package, a research bundle) rides the same identity with no new consumer code.
+
+**Harder / accepted trade-offs:**
+- `Identity` grows from two variants to three; every `match` over it gains an arm. This is the deliberate cost of expressing a shape the corpus genuinely holds.
+- The manifest is authored, not derived. A referenced file added on disk but not listed only warns; the author still owns keeping `files:` truthful. Deriving the list from disk was rejected to keep the tool from guessing which files are payload versus incidental.
+- Web creation of artifacts is deferred, so the web front lists but does not author them until a later decision.
+
+**Follow-ups:**
+- Slice the implementation as issues in registry → `new` → `check` order (per issue 0018): the `Bundle` variant plus the `ARTIFACT` row and `new`; then manifest validation in `check`; then the `index` Artifacts partition and the db-store projection.
+- Revisit `web_creatable` once Atlas has an upload path for bundle payload files.
+
+## Verification
+
+**Implementation impact:** `living-docs-core/src/doc_type.rs` (the `Identity` enum and the `ARTIFACT` row), `living-docs-core/src/paths.rs` (`dir_for`/`doc_type_for_dir` over the new variant), `living-docs-core/src/commands/new.rs` (scaffold a bundle directory with `README.md`), `living-docs-core/src/commands/check.rs` (manifest validation) and `index.rs` (Artifacts partition), plus `skills/living-docs/templates/artifact.md`.
+
+**Verification criteria:**
+- `living-docs new artifact "..."` produces `artifacts/NNNN-slug/README.md` that `living-docs check docs` passes without hand-editing.
+- Fitness function: a bundle record whose `files:` names an absent file fails `check`, and `check` learns the `Bundle` variant from the registry — adding a second `Bundle` row requires no edit inside `check`.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -39,6 +39,7 @@ repo teaches. The decision *log* is this listing plus each record's `status` /
 * [0031 — The knowledge graph is a typed bi-temporal edge set in the existing relational store](0031-the-knowledge-graph-is-a-typed-bi-temporal-edge-set-in-the-existing-relational-store.md) - Proposed
 * [0032 — Doc-code lineage is declared, not inferred](0032-doc-code-lineage-is-declared-not-inferred.md) - Proposed
 * [0033 — New consumers are fronts in the workspace, never new repos, until a deploy-cadence or ownership trigger fires](0033-new-consumers-are-fronts-in-the-workspace-never-new-repos-until-a-deploy-cadence-or-ownership-trigger-fires.md) - Proposed
+* [0034 — Artifacts are directory-bundle records: a canonical README plus a validated file manifest on a new Bundle identity](0034-artifacts-are-directory-bundle-records-a-canonical-readme-plus-a-validated-file-manifest-on-a-new-bundle-identity.md) - Proposed
 
 ## Superseded
 

--- a/docs/issues/0031-bundle-identity-variant-plus-the-artifact-registry-row-and-new-artifact-scaffolds-a-directory-bundle-with-readme.md
+++ b/docs/issues/0031-bundle-identity-variant-plus-the-artifact-registry-row-and-new-artifact-scaffolds-a-directory-bundle-with-readme.md
@@ -1,0 +1,37 @@
+---
+type: Issue
+title: Bundle identity variant plus the artifact registry row and new artifact scaffolds a directory bundle with README
+description: Add the Bundle identity variant and the artifact registry row, and make new artifact scaffold a directory bundle with a canonical README.
+status: open
+timestamp: 2026-08-07T14:38:11Z
+---
+
+<!-- Status lives in frontmatter (`status`), not a body line. Settable values are
+     exactly open | in-progress | closed. `living-docs supersede` sets Superseded on
+     this issue -- never set it by hand -- when a later issue replaces it. Everything
+     BELOW the closing `---` is the issue body and MUST stay byte-identical to the
+     published tracker body — strip the frontmatter when publishing. -->
+
+## Bundle identity variant plus the artifact registry row and new
+
+Implements [ADR 0034](/adr/0034-artifacts-are-directory-bundle-records-a-canonical-readme-plus-a-validated-file-manifest-on-a-new-bundle-identity.md). First slice: teach the domain and `new` about a directory-bundle record, so an artifact can be created at all.
+
+`Identity` has two variants, both modeling a record that is a single file. This slice adds `Bundle { dir }` for a record that IS a directory holding a canonical `README.md`, and registers the `artifact` doc type on it.
+
+### Scope
+
+Included: the `Bundle { dir }` variant on `Identity`; the `ARTIFACT` row in `DOC_TYPES` (`token: "artifact"`, `identity: Bundle { dir: "artifacts" }`, `frontmatter: "Artifact"`, `index_partition: Flat`, `body_size: Exempt`, `status_vocabulary: ["Draft", "Published", "Archived"]`, `web_creatable: false`); `paths::dir_for`/`doc_type_for_dir` honoring the variant; the `artifact.md` template; and `living-docs new artifact "..."` scaffolding `artifacts/NNNN-slug/README.md` with the `NNNN` allocated by the existing `next` counter.
+
+Explicitly kept: `Numbered` and `Singleton` keep their meaning and rows. This slice adds a variant and one row; it reshapes nothing.
+
+Explicitly out: manifest validation (issue 0032) and the index/search wiring (issue 0033). `new` seeds an empty `files:` list; it does not validate it.
+
+### Acceptance
+
+- `living-docs new artifact "A title"` creates `artifacts/0001-a-title/README.md` carrying canonical `Artifact` frontmatter with an empty `files:` list, and `living-docs check docs` passes it without hand-editing.
+- A second `new artifact` allocates `0002-...`, proving the `next` counter drives the bundle number.
+- Fitness function: `spec_for("artifact")` round-trips, and the template's `type:` line equals the row's `frontmatter` value (the existing `fitness_function_a` covers the new row with no edit).
+
+### Plan
+
+Registry first: add the `Bundle` variant and the `ARTIFACT` row, then the `artifact.md` template, then the `new` scaffold path that creates the directory and writes `README.md`. Pin the number allocation and the frontmatter shape with tests.

--- a/docs/issues/0032-check-validates-the-artifact-file-manifest-missing-listed-file-fails-unlisted-orphan-file-warns.md
+++ b/docs/issues/0032-check-validates-the-artifact-file-manifest-missing-listed-file-fails-unlisted-orphan-file-warns.md
@@ -1,0 +1,38 @@
+---
+type: Issue
+title: "check validates the artifact file manifest: missing listed file fails, unlisted orphan file warns"
+description: "Teach check to validate an artifact's files manifest: fail on a missing listed file, warn on an unlisted orphan file."
+status: open
+timestamp: 2026-08-07T14:38:11Z
+---
+
+<!-- Status lives in frontmatter (`status`), not a body line. Settable values are
+     exactly open | in-progress | closed. `living-docs supersede` sets Superseded on
+     this issue -- never set it by hand -- when a later issue replaces it. Everything
+     BELOW the closing `---` is the issue body and MUST stay byte-identical to the
+     published tracker body — strip the frontmatter when publishing. -->
+
+## check validates the artifact file manifest
+
+Implements [ADR 0034](/adr/0034-artifacts-are-directory-bundle-records-a-canonical-readme-plus-a-validated-file-manifest-on-a-new-bundle-identity.md). Second slice: make the `files:` manifest a gate signal, giving [issue 0024](/issues/0024-doc-code-pairing-for-living-docs-commit-trailers-covers-based-drift-detection-and-executable-acceptance.md) its first concrete drift instrument.
+
+After issue 0031 an artifact bundle exists with a `files:` list, but nothing checks it. This slice teaches `check` to validate the manifest against the bundle directory.
+
+### Scope
+
+Included: a `Bundle` arm in `check` that, for each artifact record, reads the `README.md` `files:` list and (1) FAILS when a listed file is absent from the bundle directory, (2) WARNS when the directory holds a file — other than `README.md` — that the manifest does not list. The arm learns the variant from the registry, so a second `Bundle`-identity row needs no edit inside `check`.
+
+Explicitly kept: the existing invariant and size checks are unchanged; the manifest check is additive.
+
+Explicitly out: deriving the list from disk (the manifest stays authored, per ADR 0034), and any index/search behavior (issue 0033).
+
+### Acceptance
+
+- An artifact whose `files:` names a file present in its directory passes `check`; naming an absent file fails `check` with a message pointing at the record and the missing file.
+- A file added to the bundle directory but not listed in `files:` produces a warning (not a failure) naming the orphan.
+- Fitness function: a test adds a second `Bundle`-identity row to a fixture registry and asserts the manifest check applies to it with no change inside `check` — the registry-driven shape from issue 0018.
+- `living-docs check docs` and `living-docs check examples/linkly/docs` stay green.
+
+### Plan
+
+Add the manifest reader and the `Bundle` arm in `check`, keyed off the registry identity. Cover the fail, warn, and pass paths with fixture bundles; pin the registry-driven fitness function.

--- a/docs/issues/0033-index-renders-the-artifacts-partition-and-the-db-store-projection-indexes-the-artifact-readme-body.md
+++ b/docs/issues/0033-index-renders-the-artifacts-partition-and-the-db-store-projection-indexes-the-artifact-readme-body.md
@@ -1,0 +1,37 @@
+---
+type: Issue
+title: index renders the Artifacts partition and the db-store projection indexes the artifact README body
+description: Render an Artifacts partition in index and index each artifact README body in the db-store projection and FTS.
+status: open
+timestamp: 2026-08-07T14:38:11Z
+---
+
+<!-- Status lives in frontmatter (`status`), not a body line. Settable values are
+     exactly open | in-progress | closed. `living-docs supersede` sets Superseded on
+     this issue -- never set it by hand -- when a later issue replaces it. Everything
+     BELOW the closing `---` is the issue body and MUST stay byte-identical to the
+     published tracker body — strip the frontmatter when publishing. -->
+
+## index renders the Artifacts partition and search indexes the README
+
+Implements [ADR 0034](/adr/0034-artifacts-are-directory-bundle-records-a-canonical-readme-plus-a-validated-file-manifest-on-a-new-bundle-identity.md). Third slice: make artifacts discoverable — listed in the index and findable in search.
+
+After issues 0031–0032 an artifact bundle is created and validated, but it appears in no index and no search result. This slice wires the two read paths.
+
+### Scope
+
+Included: `index` renders a flat `Artifacts` partition listing every `artifacts/NNNN-slug/` bundle by its `README.md` title and status; the db-store projection and FTS index the `README.md` body of each artifact, keyed like any other record. Both derive membership from the `ARTIFACT` row, not a hand-coded path.
+
+Explicitly kept: the existing index partitions and their ordering; the search behavior for all current types.
+
+Explicitly out: indexing the referenced payload files — they stay opaque per ADR 0034; only the `README.md` body is searchable.
+
+### Acceptance
+
+- `living-docs index` writes an `Artifacts` section listing each bundle, and the run is idempotent (a second `index` leaves the file byte-identical).
+- After a sync, `living-docs search "<term from a README body>"` returns the artifact record; searching a term that appears only in a payload file returns nothing.
+- `living-docs check docs` stays green with artifact bundles present in the tree.
+
+### Plan
+
+Add the `Artifacts` partition to `index` off the registry row, then extend the db-store projection to read the bundle `README.md`. Cover index idempotence and the README-only search scope with tests.

--- a/docs/issues/index.md
+++ b/docs/issues/index.md
@@ -25,6 +25,9 @@ one slice per fresh context, starting from the skeleton.
 * [0025 — describe and status resolve record numbers ambiguously across doc-type directories](0025-describe-and-status-resolve-record-numbers-ambiguously-across-doc-type-directories.md) - open
 * [0026 — Corpus import: seed the knowledge graph read-model from real repos to make graph slices demoable from day one](0026-corpus-import-seed-the-knowledge-graph-read-model-from-real-repos-to-make-graph-slices-demoable-from-day-one.md) - open
 * [0027 — MCP front: expose living-docs core verbs as MCP tools](0027-mcp-front-expose-living-docs-core-verbs-as-mcp-tools.md) - open
+* [0031 — Bundle identity variant plus the artifact registry row and new artifact scaffolds a directory bundle with README](0031-bundle-identity-variant-plus-the-artifact-registry-row-and-new-artifact-scaffolds-a-directory-bundle-with-readme.md) - open
+* [0032 — check validates the artifact file manifest: missing listed file fails, unlisted orphan file warns](0032-check-validates-the-artifact-file-manifest-missing-listed-file-fails-unlisted-orphan-file-warns.md) - open
+* [0033 — index renders the Artifacts partition and the db-store projection indexes the artifact README body](0033-index-renders-the-artifacts-partition-and-the-db-store-projection-indexes-the-artifact-readme-body.md) - open
 
 ## Closed
 


### PR DESCRIPTION
## Summary

Plan a new `artifact` doc type: a record that is a document **plus the files it references** (a report and its diagram, a dataset snapshot and its exports). Neither `Identity` variant expresses this — `Numbered` and `Singleton` both model a record that IS a single file — so the design earns a third variant rather than a special case bolted onto a consumer.

Per the repo's decide-then-implement rule, this PR is **planning only**: one ADR that settles the forks, plus the three slice issues it spawns. No `living-docs-core` code changes here.

## Decisions (ADR 0034)

- **`Identity::Bundle { dir }`** — an artifact record IS the directory `artifacts/NNNN-slug/`; the `NNNN` is allocated by `next`, so it is referable by number or slug and cannot collide.
- **Canonical `README.md`** carries the OKF frontmatter and body (not `index.md`, which OKF reserves for a no-frontmatter scaffold; `README.md` renders when the directory is opened).
- **Validated `files:` manifest** — `check` fails on a listed-but-absent file and warns on an unlisted orphan, giving issue 0024 its first concrete drift instrument.
- **Registry row** `ARTIFACT` (`index_partition: Flat`, `body_size: Exempt`, `status_vocabulary: Draft|Published|Archived`, `web_creatable: false`); FTS indexes only the `README.md` body, payload files stay opaque.

This is where issue 0018 (identity cannot express a directory-record) and issue 0024 (doc-to-file drift) meet.

## Changes

- `docs/adr/0034-…-bundle-identity.md` — the decision, consequences, and fitness functions.
- `docs/issues/0031-…` — slice 1: the `Bundle` variant + `ARTIFACT` row + `new artifact` scaffold.
- `docs/issues/0032-…` — slice 2: `check` validates the `files:` manifest (fail on missing, warn on orphan).
- `docs/issues/0033-…` — slice 3: `index` Artifacts partition + db-store/FTS over the README body.
- `docs/adr/index.md`, `docs/issues/index.md` — regenerated by `living-docs index`.

## Test plan

- [x] `living-docs check docs` — OK, 79 docs, no invariant violations.
- [x] ADR and issues scaffolded via the CLI; only bodies hand-written (authoring contract).
- [ ] Implementation lands under issues 0031 → 0032 → 0033, each its own reviewed PR.

## Notes

Slice order (registry → new → check → index) follows the fitness shape issue 0018 named: each consumer learns the `Bundle` variant from the registry, so a second bundle-type row later needs no edit inside `check`.
